### PR TITLE
WS-UIS data and GraphQL integration

### DIFF
--- a/data_mgr.py
+++ b/data_mgr.py
@@ -17,16 +17,15 @@
 """Create and update the data structure for all workflow services."""
 
 import asyncio
-from fnmatch import fnmatchcase
 
 # from google.protobuf.json_format import MessageToDict
 
-from cylc.exceptions import ClientError, ClientTimeout
-from cylc.ws_messages_pb2 import PbEntireWorkflow
-from cylc.network.scan import MSG_TIMEOUT
+from cylc.flow.exceptions import ClientError, ClientTimeout
+from cylc.flow.ws_messages_pb2 import PbEntireWorkflow
+from cylc.flow.network.scan import MSG_TIMEOUT
 
 
-# TODO: define in and import this from cylc-flow
+# TODO: define in and import this from cylc.flow
 # maps methods in cylc-flow server to the returned bytes message
 METHOD_MAP = {
     'pb_entire_workflow': PbEntireWorkflow
@@ -74,170 +73,3 @@ class DataManager(object):
             self.data = new_data
         else:
             self.data.update(new_data)
-
-    # Data access filters
-    def get_workflow_msgs(self, args):
-        """Return list of workflows."""
-        result = []
-        for flow_msg in self.data.values():
-            if self._workflow_filter(flow_msg, args):
-                result.append(flow_msg)
-        # TODO: Sorting and Pagination
-        return result
-
-    def get_nodes_all(self, node_type, args):
-        """Return nodes from all workflows, filter by args."""
-        w_args = {
-            'ids': args['workflows'],
-            'exids': args['exworkflows'],
-        }
-        nodes = [
-            n for k in self.get_workflow_msgs(w_args)
-            for n in getattr(k, node_type)]
-        result = []
-        for node in nodes:
-            if self._node_filter(node, args):
-                result.append(node)
-        # TODO: Sorting and Pagination
-        return result
-
-    def get_nodes_by_id(self, node_type, args):
-        """Return protobuf node objects for given id."""
-        nat_ids = args.get('native_ids', [])
-        w_ids = []
-        for nat_id in nat_ids:
-            o_name, w_name, nid = nat_id.split('/', 2)
-            w_ids.append(f"{o_name}/{w_name}")
-        if node_type == 'proxy_nodes':
-            nodes = (
-                n for w_id in set(w_ids)
-                for n in (
-                    list(getattr(self.data[w_id], 'task_proxies', []))
-                    + list(getattr(self.data[w_id], 'family_proxies', []))))
-        else:
-            nodes = (
-                n for w_id in set(w_ids)
-                for n in getattr(self.data[w_id], node_type, []))
-        result = []
-        for node in nodes:
-            if ((not nat_ids or node.id in set(nat_ids)) and
-                    self._node_filter(node, args)):
-                result.append(node)
-        # TODO: Sorting and Pagination
-        return result
-
-    def get_node_by_id(self, node_type, args):
-        """Return protobuf node object for given id."""
-        n_id = args.get('id')
-        o_name, w_name, remainder = n_id.split('/', 2)
-        w_id = f"{o_name}/{w_name}"
-        if node_type == 'proxy_nodes':
-            nodes = (
-                list(getattr(self.data[w_id], 'task_proxies', []))
-                + list(getattr(self.data[w_id], 'family_proxies', [])))
-        else:
-            nodes = getattr(self.data[w_id], node_type, [])
-        for node in nodes:
-            if node.id == n_id:
-                return node
-        return None
-
-    def get_edges_all(self, args):
-        """Return edges from all workflows, filter by args."""
-        w_args = {
-            'ids': args['workflows'],
-            'exids': args['exworkflows'],
-        }
-        result = []
-        for edge in [
-                n for k in self.get_workflow_msgs(w_args)
-                for n in getattr(k, 'edges')]:
-            result.append(edge)
-        # TODO: Sorting and Pagination
-        return result
-
-    def get_edges_by_id(self, args):
-        """Return protobuf edge objects for given id."""
-        nat_ids = args.get('native_ids', [])
-        w_ids = []
-        for nat_id in nat_ids:
-            oname, wname, eid = nat_id.split('/', 2)
-            w_ids.append(f"{oname}/{wname}")
-        w_ids = list(set(w_ids))
-        result = []
-        for edge in [
-                e for k in w_ids
-                for e in getattr(self.data[k], 'edges')]:
-            result.append(edge)
-        # TODO: Sorting and Pagination
-        return result
-
-    def _node_filter(self, node, args):
-        """Filter nodes based on attribute arguments"""
-        natts = self._collate_node_atts(node)
-        return (
-                (not args.get('states') or node.state in args['states']) and
-                not (args.get('exstates') and
-                     node.state in args['exstates']) and
-                (args.get('mindepth', -1) < 0 or
-                    node.depth >= args['mindepth']) and
-                (args.get('maxdepth', -1) < 0 or
-                    node.depth <= args['maxdepth']) and
-                (not args.get('ids') or
-                    self._node_atts_filter(natts, args['ids'])) and
-                not (args.get('exids') and
-                     self._node_atts_filter(natts, args['exids'])))
-
-    def _workflow_filter(self, flow, args):
-        """Filter workflows based on attribute arguments"""
-        natts = [flow.workflow.owner, flow.workflow.name, flow.workflow.status]
-        return (
-                (not args.get('ids') or
-                    self._workflow_atts_filter(natts, args['ids'])) and
-                not (args.get('exids') and
-                     self._workflow_atts_filter(natts, args['exids'])))
-
-    @staticmethod
-    def _workflow_atts_filter(natts, items):
-        """Match components of id argument with those of workflow id."""
-        for owner, name, status in set(items):
-            if ((not owner or fnmatchcase(natts[0], owner)) and
-                    (not name or fnmatchcase(natts[1], name)) and
-                    (not status or natts[2] == status)):
-                return True
-        return False
-
-    @staticmethod
-    def _node_atts_filter(natts, items):
-        """Match node id argument with node attributes."""
-        for owner, workflow, cycle, name, submit_num, state in items:
-            if ((not owner or fnmatchcase(natts[0], owner)) and
-                    (not workflow or fnmatchcase(natts[1], workflow)) and
-                    (not cycle or fnmatchcase(natts[2], cycle)) and
-                    any(fnmatchcase(nn, name) for nn in natts[3]) and
-                    (not submit_num or
-                        fnmatchcase(str(natts[4]), submit_num.lstrip('0'))) and
-                    (not state or natts[5] == state)):
-                return True
-        return False
-
-    @staticmethod
-    def _collate_node_atts(node):
-        """Collate node filter attributes."""
-        node_id = getattr(node, 'id')
-        slash_count = node_id.count('/')
-        n_id = node_id.split('/', slash_count)
-        if slash_count == 2:
-            n_cycle = None
-            n_name = n_id[2]
-        else:
-            n_cycle = n_id[2]
-            n_name = n_id[3]
-        return [
-            n_id[0],
-            n_id[1],
-            n_cycle,
-            getattr(node, 'namespace', [n_name]),
-            getattr(node, 'submit_num', None),
-            getattr(node, 'state', None),
-        ]

--- a/data_mgr.py
+++ b/data_mgr.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Create and update the data structure for all workflow services."""
+
+from fnmatch import fnmatchcase
+
+from tornado import gen
+# from google.protobuf.json_format import MessageToDict
+
+# from cylc import flags
+from cylc.exceptions import ClientError, ClientTimeout
+from cylc.ws_messages_pb2 import PbEntireWorkflow
+from cylc.network.scan import MSG_TIMEOUT
+
+
+METHOD_MAP = {
+    'pb_entire_workflow': PbEntireWorkflow
+}
+
+
+async def get_workflow_data(w_id, client, method):
+    # Use already established client
+    try:
+        pb_msg = await client.async_request(method)
+    except ClientTimeout as exc:
+        return (w_id, MSG_TIMEOUT)
+    except ClientError as exc:
+        return (w_id, None)
+    else:
+        ws_data = METHOD_MAP[method]()
+        ws_data.ParseFromString(pb_msg)
+    return (w_id, ws_data)
+
+
+class DataManager(object):
+
+    def __init__(self, ws_mgr):
+        self.ws_mgr = ws_mgr
+        self.data = {}
+
+    # **
+    # Data syncing
+    # **
+    async def entire_workflow_update(self, ids=None):
+        if ids is None:
+            ids = []
+        new_data = {}
+        ws_args = (
+            (w_id, info['req_client'], 'pb_entire_workflow')
+            for w_id, info in self.ws_mgr.workflows.items())
+        items = await gen.multi(
+            get_workflow_data(*args) for args in ws_args
+            if not ids or args[0] in ids)
+        for w_id, result in items:
+            if result is not None and result != MSG_TIMEOUT:
+                new_data[w_id] = result
+        if not ids:
+            # atomic update
+            self.data = new_data
+        else:
+            # apparently faster than update(new_data)
+            for w_id, flow in new_data.items():
+                self.data[w_id] = flow
+
+    # **
+    # Data access filters
+    # **
+    def get_workflow_msgs(self, args):
+        """Return list of workflows."""
+        result = []
+        for flow_msg in self.data.values():
+            if self._workflow_filter(flow_msg, args):
+                result.append(flow_msg)
+        return result
+
+    def get_nodes_all(self, node_type, args):
+        """Return list of nodes (defns/proxies/jobs)."""
+        w_args = {
+            'ids': args['workflows'],
+            'exids': args['exworkflows'],
+        }
+        nodes = [
+            n for k in self.get_workflow_msgs(w_args)
+            for n in getattr(k, node_type)]
+        result = []
+        for node in nodes:
+            if self._node_filter(node, args):
+                result.append(node)
+        return result
+
+    def get_nodes_id(self, node_type, args):
+        """Return protobuf node objects for given id."""
+        nat_ids = args.get('native_ids', [])
+        w_ids = []
+        for nat_id in nat_ids:
+            o_name, w_name, nid = nat_id.split('/', 2)
+            w_ids.append(f"{o_name}/{w_name}")
+        if node_type == 'proxy_nodes':
+            nodes = (
+                n for w_id in set(w_ids)
+                for n in (
+                    list(getattr(self.data[w_id], 'task_proxies', []))
+                    + list(getattr(self.data[w_id], 'family_proxies', []))))
+        else:
+            nodes = (
+                n for w_id in set(w_ids)
+                for n in getattr(self.data[w_id], node_type, []))
+        result = []
+        for node in nodes:
+            if ((not nat_ids or node.id in set(nat_ids)) and
+                    self._node_filter(node, args)):
+                result.append(node)
+        return result
+
+    def get_node_id(self, node_type, args):
+        """Return protobuf node object for given id."""
+        n_id = args.get('id')
+        o_name, w_name, remainder = n_id.split('/', 2)
+        w_id = f"{o_name}/{w_name}"
+        if node_type == 'proxy_nodes':
+            nodes = (
+                list(getattr(self.data[w_id], 'task_proxies', []))
+                + list(getattr(self.data[w_id], 'family_proxies', [])))
+        else:
+            nodes = getattr(self.data[w_id], node_type, [])
+        for node in nodes:
+            if node.id == n_id:
+                return node
+        return None
+
+    def get_edges_all(self, args):
+        """Return all workflows protobuf edge objects for given id."""
+        w_args = {
+            'ids': args['workflows'],
+            'exids': args['exworkflows'],
+        }
+        result = []
+        for edge in [
+                n for k in self.get_workflow_msgs(w_args)
+                for n in getattr(k, 'edges')]:
+            result.append(edge)
+        return result
+
+    def get_edges_id(self, args):
+        """Return protobuf edge objects for given id."""
+        nat_ids = args.get('native_ids', [])
+        w_ids = []
+        for nat_id in nat_ids:
+            oname, wname, eid = nat_id.split('/', 2)
+            w_ids.append(f"{oname}/{wname}")
+        w_ids = list(set(w_ids))
+        result = []
+        for edge in [
+                e for k in w_ids
+                for e in getattr(self.data[k], 'edges')]:
+            result.append(edge)
+        return result
+
+    def _node_filter(self, node, args):
+        """Filter nodes based on attribute arguments"""
+        node_id = getattr(node, 'id')
+        slash_count = node_id.count('/')
+        n_id = node_id.split('/', slash_count)
+        if slash_count == 2:
+            n_cycle = None
+            n_name = n_id[2]
+        else:
+            n_cycle = n_id[2]
+            n_name = n_id[3]
+        natts = [
+            n_id[0],
+            n_id[1],
+            n_cycle,
+            getattr(node, 'namespace', [n_name]),
+            getattr(node, 'submit_num', None),
+            getattr(node, 'state', None),
+        ]
+        return (
+                (not args.get('states') or node.state in args['states']) and
+                not (args.get('exstates') and
+                     node.state in args['exstates']) and
+                (args.get('mindepth', -1) < 0 or
+                    node.depth >= args['mindepth']) and
+                (args.get('maxdepth', -1) < 0 or
+                    node.depth <= args['maxdepth']) and
+                (not args.get('ids') or
+                    self._node_atts_filter(natts, args['ids'])) and
+                not (args.get('exids') and
+                     self._node_atts_filter(natts, args['exids'])))
+
+    def _workflow_filter(self, flow, args):
+        """Filter workflows based on attribute arguments"""
+        natts = [flow.workflow.owner, flow.workflow.name, flow.workflow.status]
+        return (
+                (not args.get('ids') or
+                    self._workflow_atts_filter(natts, args['ids'])) and
+                not (args.get('exids') and
+                     self._workflow_atts_filter(natts, args['exids'])))
+
+    @staticmethod
+    def _workflow_atts_filter(natts, items):
+        """Match components of id argument with those of workflow id."""
+        for owner, name, status in set(items):
+            if ((not owner or fnmatchcase(natts[0], owner)) and
+                    (not name or fnmatchcase(natts[1], name)) and
+                    (not status or natts[2] == status)):
+                return True
+        return False
+
+    @staticmethod
+    def _node_atts_filter(natts, items):
+        """Match node id argument with node attributes."""
+        for owner, workflow, cycle, name, submit_num, state in items:
+            if ((not owner or fnmatchcase(natts[0], owner)) and
+                    (not workflow or fnmatchcase(natts[1], workflow)) and
+                    (not cycle or fnmatchcase(natts[2], cycle)) and
+                    any(fnmatchcase(nn, name) for nn in natts[3]) and
+                    (not submit_num or
+                        fnmatchcase(str(natts[4]), submit_num.lstrip('0'))) and
+                    (not state or natts[5] == state)):
+                return True
+        return False

--- a/handlers.py
+++ b/handlers.py
@@ -93,7 +93,8 @@ class CylcScanHandler(HubOAuthenticated, APIHandler):
 
     @web.authenticated
     def get(self):
-        cylc_scan_proc = Popen("cylc scan", shell=True, stdout=PIPE)
+        cylc_scan_proc = Popen(
+            "cylc scan --color=never", shell=True, stdout=PIPE)
         cylc_scan_out = cylc_scan_proc.communicate()[0]
 
         suite_lines = cylc_scan_out.splitlines()

--- a/handlers.py
+++ b/handlers.py
@@ -23,6 +23,8 @@ from typing import List, Union
 from jupyterhub import __version__ as jupyterhub_version
 from jupyterhub.services.auth import HubOAuthenticated
 from tornado import web
+from graphene_tornado.tornado_graphql_handler import TornadoGraphQLHandler
+from graphql import get_default_backend
 
 
 class BaseHandler(web.RequestHandler):
@@ -102,8 +104,45 @@ class CylcScanHandler(HubOAuthenticated, APIHandler):
         self.write(json.dumps(suites))
 
 
+# This is needed in order to pass the server context in addition to existing.
+# It's possible to just overwrite TornadoGraphQLHandler.context but we would
+# somehow need to pass the request info (headers, username ...etc) in also
+class UIServerGraphQLHandler(TornadoGraphQLHandler):
+
+    # Declare extra attributes
+    uiserver = None
+
+    def initialize(self, schema=None, executor=None, middleware=None,
+                   root_value=None, graphiql=False, pretty=False,
+                   batch=False, backend=None, **kwargs):
+        super(TornadoGraphQLHandler, self).initialize()
+
+        self.schema = schema
+        if middleware is not None:
+            self.middleware = list(self.instantiate_middleware(middleware))
+        self.executor = executor
+        self.root_value = root_value
+        self.pretty = pretty
+        self.graphiql = graphiql
+        self.batch = batch
+        self.backend = backend or get_default_backend()
+        # Set extra attributes
+        for key, value in kwargs.items():
+            if hasattr(self, key):
+                setattr(self, key, value)
+
+    @property
+    def context(self):
+        wider_context = {
+            'uiserver': self.uiserver,
+            'request': self.request,
+        }
+        return wider_context
+
+
 __all__ = [
     "MainHandler",
     "UserProfileHandler",
-    "CylcScanHandler"
+    "CylcScanHandler",
+    "UIServerGraphQLHandler"
 ]

--- a/handlers.py
+++ b/handlers.py
@@ -110,7 +110,7 @@ class CylcScanHandler(HubOAuthenticated, APIHandler):
 class UIServerGraphQLHandler(TornadoGraphQLHandler):
 
     # Declare extra attributes
-    uiserver = None
+    resolvers = None
 
     def initialize(self, schema=None, executor=None, middleware=None,
                    root_value=None, graphiql=False, pretty=False,
@@ -134,8 +134,8 @@ class UIServerGraphQLHandler(TornadoGraphQLHandler):
     @property
     def context(self):
         wider_context = {
-            'uiserver': self.uiserver,
             'request': self.request,
+            'resolvers': self.resolvers,
         }
         return wider_context
 

--- a/resolvers.py
+++ b/resolvers.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""GraphQL resolvers for use in data accessing and mutation of workflows."""
+
+from fnmatch import fnmatchcase
+
+
+class Resolvers(object):
+
+    def __init__(self, ws_mgr, data_mgr):
+        self.ws_mgr = ws_mgr
+        self.data_mgr = data_mgr
+
+    # Query resolvers
+    # workflows
+    async def get_workflow_msgs(self, args):
+        """Return list of workflows."""
+        result = []
+        for flow_msg in self.data_mgr.data.values():
+            if self._workflow_filter(flow_msg, args):
+                result.append(flow_msg)
+        # TODO: Sorting and Pagination
+        return result
+
+    def _workflow_filter(self, flow, args):
+        """Filter workflows based on attribute arguments"""
+        natts = self._collate_workflow_atts(flow.workflow)
+        return (
+                (not args.get('workflows') or
+                    self._workflow_atts_filter(natts, args['workflows'])) and
+                not (args.get('exworkflows') and
+                     self._workflow_atts_filter(natts, args['exworkflows'])))
+
+    # nodes
+    async def get_nodes_all(self, node_type, args):
+        """Return nodes from all workflows, filter by args."""
+        nodes = [
+            n for k in await self.get_workflow_msgs(args)
+            for n in getattr(k, node_type)]
+        result = []
+        for node in nodes:
+            if self._node_filter(node, args):
+                result.append(node)
+        # TODO: Sorting and Pagination
+        return result
+
+    async def get_nodes_by_id(self, node_type, args):
+        """Return protobuf node objects for given id."""
+        nat_ids = args.get('native_ids', [])
+        w_ids = []
+        for nat_id in nat_ids:
+            o_name, w_name, nid = nat_id.split('/', 2)
+            w_ids.append(f'{o_name}/{w_name}')
+        if node_type == 'proxy_nodes':
+            nodes = (
+                n for w_id in set(w_ids) for n in (
+                    list(getattr(
+                            self.data_mgr.data[w_id],
+                            'task_proxies', []))
+                    + list(getattr(
+                            self.data_mgr.data[w_id],
+                            'family_proxies', []))))
+        else:
+            nodes = (
+                n for w_id in set(w_ids) for n in
+                getattr(self.data_mgr.data[w_id], node_type, []))
+        result = []
+        for node in nodes:
+            if ((not nat_ids or node.id in set(nat_ids)) and
+                    self._node_filter(node, args)):
+                result.append(node)
+        # TODO: Sorting and Pagination
+        return result
+
+    def _node_filter(self, node, args):
+        """Filter nodes based on attribute arguments"""
+        natts = self._collate_node_atts(node)
+        return (
+                (not args.get('states') or node.state in args['states']) and
+                not (args.get('exstates') and
+                     node.state in args['exstates']) and
+                (args.get('mindepth', -1) < 0 or
+                    node.depth >= args['mindepth']) and
+                (args.get('maxdepth', -1) < 0 or
+                    node.depth <= args['maxdepth']) and
+                (not args.get('ids') or
+                    self._node_atts_filter(natts, args['ids'])) and
+                not (args.get('exids') and
+                     self._node_atts_filter(natts, args['exids'])))
+
+    async def get_node_by_id(self, node_type, args):
+        """Return protobuf node object for given id."""
+        n_id = args.get('id')
+        o_name, w_name, remainder = n_id.split('/', 2)
+        w_id = f'{o_name}/{w_name}'
+        if node_type == 'proxy_nodes':
+            nodes = (
+                list(getattr(
+                    self.data_mgr.data[w_id], 'task_proxies', []))
+                + list(getattr(
+                    self.data_mgr.data[w_id], 'family_proxies', [])))
+        else:
+            nodes = getattr(self.data_mgr.data[w_id], node_type, [])
+        for node in nodes:
+            if node.id == n_id:
+                return node
+        return None
+
+    # edges
+    async def get_edges_all(self, args):
+        """Return edges from all workflows, filter by args."""
+        result = []
+        for edge in [
+                n for k in await self.get_workflow_msgs(args)
+                for n in getattr(k, 'edges')]:
+            result.append(edge)
+        # TODO: Sorting and Pagination
+        return result
+
+    async def get_edges_by_id(self, args):
+        """Return protobuf edge objects for given id."""
+        nat_ids = args.get('native_ids', [])
+        w_ids = []
+        for nat_id in nat_ids:
+            oname, wname, eid = nat_id.split('/', 2)
+            w_ids.append(f'{oname}/{wname}')
+        w_ids = list(set(w_ids))
+        result = []
+        for edge in [
+                e for k in w_ids
+                for e in getattr(self.data_mgr.data[k], 'edges')]:
+            result.append(edge)
+        # TODO: Sorting and Pagination
+        return result
+
+    # Mutations
+    async def mutator(self, command, w_args, args):
+        """Mutate workflow."""
+        w_ids = [flow.workflow.id
+                 for flow in await self.get_workflow_msgs(w_args)]
+        return self.ws_mgr.multi_request(command, w_ids, args)
+
+    async def nodes_mutator(self, command, ids, w_args, args):
+        """Mutate node items of associated workflows."""
+        w_ids = [flow.workflow.id
+                 for flow in await self.get_workflow_msgs(w_args)]
+        if w_ids == []:
+            return 'Error: No matching Workflow'
+        # match proxy ID args with workflows
+        flow_ids = []
+        multi_args = {}
+        for w_id in w_ids:
+            items = []
+            for owner, workflow, cycle, name, submit_num, state in ids:
+                if workflow and owner is None:
+                    owner = "*"
+                if (not (owner and workflow) or
+                        fnmatchcase(w_id, f'{owner}/{workflow}')):
+                    if cycle is None:
+                        cycle = '*'
+                    id_arg = f'{cycle}/{name}'
+                    if submit_num:
+                        id_arg = f'{id_arg}/{submit_num}'
+                    if state:
+                        id_arg = f'{id_arg}:{state}'
+                    items.append(id_arg)
+            if items:
+                flow_ids.append(w_id)
+                multi_args[w_id] = args
+                if command == 'insert_tasks':
+                    multi_args[w_id]['items'] = items
+                elif command == 'put_messages':
+                    multi_args[w_id]['task_job'] = items[0]
+                else:
+                    multi_args[w_id]['task_globs'] = items
+        return self.ws_mgr.multi_request(
+            command, flow_ids, multi_args=multi_args)
+
+    # Message Filters
+    @staticmethod
+    def _collate_workflow_atts(workflow):
+        """Collate workflow filter attributes."""
+        return [
+            workflow.owner,
+            workflow.name,
+            workflow.status,
+        ]
+
+    @staticmethod
+    def _workflow_atts_filter(natts, items):
+        """Match components of id argument with those of workflow id."""
+        for owner, name, status in set(items):
+            if ((not owner or fnmatchcase(natts[0], owner)) and
+                    (not name or fnmatchcase(natts[1], name)) and
+                    (not status or natts[2] == status)):
+                return True
+        return False
+
+    @staticmethod
+    def _collate_node_atts(node):
+        """Collate node filter attributes."""
+        node_id = getattr(node, 'id')
+        slash_count = node_id.count('/')
+        n_id = node_id.split('/', slash_count)
+        if slash_count == 2:
+            n_cycle = None
+            n_name = n_id[2]
+        else:
+            n_cycle = n_id[2]
+            n_name = n_id[3]
+        return [
+            n_id[0],
+            n_id[1],
+            n_cycle,
+            getattr(node, 'namespace', [n_name]),
+            getattr(node, 'submit_num', None),
+            getattr(node, 'state', None),
+        ]
+
+    @staticmethod
+    def _node_atts_filter(natts, items):
+        """Match node id argument with node attributes."""
+        for owner, workflow, cycle, name, submit_num, state in items:
+            if ((not owner or fnmatchcase(natts[0], owner)) and
+                    (not workflow or fnmatchcase(natts[1], workflow)) and
+                    (not cycle or fnmatchcase(natts[2], cycle)) and
+                    any(fnmatchcase(nn, name) for nn in natts[3]) and
+                    (not submit_num or
+                        fnmatchcase(str(natts[4]), submit_num.lstrip('0'))) and
+                    (not state or natts[5] == state)):
+                return True
+        return False

--- a/schema.py
+++ b/schema.py
@@ -1,0 +1,934 @@
+#!/usr/bin/env python3
+
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""GraphQL API schema via Graphene implementation."""
+
+from graphene import (
+    Boolean, Field, Float, ID, InputObjectType, Int,
+    List, Mutation, ObjectType, Schema, String, Union
+)
+from graphene.types.resolver import dict_resolver
+from graphene.types.generic import GenericScalar
+from graphene.utils.str_converters import to_snake_case
+
+
+NODE_MAP = {
+    'Task': 'tasks',
+    'TaskProxy': 'task_proxies',
+    'Family': 'families',
+    'FamilyProxy': 'family_proxies',
+    'Job': 'jobs',
+    'Node': 'proxy_nodes',
+}
+
+CYCLING_TYPES = [
+    'family_proxies',
+    'jobs',
+    'task_proxies',
+]
+
+PROXY_TYPES = [
+    'family_proxies',
+    'task_proxies',
+]
+
+DEF_TYPES = [
+    'families',
+    'tasks',
+]
+
+
+def parse_workflow_id(item):
+    """Split workflow id argument to individual workflow attributes.
+    Args:
+        item (owner/workflow:status):
+            It's possible to traverse workflows,
+            defaults to UI Server owner, and ``*`` glob for workflow.
+
+    Returns:
+        A tuple of id components in respective order. For example:
+
+        (owner, name, status)
+    """
+    owner, workflow, status = (None, None, None)
+    if ':' in item:
+        head, status = item.rsplit(':', 1)
+    else:
+        head, status = (item, None)
+    if head.count('/'):
+        owner, workflow = head.split('/', 1)
+    else:
+        # more common to filter on workflow (with owner constant)
+        workflow = head
+    return (owner, workflow, status)
+
+
+def parse_node_id(item, node_type=None):
+    """Parse definition, job, or proxy id argument returning components.
+
+    Args:
+        item: An string representing a node ID. Jobs fill out
+            cycle/name/num first, cycle is irrelevant to Def
+            owner/workflow is always last.
+            For example:
+
+            name
+            cycle/na*
+            submit_num.name.cycle.workflow.owner:state
+            nam*.cycle*
+            workflow/cycle/name
+            owner/workflow/cycle/name/submit_num:state
+            cycle/*/submit_num
+            submit_num.name:state
+
+    Returns:
+        A tuple of string id components in respective order. For example:
+
+        (owner, workflow, cycle, name, submit_num, state)
+
+        None type is set for missing components.
+    """
+    if ":" in item:
+        head, state = item.rsplit(":", 1)
+    else:
+        head, state = (item, None)
+    if "/" in head:
+        dil_count = head.count("/")
+        parts = head.split("/", dil_count)
+    else:
+        dil_count = head.count(".")
+        parts = head.split(".", dil_count)[::-1]
+    if node_type in DEF_TYPES:
+        owner, workflow, name = [None] * (2 - dil_count) + parts
+        parts = [owner, workflow, None, name, None]
+    elif node_type in PROXY_TYPES:
+        parts = [None] * (3 - dil_count) + parts + [None]
+    elif dil_count < 4:
+        if dil_count == 0:
+            parts = [None, None, None] + parts + [None]
+        elif dil_count < 3:
+            parts = [None, None] + parts + [None] * (2 - dil_count)
+        else:
+            parts = [None] * (4 - dil_count) + parts
+    parts += [state]
+    return tuple(parts)
+
+
+# ** Query Related **#
+
+# Field args (i.e. for queries etc):
+jobs_args = dict(
+    ids=List(ID, default_value=[]),
+    exids=List(ID, default_value=[]),
+    states=List(String, default_value=[]),
+    exstates=List(String, default_value=[]),
+)
+
+all_jobs_args = dict(
+    workflows=List(ID, default_value=[]),
+    exworkflows=List(ID, default_value=[]),
+    ids=List(ID, default_value=[]),
+    exids=List(ID, default_value=[]),
+    states=List(String, default_value=[]),
+    exstates=List(String, default_value=[]),
+)
+
+def_args = dict(
+    ids=List(ID, default_value=[]),
+    exids=List(ID, default_value=[]),
+    mindepth=Int(default_value=-1),
+    maxdepth=Int(default_value=-1),
+)
+
+all_def_args = dict(
+    workflows=List(ID, default_value=[]),
+    exworkflows=List(ID, default_value=[]),
+    ids=List(ID, default_value=[]),
+    exids=List(ID, default_value=[]),
+    mindepth=Int(default_value=-1),
+    maxdepth=Int(default_value=-1),
+)
+
+proxy_args = dict(
+    ids=List(ID, default_value=[]),
+    exids=List(ID, default_value=[]),
+    states=List(String, default_value=[]),
+    exstates=List(String, default_value=[]),
+    mindepth=Int(default_value=-1),
+    maxdepth=Int(default_value=-1),
+)
+
+all_proxy_args = dict(
+    workflows=List(ID, default_value=[]),
+    exworkflows=List(ID, default_value=[]),
+    ids=List(ID, default_value=[]),
+    exids=List(ID, default_value=[]),
+    states=List(String, default_value=[]),
+    exstates=List(String, default_value=[]),
+    mindepth=Int(default_value=-1),
+    maxdepth=Int(default_value=-1),
+)
+
+edge_args = dict(
+    ids=List(ID, default_value=[]),
+    exids=List(ID, default_value=[]),
+    states=List(String, default_value=[]),
+    exstates=List(String, default_value=[]),
+    mindepth=Int(default_value=-1),
+    maxdepth=Int(default_value=-1),
+)
+
+all_edge_args = dict(
+    workflows=List(ID, default_value=[]),
+    exworkflows=List(ID, default_value=[]),
+)
+
+
+# Resolvers:
+
+def get_workflows(root, info, **args):
+    data_mgr = info.context.get('uiserver').data_mgr
+    args['ids'] = [parse_workflow_id(w_id) for w_id in args['ids']]
+    args['exids'] = [parse_workflow_id(w_id) for w_id in args['exids']]
+    return [flow.workflow for flow in data_mgr.get_workflow_msgs(args)]
+
+
+def get_nodes_all(root, info, **args):
+    """Resolver for returning job, task, family nodes"""
+    field_name = to_snake_case(info.field_name)
+    field_ids = getattr(root, field_name, None)
+    if hasattr(args, 'id'):
+        args['ids'] = [args.get('id')]
+    if field_ids:
+        args['ids'] = field_ids
+    elif field_ids == []:
+        return []
+    try:
+        obj_type = str(info.return_type.of_type).replace('!', '')
+    except AttributeError:
+        obj_type = str(info.return_type)
+    node_type = NODE_MAP[obj_type]
+    args['ids'] = [parse_node_id(n_id, node_type) for n_id in args['ids']]
+    args['exids'] = [parse_node_id(n_id, node_type) for n_id in args['exids']]
+    args['workflows'] = [
+        parse_workflow_id(w_id) for w_id in args['workflows']]
+    args['exworkflows'] = [
+        parse_workflow_id(w_id) for w_id in args['exworkflows']]
+    data_mgr = info.context.get('uiserver').data_mgr
+    return data_mgr.get_nodes_all(node_type, args)
+
+
+def get_nodes_id(root, info, **args):
+    """Resolver for returning job, task, family node"""
+    field_name = to_snake_case(info.field_name)
+    field_ids = getattr(root, field_name, None)
+    if hasattr(args, 'id'):
+        args['ids'] = [args.get('id')]
+    if field_ids:
+        if isinstance(field_ids, str):
+            field_ids = [field_ids]
+        args['native_ids'] = field_ids
+    elif field_ids == []:
+        return []
+    try:
+        obj_type = str(info.return_type.of_type).replace('!', '')
+    except AttributeError:
+        obj_type = str(info.return_type)
+    node_type = NODE_MAP[obj_type]
+    args['ids'] = [parse_node_id(n_id, node_type) for n_id in args['ids']]
+    args['exids'] = [parse_node_id(n_id, node_type) for n_id in args['exids']]
+    data_mgr = info.context.get('uiserver').data_mgr
+    return data_mgr.get_nodes_id(node_type, args)
+
+
+def get_node_id(root, info, **args):
+    """Resolver for returning job, task, family node"""
+    field_name = to_snake_case(info.field_name)
+    field_id = getattr(root, field_name, None)
+    if field_id:
+        args['id'] = field_id
+    if args.get('id', None) is None:
+        return None
+    try:
+        obj_type = str(info.return_type.of_type).replace('!', '')
+    except AttributeError:
+        obj_type = str(info.return_type)
+    data_mgr = info.context.get('uiserver').data_mgr
+    return data_mgr.get_node_id(NODE_MAP[obj_type], args)
+
+
+def get_edges_all(root, info, **args):
+    data_mgr = info.context.get('uiserver').data_mgr
+    return data_mgr.get_edges_all(args)
+
+
+def get_edges_id(root, info, **args):
+    field_name = to_snake_case(info.field_name)
+    field_ids = getattr(root, field_name, None)
+    if field_ids:
+        args['native_ids'] = list(field_ids)
+    elif field_ids == []:
+        return []
+    data_mgr = info.context.get('uiserver').data_mgr
+    return data_mgr.get_edges_id(args)
+
+# Types:
+
+
+class Meta(ObjectType):
+    """Meta data fields, and custom fields generic userdefined dump"""
+    title = String(default_value=None)
+    description = String(default_value=None)
+    URL = String(default_value=None)
+    user_defined = List(String, default_value=[])
+
+
+class TimeZone(ObjectType):
+    """Time zone info."""
+    hours = Int()
+    minutes = Int()
+    string_basic = String()
+    string_extended = String()
+
+
+class StateTotals(ObjectType):
+    """State Totals."""
+    runahead = Int()
+    waiting = Int()
+    held = Int()
+    queued = Int()
+    expired = Int()
+    ready = Int()
+    submit_failed = Int()
+    submit_retrying = Int()
+    submitted = Int()
+    retrying = Int()
+    running = Int()
+    failed = Int()
+    succeeded = Int()
+
+
+class Workflow(ObjectType):
+    """Global workflow info."""
+    id = ID(required=True)
+    name = String()
+    status = String()
+    host = String()
+    port = Int()
+    owner = String()
+    tasks = List(
+        lambda: Task,
+        description="""Task definitions.""",
+        args=def_args,
+        resolver=get_nodes_id)
+    families = List(
+        lambda: Family,
+        description="""Family definitions.""",
+        args=def_args,
+        resolver=get_nodes_id)
+    edges = Field(
+        lambda: Edges,
+        args=edge_args,
+        description="""Graph edges""")
+    api_version = Int()
+    cylc_version = String()
+    last_updated = Float()
+    meta = Field(Meta)
+    newest_runahead_cycle_point = String()
+    newest_cycle_point = String()
+    oldest_cycle_point = String()
+    reloading = Boolean()
+    run_mode = String()
+    state_totals = Field(StateTotals)
+    workflow_log_dir = String()
+    time_zone_info = Field(TimeZone)
+    tree_depth = Int()
+    ns_defn_order = List(String)
+    job_log_names = List(String)
+    states = List(String)
+
+
+class Job(ObjectType):
+    """Jobs."""
+    id = ID(required=True)
+    submit_num = Int()
+    state = String()
+    task_proxy = Field(
+        lambda: TaskProxy,
+        description="""Associated Task Proxy""",
+        required=True,
+        resolver=get_node_id)
+    submitted_time = String()
+    started_time = String()
+    finished_time = String()
+    batch_sys_job_id = ID()
+    batch_sys_name = String()
+    env_script = String()
+    err_script = String()
+    exit_script = String()
+    execution_time_limit = Float()
+    host = String()
+    init_script = String()
+    job_log_dir = String()
+    owner = String()
+    post_script = String()
+    pre_script = String()
+    script = String()
+    work_sub_dir = String()
+    batch_sys_conf = List(String)
+    environment = List(String)
+    directives = List(String)
+    param_env_tmpl = List(String)
+    param_var = List(String)
+    extra_logs = List(String)
+
+
+class Task(ObjectType):
+    """Task definition, static fields"""
+    id = ID(required=True)
+    name = String(required=True)
+    meta = Field(Meta)
+    mean_elapsed_time = Float()
+    depth = Int()
+    proxies = List(
+        lambda: TaskProxy,
+        description="""Associated cycle point proxies""",
+        args=proxy_args,
+        resolver=get_nodes_id)
+    namespace = List(String, required=True)
+
+
+class PollTask(ObjectType):
+    """Polling task edge"""
+    local_proxy = ID(required=True)
+    workflow = String()
+    remote_proxy = ID(required=True)
+    req_state = String()
+    graph_string = String()
+
+
+class Condition(ObjectType):
+    """Prerequisite conditions."""
+    task_proxy = Field(
+        lambda: TaskProxy,
+        description="""Associated Task Proxy""",
+        resolver=get_node_id)
+    expr_alias = String()
+    req_state = String()
+    satisfied = Boolean()
+    message = String()
+
+
+class Prerequisite(ObjectType):
+    """Task prerequisite."""
+    expression = String()
+    conditions = List(
+        Condition,
+        description="""Condition monomers of a task prerequisites.""")
+    cycle_points = List(String)
+    satisfied = Boolean()
+
+
+class TaskProxy(ObjectType):
+    """Task Cycle Specific info"""
+    id = ID(required=True)
+    task = Field(
+        Task,
+        description="""Task definition""",
+        required=True,
+        resolver=get_node_id)
+    state = String()
+    cycle_point = String()
+    spawned = Boolean()
+    depth = Int()
+    job_submits = Int()
+    latest_message = String()
+    outputs = GenericScalar(default_value=[])
+    broadcasts = List(String, default_value=[])
+    namespace = List(String, required=True)
+    proxy_namespace = List(String)
+    prerequisites = List(Prerequisite)
+    jobs = List(
+        Job,
+        description="""Task jobs.""",
+        args=jobs_args,
+        resolver=get_nodes_id)
+    parents = List(
+        lambda: FamilyProxy,
+        description="""Task parents.""",
+        args=proxy_args,
+        resolver=get_nodes_id)
+
+
+class Family(ObjectType):
+    """Task definition, static fields"""
+    id = ID(required=True)
+    name = String(required=True)
+    meta = Field(Meta)
+    depth = Int()
+    proxies = List(
+        lambda: FamilyProxy,
+        description="""Associated cycle point proxies""",
+        args=proxy_args,
+        resolver=get_nodes_id)
+    parents = List(
+        lambda: Family,
+        description="""Family definition parent.""",
+        args=def_args,
+        resolver=get_nodes_id)
+    child_tasks = List(
+        Task,
+        description="""Descendedant definition tasks.""",
+        args=def_args,
+        resolver=get_nodes_id)
+    child_families = List(
+        lambda: Family,
+        description="""Descendedant desc families.""",
+        args=def_args,
+        resolver=get_nodes_id)
+
+
+class FamilyProxy(ObjectType):
+    class Meta:
+        description = """Family composite."""
+    id = ID(required=True)
+    cycle_point = String()
+    name = String()
+    family = Field(
+        Family,
+        description="""Family definition""",
+        required=True,
+        resolver=get_node_id)
+    state = String()
+    depth = Int()
+    parents = List(
+        lambda: FamilyProxy,
+        description="""Family parent proxies.""",
+        args=proxy_args,
+        resolver=get_nodes_id)
+    child_tasks = List(
+        TaskProxy,
+        description="""Descendedant task proxies.""",
+        args=proxy_args,
+        resolver=get_nodes_id)
+    child_families = List(
+        lambda: FamilyProxy,
+        description="""Descendedant family proxies.""",
+        args=proxy_args,
+        resolver=get_nodes_id)
+
+
+class Node(Union):
+    class Meta:
+        types = (TaskProxy, FamilyProxy)
+
+    @classmethod
+    def resolve_type(cls, instance, info):
+        if hasattr(instance, 'task'):
+            return TaskProxy
+        return FamilyProxy
+
+
+class Edge(ObjectType):
+    class Meta:
+        description = """Dependency edge task/family proxies"""
+    id = ID(required=True)
+    tail_node = Field(
+        Node,
+        resolver=get_node_id)
+    head_node = Field(
+        Node,
+        resolver=get_node_id)
+    suicide = Boolean()
+    cond = Boolean()
+
+
+class Edges(ObjectType):
+    class Meta:
+        description = """Dependency edge"""
+    edges = List(
+        Edge,
+        required=True,
+        args=edge_args,
+        resolver=get_edges_id)
+    workflow_polling_tasks = List(PollTask)
+    leaves = List(String)
+    feet = List(String)
+
+# Query declaration
+
+
+class Query(ObjectType):
+    workflows = List(
+        Workflow,
+        ids=List(ID, default_value=[]),
+        exids=List(ID, default_value=[]),
+        resolver=get_workflows)
+    job = Field(
+        Job,
+        id=ID(required=True),
+        resolver=get_node_id)
+    jobs = List(
+        Job,
+        args=all_jobs_args,
+        resolver=get_nodes_all)
+    task = Field(
+        Task,
+        id=ID(required=True),
+        resolver=get_node_id)
+    tasks = List(
+        Task,
+        args=all_def_args,
+        resolver=get_nodes_all)
+    task_proxy = Field(
+        TaskProxy,
+        id=ID(required=True),
+        resolver=get_node_id)
+    task_proxies = List(
+        TaskProxy,
+        args=all_proxy_args,
+        resolver=get_nodes_all)
+    family = Field(
+        Family,
+        id=ID(required=True),
+        resolver=get_node_id)
+    families = List(
+        Family,
+        args=all_def_args,
+        resolver=get_nodes_all)
+    family_proxy = Field(
+        FamilyProxy,
+        id=ID(required=True),
+        resolver=get_node_id)
+    family_proxies = List(
+        FamilyProxy,
+        args=all_proxy_args,
+        resolver=get_nodes_all)
+    edges = List(
+        Edge,
+        args=all_edge_args,
+        resolver=get_edges_all)
+
+
+# ** Mutation Related ** #
+# Mutations defined:
+class Broadcast(Mutation):
+    class Meta:
+        description = """Clear, Expire, or Put a broadcast:
+- Clear settings globally, or for listed namespaces and/or points
+- Expire all settings targeting cycle points earlier than cutoff.
+- Put up new broadcast settings (server side interface)."""
+
+    class Arguments:
+        action = String(
+            description="""String options:
+- put
+- clear
+- expire""",
+            required=True,)
+        points = List(
+            String,
+            description="""points: ["*"]""",)
+        namespaces = List(
+            String,
+            description="""namespaces: ["foo", "BAZ"]""",)
+        settings = List(
+            GenericScalar,
+            description="""
+settings: [{envronment: {ENVKEY: "env_val"}}, ...]""",)
+
+    modified_settings = GenericScalar()
+    bad_options = GenericScalar()
+
+    def mutate(self, info, action, points=[], namespaces=[], settings=[]):
+        data_mgr = info.context.get('uiserver').data_mgr
+        broadcast_mgr = data_mgr.task_events_mgr.broadcast_mgr
+        mod_ret = []
+        if action == 'put':
+            mod_ret, bad_ret = broadcast_mgr.put_broadcast(
+                points, namespaces, settings)
+        elif action == 'clear':
+            mod_ret, bad_ret = broadcast_mgr.clear_broadcast(
+                points, namespaces, settings)
+        elif action == 'expire':
+            if points:
+                cutoff = points[0]
+                mod_ret, bad_ret = broadcast_mgr.expire_broadcast(cutoff)
+        else:
+            bad_ret = {'action': action}
+        return Broadcast(modified_settings=mod_ret, bad_options=bad_ret)
+
+
+class HoldWorkflow(Mutation):
+    class Meta:
+        description = """Hold items/workflow:
+- set hold on workflow.  (default)
+- Set hold point of workflow."""
+
+    class Arguments:
+        hold_type = String(
+            description="""String options:
+- hold_suite  (default)
+- hold_after_point_string""")
+        point_string = String()
+    command_queued = Boolean()
+
+    def mutate(self, info, hold_type='hold_suite', point_string=None):
+        data_mgr = info.context.get('uiserver').data_mgr
+        item_tuple = ()
+        if point_string is not None:
+            item_tuple = (point_string,)
+        data_mgr.command_queue.put((hold_type, item_tuple, {}))
+        return HoldWorkflow(command_queued=True)
+
+
+class NudgeWorkflow(Mutation):
+    class Meta:
+        description = """Tell workflow to try task processing."""
+    command_queued = Boolean()
+
+    def mutate(self, info):
+        data_mgr = info.context.get('uiserver').data_mgr
+        data_mgr.command_queue.put(("nudge", (), {}))
+        return NudgeWorkflow(command_queued=True)
+
+
+class PutMessages(Mutation):
+    class Meta:
+        description = """Put task messages in queue for processing
+            later by the main loop."""
+
+    class Arguments:
+        job_id = String(
+            description="""Task job in the form "CYCLE/TASK_NAME/SUBMIT_NUM""",
+            required=True)
+        event_time = String(required=True)
+        messages = List(
+            List(String, required=True),
+            description="""List in the form [[severity, message], ...].""")
+    messages_queued = String()
+
+    def mutate(self, info, job_id, event_time, messages):
+        data_mgr = info.context.get('uiserver').data_mgr
+        for severity, message in messages:
+            data_mgr.message_queue.put((job_id, event_time, severity, message))
+        return PutMessages(messages_queued='%d' % len(messages))
+
+
+class ReleaseWorkflow(Mutation):
+    class Meta:
+        description = """Tell workflow to reload the workflow definition."""
+    # class Arguments:
+    #    workflows
+    command_queued = Boolean()
+
+    def mutate(self, info):
+        data_mgr = info.context.get('uiserver').data_mgr
+        data_mgr.command_queue.put(("release_suite", (), {}))
+        return ReleaseWorkflow(command_queued=True)
+
+
+class ReloadWorkflow(Mutation):
+    class Meta:
+        description = """Tell workflow to reload the workflow definition."""
+    command_queued = Boolean()
+
+    def mutate(self, info):
+        data_mgr = info.context.get('uiserver').data_mgr
+        data_mgr.command_queue.put(("reload_suite", (), {}))
+        return ReloadWorkflow(command_queued=True)
+
+
+class SetVerbosity(Mutation):
+    class Meta:
+        description = """Set workflow verbosity to new level."""
+
+    class Arguments:
+        level = String(
+            description="""levels:
+INFO, WARNING, NORMAL, CRITICAL, ERROR, DEBUG""",
+            required=True)
+    command_queued = Boolean()
+
+    def mutate(self, info, level):
+        data_mgr = info.context.get('uiserver').data_mgr
+        data_mgr.command_queue.put(("set_verbosity", (level,), {}))
+        return SetVerbosity(command_queued=True)
+
+
+class StopWorkflowArgs(InputObjectType):
+    kill_active_tasks = Boolean(description="""Use with:
+- set_stop_cleanly""")
+    Terminate = Boolean(description="""Use with:
+- stop_now""")
+
+
+class StopWorkflow(Mutation):
+    class Meta:
+        description = """Workflow stop actions:
+- Cleanly or after kill active tasks. (default)
+- After cycle point.
+- On event handler completion, or terminate right away.
+- After an instance of a task."""
+
+    class Arguments:
+        action = String(
+            description="""String options:
+- set_stop_cleanly  (default)
+- set_stop_after_clock_time
+- set_stop_after_task
+- stop_now""")
+        item = String(
+            description="""Stop items:
+- after_clock_time: ISO 8601 compatible or YYYY/MM/DD-HH:mm
+- after_task: task ID""",)
+        args = StopWorkflowArgs()
+    command_queued = Boolean()
+
+    def mutate(self, info, action='set_stop_cleanly', item=None, args={}):
+        data_mgr = info.context.get('uiserver').data_mgr
+        item_tuple = ()
+        if item is not None:
+            item_tuple = (item,)
+        data_mgr.command_queue.put((action, item_tuple, args))
+        return StopWorkflow(command_queued=True)
+
+
+class TaskArgs(InputObjectType):
+    check_syntax = Boolean(description="""Use with actions:
+- dry_run_tasks""")
+    no_check = Boolean(description="""Use with actions:
+- insert_tasks""")
+    stop_point_string = String(description="""Use with actions:
+- insert_tasks""")
+    poll_succ = Boolean(description="""Use with actions:
+- poll_tasks""")
+    spawn = Boolean(description="""Use with actions:
+- remove_tasks""")
+    state = String(description="""Use with actions:
+- reset_task_states""")
+    outputs = List(String, description="""Use with actions:
+- reset_task_states""")
+    back_out = Boolean(description="""Use with actions:
+- trigger_tasks""")
+
+
+class TaskActions(Mutation):
+    class Meta:
+        description = """Task actions:
+- Prepare job file for task(s).
+- Hold tasks.
+- Insert task proxies.
+- Kill task jobs.
+- Return True if task_id exists (and running).
+- Unhold tasks.
+- Remove tasks from task pool.
+- Reset statuses tasks.
+- Spawn tasks.
+- Trigger submission of task jobs where possible."""
+
+    class Arguments:
+        action = String(
+            description="""Task actions:
+- dry_run_tasks
+- hold_tasks
+- insert_tasks
+- kill_tasks
+- poll_tasks
+- release_tasks
+- remove_tasks
+- reset_task_states
+- spawn_tasks
+- trigger_tasks""",
+            required=True,)
+        items = List(
+            String,
+            description="""
+A list of identifiers (family/glob/id) for matching task proxies, i.e.
+["foo.201901*:failed", "201901*/baa:failed", "FAM.20190101T0000Z", "FAM2",
+    "*.20190101T0000Z"]
+""",
+            required=True,)
+        args = TaskArgs()
+    command_queued = Boolean()
+
+    def mutate(self, info, action, items, args={}):
+        data_mgr = info.context.get('uiserver').data_mgr
+        data_mgr.command_queue.put((action, (items,), args))
+        return TaskActions(command_queued=True)
+
+
+class TakeCheckpoint(Mutation):
+    class Meta:
+        description = """Checkpoint current task pool."""
+
+    class Arguments:
+        items = List(
+            String,
+            description="""items[0] used as checkpoint event name).""",
+            required=True,)
+    command_queued = Boolean()
+
+    def mutate(self, info, items):
+        data_mgr = info.context.get('uiserver').data_mgr
+        data_mgr.command_queue.put(("take_checkpoints", (items,), {}))
+        return TakeCheckpoint(command_queued=True)
+
+
+class XTrigger(Mutation):
+    class Meta:
+        description = """Server-side external event trigger interface."""
+
+    class Arguments:
+        event_message = String(required=True)
+        event_id = String(required=True)
+    event_queued = Boolean()
+
+    def mutate(self, info, event_message, event_id):
+        data_mgr = info.context.get('uiserver').data_mgr
+        data_mgr.ext_trigger_queue.put((event_message, event_id))
+        return XTrigger(event_queued=True)
+
+
+# Mutation declarations
+class Mutation(ObjectType):
+    broadcast = Broadcast.Field(
+        description=Broadcast._meta.description)
+    x_trigger = XTrigger.Field(
+        description=XTrigger._meta.description)
+    hold_workflow = HoldWorkflow.Field(
+        description=HoldWorkflow._meta.description)
+    nudge_workflow = NudgeWorkflow.Field(
+        description=NudgeWorkflow._meta.description)
+    put_messages = PutMessages.Field(
+        description=PutMessages._meta.description)
+    release_workflow = ReleaseWorkflow.Field(
+        description=ReleaseWorkflow._meta.description)
+    reload_workflow = ReloadWorkflow.Field(
+        description=ReloadWorkflow._meta.description)
+    set_verbosity = SetVerbosity.Field(
+        description=SetVerbosity._meta.description)
+    stop_workflow = StopWorkflow.Field(
+        description=StopWorkflow._meta.description)
+    take_checkpoint = TakeCheckpoint.Field(
+        description=TakeCheckpoint._meta.description)
+    task_actions = TaskActions.Field(
+        description=TaskActions._meta.description)
+
+
+schema = Schema(query=Query, mutation=Mutation)

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,13 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+# TODO: update cylc/cylc-flow dependency after cylc-flow PR has been merged
 install_requires = [
     'jupyterhub==1.0.*',
     'tornado==6.0.*',
-    'graphene-tornado==2.1.*'
+    'graphene-tornado==2.1.*',
+    ('cylc @ https://github.com/dwsutherland/cylc'
+     '/tarball/protobuf-uis-feed#egg=cylc-8.0a1.dev')
 ]
 
 setup_requires = [

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,12 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/cylc/cylc-uiserver/',
-    py_modules=['handlers', 'cylc_singleuser'],
+    py_modules=[
+        'handlers',
+        'cylc_singleuser',
+        'data_mgr',
+        'workflow_services_mgr',
+        'schema'],
     python_requires='>=3.7',
     install_requires=install_requires,
     setup_requires=setup_requires,

--- a/setup.py
+++ b/setup.py
@@ -23,13 +23,13 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-# TODO: update cylc/cylc-flow dependency after cylc-flow PR has been merged
 install_requires = [
     'jupyterhub==1.0.*',
     'tornado==6.0.*',
     'graphene-tornado==2.1.*',
-    ('cylc @ https://github.com/dwsutherland/cylc'
-     '/tarball/protobuf-uis-feed#egg=cylc-8.0a1.dev')
+    ('cylc-flow @ https://github.com/cylc/cylc-flow'
+     '/tarball/master#egg=cylc-8.0a1.dev')
+    #'cylc-flow==8.*'
 ]
 
 setup_requires = [
@@ -58,7 +58,8 @@ setup(
         'handlers',
         'cylc_singleuser',
         'data_mgr',
-        'workflow_services_mgr',
+        'workflows_mgr',
+        'resolvers',
         'schema'],
     python_requires='>=3.7',
     install_requires=install_requires,

--- a/workflow_services_mgr.py
+++ b/workflow_services_mgr.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Manage Workflow services.
+
+Includes:
+    - Spawning (#TODO)
+    - Scans/updates
+    - ZeroMQ REQ/RES client initiation and checks
+    - ?
+
+"""
+import sys
+import socket
+
+from tornado import gen
+
+from cylc import flags
+from cylc.hostuserutil import is_remote_host, get_host_ip_by_name
+from cylc.network.client import SuiteRuntimeClient
+from cylc.network.scan import (
+    get_scan_items_from_fs, re_compile_filters, MSG_TIMEOUT)
+
+CLIENT_TIMEOUT = 2.0
+
+
+async def est_workflow(reg, host, port, timeout=None):
+    """Establish communication with workflow, setting up REQ client."""
+    if is_remote_host(host):
+        try:
+            host = get_host_ip_by_name(host)  # IP reduces DNS traffic
+        except socket.error as exc:
+            if cylc.flags.debug:
+                raise
+            sys.stderr.write("ERROR: %s: %s\n" % (exc, host))
+            return (reg, host, port, None)
+
+    # NOTE: Connect to the suite by host:port. This way the
+    #       SuiteRuntimeClient will not attempt to check the contact file
+    #       which would be unnecessary as we have already done so.
+    # NOTE: This part of the scan *is* IO blocking.
+    client = SuiteRuntimeClient(reg, host=host, port=port, timeout=timeout)
+
+    result = {}
+    result['client'] = client
+    try:
+        msg = await client.async_request('identify')
+    except ClientTimeout as exc:
+        return (reg, host, port, MSG_TIMEOUT)
+    except ClientError as exc:
+        return (reg, host, port, result or None)
+    else:
+        result.update(msg)
+    return (reg, host, port, result)
+
+
+class WorkflowServicesMgr(object):
+
+    def __init__(self):
+        self.workflows = {}
+
+    def spawn_workflow(self):
+        # TODO - Spawn workflows
+        pass
+
+    async def gather_workflows(self):
+        workflows = {}
+        cre_owner, cre_name = re_compile_filters(None, ['.*'])
+        scan_args = (
+            (reg, host, port, CLIENT_TIMEOUT)
+            for reg, host, port in
+            get_scan_items_from_fs(cre_owner, cre_name))
+
+        items = await gen.multi([est_workflow(*x) for x in scan_args])
+        for reg, host, port, info in items:
+            if info is not None and info != MSG_TIMEOUT:
+                owner = info['owner']
+                workflows[f"{owner}/{reg}"] = {
+                    'name': info['name'],
+                    'owner': owner,
+                    'host': host,
+                    'port': port,
+                    'version': info['version'],
+                    'req_client': info['client'],
+                }
+        # atomic update
+        self.workflows = workflows

