### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+---
+cache: pip
+dist: xenial
+addons:
+  apt:
+    update: true  # instruct travis-ci to always run apt-get before each build
+
+language: python
+python: 3.7
+
+install:
+  - pip install .[all]
+script:
+  - python setup.py test
+after_success:
+  # Report metrics, such as coverage
+  - coverage xml --ignore-errors
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/cylc/cylc-uiserver.svg?branch=master)](https://travis-ci.org/cylc/cylc-uiserver)
+[![codecov](https://codecov.io/gh/cylc/cylc-uiserver/branch/master/graph/badge.svg)](https://codecov.io/gh/cylc/cylc-uiserver)
+
 # Running Cylc with JupyterHub
 
 _This is a Work-In-Progress_

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test = pytest
 
 [tool:pytest]
-addopts = --verbose -s -v
+addopts = --verbose -s -v --cov
 python_files = tests.py

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,32 @@
-from setuptools import setup
 from os import path
+
+from setuptools import setup
 
 here = path.abspath(path.dirname(__file__))
 
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
+
+install_requires = [
+    'jupyterhub',
+    'tornado',
+    'graphene-tornado'
+]
+
+setup_requires = [
+    'pytest-runner'
+]
+
+tests_require = [
+    'pytest',
+    'coverage',
+    'pytest-cov'
+]
+
+extras_require = {
+    'tests': tests_require,
+    'all': install_requires + tests_require
+}
 
 setup(
     name='cylc-uiserver',
@@ -15,19 +37,10 @@ setup(
     url='https://github.com/cylc/cylc-uiserver/',
     py_modules=['handlers', 'cylc_singleuser'],
     python_requires='>=3.7',
-    install_requires=[
-        'jupyterhub',
-        'tornado',
-        'graphene-tornado'
-    ],
-    setup_requires=[
-        'pytest-runner'
-    ],
-    tests_require=[
-        'pytest',
-        'coverage',
-        'pytest-cov'
-    ],
+    install_requires=install_requires,
+    setup_requires=setup_requires,
+    tests_require=tests_require,
+    extras_require=extras_require,
     entry_points={
         'console_scripts': [
             'cylc-singleuser=cylc_singleuser:main'


### PR DESCRIPTION
Close #23 

Adds the `.travis.yml` file, enables coverage, and also adds the `tests` and `all` groups to Setuptools script, so that Travis & users can install the necessary dependencies for running either installation, or tests locally.

Tested on my fork: https://travis-ci.org/kinow/cylc-uiserver/builds/520499822

Coverage tested on my fork too: https://codecov.io/gh/kinow/cylc-uiserver/branch/add-travis

Badges added with links to the cylc organisation instead of my account. Also enabled Travis already on this repository, so if merged, it should immediately trigger the first build against master branch, and badges should update soon (though browser cache may still display them as gray-ed and unknown).

Cheers
Bruno