### PR TITLE
Specify the versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 install_requires = [
-    'jupyterhub==0.9.*',
+    'jupyterhub==1.0.*',
     'tornado==6.0.*',
-    'graphene-tornado==2.0.*'
+    'graphene-tornado==2.1.*'
 ]
 
 setup_requires = [

--- a/setup.py
+++ b/setup.py
@@ -24,19 +24,19 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 install_requires = [
-    'jupyterhub',
-    'tornado',
-    'graphene-tornado'
+    'jupyterhub==0.9.*',
+    'tornado==6.0.*',
+    'graphene-tornado==2.0.*'
 ]
 
 setup_requires = [
-    'pytest-runner'
+    'pytest-runner==4.4.*'
 ]
 
 tests_require = [
-    'pytest',
-    'coverage',
-    'pytest-cov'
+    'pytest==4.4.*',
+    'coverage==4.5.*',
+    'pytest-cov==2.6.*'
 ]
 
 extras_require = {


### PR DESCRIPTION
Close #9 

This pull request makes sure we have the requirements versions well defined in our setuptools configuration.

Notice that `jupyterhub` has a requirement on `tornado >= 5.0`. Which means that if you have `tornado==5.0`, and happens to also have `jupyterhub==0.9.6` (their latest release), the environment requirements would be OK. Even though there is no guarantee JupyterHub 0.9.6 works with Tornado 5.x any more (they upgraded to 6 and even reported back bugs in the WebSockets features, so they may have changed their API).

We are doing the same in the pull request to add `setup.py` to Cylc, with the argument that having a clear picture of what are our requirements, should gives us less headaches for maintaining the project (e.g. users reporting that it is not working for them, but in reality they have an outdated dependency).