--- a/workflows_mgr.py
+++ b/workflows_mgr.py
@@ -27,11 +27,11 @@ import sys
 import socket
 import asyncio
 
-from cylc import flags
-from cylc.exceptions import ClientError, ClientTimeout
-from cylc.hostuserutil import is_remote_host, get_host_ip_by_name
-from cylc.network.client import SuiteRuntimeClient
-from cylc.network.scan import (
+from cylc.flow import flags
+from cylc.flow.exceptions import ClientError, ClientTimeout
+from cylc.flow.hostuserutil import is_remote_host, get_host_ip_by_name
+from cylc.flow.network.client import SuiteRuntimeClient
+from cylc.flow.network.scan import (
     get_scan_items_from_fs, re_compile_filters, MSG_TIMEOUT)
 
 CLIENT_TIMEOUT = 2.0
@@ -71,7 +71,7 @@ async def est_workflow(reg, host, port, timeout=None):
     return (reg, host, port, client, result)
 
 
-class WorkflowServicesMgr(object):
+class WorkflowsManager(object):
 
     def __init__(self):
         self.workflows = {}


### PR DESCRIPTION
The sibling pull-request to the UI Server graphql protobuf feed:
https://github.com/cylc/cylc/pull/3122
And the Cylc8 UI Server component implementation of the [GraphQL PoC](https://github.com/cylc/cylc/issues/2900).

There will be many more improvements/additions to be incorporated both in this and subsequent pull requests, however, for the sake of UI development and review this needs to be exposed.

The extra dependencies are:
```
    'pyzmq',
    'protobuf',
    'python-jose',
    'colorama',
```
(`colorama` due to the `cylc scan` CL call, which will be deprecated as workflow discovery is already integrated)

The instructions on installation are included in the README.md, and for this change cylc workflow library needs to be put into the python path (or venv site packages), I just source:
```
source ~/.envs/cylc-uis/bin/activate
source ~/.npm_env
export PYTHONPATH="${PYTHONPATH}:/home/sutherlander/repos/cylc8/lib"
```
With `.npm_env` being my local node.js environment:
```
# Node environment
export NPM_PACKAGES="${HOME}/.npm-packages"
export NODE_PATH="$NPM_PACKAGES/lib/node_modules:$NODE_PATH"
export PATH="$NPM_PACKAGES/bin:$PATH"

unset MANPATH
export MANPATH="$NPM_PACKAGES/share/man:$(manpath)"
```

There are three main files in this change:
`schema.py` - GraphQL data structure and types definition (uses [graphene](https://graphene-python.org/))
`workflow_services_mgr.py` - Workflow discovery, REQ client established (and passed to data manager), and spawning (to come).
`data_mgr.py` - Uses established client/workflows to retrieve and process data structure (decode protobuf), and contains access & filtering methods used by the resolvers.

In order to pass in the uiserver/data_manager as context to the resolver's I had to subclass the `graphene-tornado` GraphQL handler:
```
class UIServerGraphQLHandler(TornadoGraphQLHandler):

    #Extra attributes
    uiserver = None

    def initialize(self, **kwargs):
        super(TornadoGraphQLHandler, self).initialize()
        for key, value in kwargs.items():
            if hasattr(self, key):
                if key == 'middleware' and value is not None:
                    setattr(self, key,
                        list(self.instantiate_middleware(value)))
                else:
                    setattr(self, key, value)

    @property
    def context(self):
        wider_context = {
            'uiserver': self.uiserver,
            'request': self.request,
        }
        return wider_context
```

The data update method is very crude at the moment; it pulls the full workflow data msg every 5 secs (which should be faster than CLI `$ cylc client --no-input baz pb_entire_workflow` as the client is already established by the WS manager)... This message is decoded/parsed as a protobuf object (class instance) and stored in a dictionary with "owner/workflow" as a key. 
One of the good features of the UI Server holding/maintaining a data structure is, without needing multiple requests, we can query and filter across workflows, for example:
**query**
```
query workflows($tIds: [ID]){
  workflows(ids: ["baz", "jin"]){
    id
    name
    status
    stateTotals {
      runahead
      waiting
      held
      queued
      expired
      ready
      submitFailed
      submitRetrying
      submitted
      retrying
      running
      failed
      succeeded
    }
    tasks(ids: $tIds){
      name
      meta {
        title
        description
        URL
        userDefined
      }
      proxies(ids: $tIds){
        cyclePoint
        state
      }
    }
  }
}
```
**variables**
```
{
  "tIds": ["foo", "baz"]
}
```
**results**
```
{
  "data": {
    "workflows": [
      {
        "id": "sutherlander/baz",
        "name": "baz",
        "status": "held",
        "stateTotals": {
          "runahead": 0,
          "waiting": 0,
          "held": 5,
          "queued": 0,
          "expired": 0,
          "ready": 0,
          "submitFailed": 0,
          "submitRetrying": 0,
          "submitted": 0,
          "retrying": 0,
          "running": 0,
          "failed": 0,
          "succeeded": 19
        },
        "tasks": [
          {
            "name": "foo",
            "meta": {
              "title": "Some Top family",
              "description": "some task foo",
              "URL": "https://github.com/dwsutherland/cylc",
              "userDefined": [
                "importance=Critical",
                "alerts=none"
              ]
            },
            "proxies": [
              {
                "cyclePoint": "20170301T0000+12",
                "state": "succeeded"
              },
              {
                "cyclePoint": "20170401T0000+12",
                "state": "succeeded"
              },
              {
                "cyclePoint": "20170501T0000+12",
                "state": "held"
              }
            ]
          }
        ]
      },
      {
        "id": "sutherlander/jin",
        "name": "jin",
        "status": "held",
        "stateTotals": {
          "runahead": 0,
          "waiting": 0,
          "held": 1,
          "queued": 0,
          "expired": 0,
          "ready": 0,
          "submitFailed": 0,
          "submitRetrying": 0,
          "submitted": 0,
          "retrying": 0,
          "running": 0,
          "failed": 0,
          "succeeded": 0
        },
        "tasks": [
          {
            "name": "baz",
            "meta": {
              "title": "",
              "description": "",
              "URL": "",
              "userDefined": []
            },
            "proxies": [
              {
                "cyclePoint": "1",
                "state": "held"
              }
            ]
          }
        ]
      }
    ]
  }
}
```
This applies to all fields (from root query), i.e. tasks, jobs, familes, edges... This could open up some possibilities for us.. (And obviously gives us the data for the __"gscan"__ type web view)

A lot more to do, but this is a start 😃 


**This Pull Request**
- [x] Workflow services discovery, management, ZeroMQ REQ/RES client
- [x] Add Data management (protobuf message request & processing) and access methods
- [x] Write/Integrate PoC graphql schema to represent UIS context.
- [x] Query types functioning.
- [x] Mutations types functioning.
- [ ] ? Perhaps some of the below additional

**Additional** (to come or future PR?)
- [ ] Incremental updates to data structure using deltas and checksum skeleton.
- [ ] Deltas received via PUB/SUB from Workflow Services UI Server and checksum skeleton data management.
- [ ] Tornado WebSockets and Subscription server implementation
- [ ] Pagination
- [ ] Workflow services spawning
- [ ] Testing


