### PR TITLE
Use a different content type for API handlers

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -33,6 +33,12 @@ class BaseHandler(web.RequestHandler):
         self.set_header("Access-Control-Allow-Origin", "*")
         self.set_header("Access-Control-Allow-Headers", "x-requested-with")
         self.set_header('Access-Control-Allow-Methods', 'POST, GET, OPTIONS')
+
+
+class APIHandler(BaseHandler):
+
+    def set_default_headers(self) -> None:
+        super().set_default_headers()
         self.set_header("Content-Type", 'application/json')
 
 
@@ -52,14 +58,18 @@ class MainHandler(HubOAuthenticated, BaseHandler):
         self.write(open(index).read())
 
 
-class UserProfileHandler(HubOAuthenticated, BaseHandler):
+class UserProfileHandler(HubOAuthenticated, APIHandler):
+
+    def set_default_headers(self) -> None:
+        super().set_default_headers()
+        self.set_header("Content-Type", 'application/json')
 
     @web.authenticated
     def get(self):
         self.write(json.dumps(self.get_current_user()))
 
 
-class CylcScanHandler(HubOAuthenticated, BaseHandler):
+class CylcScanHandler(HubOAuthenticated, APIHandler):
 
     def _parse_suite_line(self, suite_line: bytes) -> Union[dict, None]:
         if suite_line:


### PR DESCRIPTION
Follow up after #37 . I accidentally set the content type of all handlers to be application/json, and the main page failed to load.

Fixing that having two separate base classes for normal handlers and for the API handlers. If you open JupyterHub project, in side the `jupyterhub` package you should have `handlers` and `apihandlers`. They do something similar, but with way more stuff.

So for the future, an alternative would be to simply re-use their classes and stop re-creating the same structure here. But @MartinRyan is working on a solution that could remove the dependency of jupyterhub of cylc-uiserver, so no plans to remove these handlers for now 👍 