### PR TITLE
Add handlers.py to list of Python modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/cylc/cylc-jupyterhub/',
-    py_modules=['cylc_singleuser'],
+    py_modules=['handlers', 'cylc_singleuser'],
     python_requires='>=3.6',
     install_requires=[
         'jupyterhub',


### PR DESCRIPTION
Close #17 

We defined `cylc_singleuser.py` as Python module exported by the project (`py_modules` array in `setup.py`), but forgot to include `handlers.py`.

It means that in `cylc_singleuser` when we imported `from handlers import *`, the `handlers` module would simply never be found.

Even better if we included a top level package, etc. But we can work on that later. For now this one fixes #17 

