### PR TITLE
Add unit tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,57 @@
+[run]
+branch=True
+cover_pylib=False
+concurrency=thread
+data_file=.coverage
+disable_warnings=
+    trace-changed
+    module-not-python
+    module-not-imported
+    no-data-collected
+    module-not-measured
+    # include-ignored
+omit =
+    venv/*
+    tests.py
+    setup.py
+    jupyterhub_config.py
+parallel = True
+plugins=
+include=
+    *cylc_singleuser.py*
+    *handlers.py*
+timid = False
+
+
+[report]
+
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    def parse_args
+    def main
+fail_under=0
+ignore_errors = False
+omit =
+    venv/*
+    tests.py
+    setup.py
+    jupyterhub_config.py
+precision=2
+show_missing=False
+skip_covered=False
+sort=Name
+
+[html]
+
+directory=htmlcov
+extra_css=
+title=
+
+
+[xml]
+
+output=coverage.xml
+package_depth=99

--- a/cylc_singleuser.py
+++ b/cylc_singleuser.py
@@ -66,7 +66,7 @@ class CylcUIServer(object):
             self._static = static
         else:
             script_dir = os.path.dirname(__file__)
-            self._static = os.path.join(script_dir, static)
+            self._static = os.path.abspath(os.path.join(script_dir, static))
         self._jupyter_hub_service_prefix = jupyter_hub_service_prefix
 
     def _make_app(self):
@@ -133,3 +133,6 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+
+__all__ = ['MainHandler', 'UserProfileHandler', 'MyApplication', 'CylcUIServer', 'main']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[aliases]
+test = pytest
+
+[tool:pytest]
+addopts = --verbose -s -v
+python_files = tests.py

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,14 @@ setup(
         'tornado',
         'graphene-tornado'
     ],
+    setup_requires=[
+        'pytest-runner'
+    ],
+    tests_require=[
+        'pytest',
+        'coverage',
+        'pytest-cov'
+    ],
     entry_points={
         'console_scripts': [
             'cylc-singleuser=cylc_singleuser:main'

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,80 @@
+import os
+import shutil
+import tempfile
+from unittest.mock import patch
+
+from tornado.httpclient import HTTPResponse
+from tornado.testing import AsyncHTTPTestCase
+from tornado.web import Application
+
+from cylc_singleuser import *
+
+
+class MainHandlerTest(AsyncHTTPTestCase):
+    """Test for the Main handler"""
+    def get_app(self) -> Application:
+        self.tempdir = tempfile.mkdtemp(suffix='mainhandlertest')
+        return MyApplication(
+            handlers=[
+                ('/', MainHandler, {"path": self.tempdir})
+            ]
+        )
+
+    def test_jupyterhub_version_returned(self):
+        with patch.object(MainHandler, 'get_current_user') as mocked:
+            mocked.return_value = {'name': 'yossarian'}
+            with open(os.path.join(self.tempdir, "index.html"), "w+") as nf:
+                nf.write("TESTING!")
+                nf.flush()
+                response = self.fetch("/")  # type: HTTPResponse
+                assert response.body == b"TESTING!"
+                assert "X-JupyterHub-Version" in response.headers
+
+    def tearDown(self) -> None:
+        if self.tempdir:
+            shutil.rmtree(self.tempdir, ignore_errors=True)
+
+
+
+class UserProfileHandlerTest(AsyncHTTPTestCase):
+    """Test for UserProfile handler"""
+    def get_app(self) -> Application:
+        return MyApplication(
+            handlers=[
+                ('/userprofile', UserProfileHandler)
+            ]
+        )
+
+    def test_user_profile_handler_cors_headers(self):
+        with patch.object(UserProfileHandler, 'get_current_user') as mocked:
+            mocked.return_value = {'name': 'yossarian'}
+            response = self.fetch("/userprofile")  # type: HTTPResponse
+            assert "Access-Control-Allow-Origin" in response.headers
+            assert "Access-Control-Allow-Headers" in response.headers
+            assert "Access-Control-Allow-Methods" in response.headers
+            assert "Content-Type" in response.headers
+            assert b'yossarian' in  response.body
+
+
+def test_my_application():
+    """Test creating the Tornado app."""
+    my_application = MyApplication(handlers=[])
+    assert not my_application.is_closing
+    my_application.signal_handler(None, None)
+    assert my_application.is_closing
+
+
+def test_cylcuiserver_absolute_path():
+    """Test a Cylc UI server created with absolute path for static assets."""
+    cylc_uiserver = CylcUIServer(8000, '/static/path', '/users/test')
+    assert cylc_uiserver._port == 8000
+    assert cylc_uiserver._static == '/static/path'
+    assert cylc_uiserver._jupyter_hub_service_prefix == '/users/test'
+
+
+def test_cylcuiserver_relative_path():
+    """Test a Cylc UI server created with relative path for static assets."""
+    cylc_uiserver = CylcUIServer(8000, './', '/users/test')
+    assert cylc_uiserver._port == 8000
+    assert cylc_uiserver._static == os.path.dirname(__file__)
+    assert cylc_uiserver._jupyter_hub_service_prefix == '/users/test'


### PR DESCRIPTION
Close #24 

First batch ready. Learned how to test Tornado handlers too. They provide some classes that you extend, then you get the necessary code for handling async/ioloop/handler/etc encapsulated :tada: 

Managed to cover 50% of the code, which is good enough IMO for now, as most of the code not covered includes the handler that calls `cylc scan` with `Popen` (not fun to test that).

Cheers
Bruno