### PR TITLE
Fix 404 after jupyterhub 1.0.0

### DIFF
--- a/cylc_singleuser.py
+++ b/cylc_singleuser.py
@@ -23,11 +23,11 @@ import signal
 
 from graphene_tornado.schema import schema
 from graphene_tornado.tornado_graphql_handler import TornadoGraphQLHandler
-from jupyterhub.services.auth import HubOAuthCallbackHandler
-from jupyterhub.utils import url_path_join
 from tornado import web, ioloop
 
 from handlers import *
+from jupyterhub.services.auth import HubOAuthCallbackHandler
+from jupyterhub.utils import url_path_join
 
 
 class MyApplication(web.Application):
@@ -83,6 +83,11 @@ class CylcUIServer(object):
                  TornadoGraphQLHandler, dict(graphiql=True, schema=schema, batch=True)),
                 (url_path_join(self._jupyter_hub_service_prefix, '/graphql/graphiql'),
                  TornadoGraphQLHandler, dict(graphiql=True, schema=schema)),
+
+                # since jupyterhub 1.0.0, the "My Server link the hub page removed the last
+                # slash from the URL. This handler is based on the handler with the same name
+                # in jupyterhub 1.0.0, and adds back the last `/` to every URL in the app.
+                (r".*", AddSlashHandler)
             ],
             # FIXME: decide (and document) whether cookies will be permanent after server restart.
             cookie_secret="cylc-secret-cookie"

--- a/handlers.py
+++ b/handlers.py
@@ -15,15 +15,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
-import re
 import os
+import re
 from subprocess import Popen, PIPE
-
-from jupyterhub.services.auth import HubOAuthenticated
-from tornado import web
 from typing import List, Union
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
+
+from tornado import web
 
 from jupyterhub import __version__ as jupyterhub_version
+from jupyterhub.services.auth import HubOAuthenticated
 
 
 class BaseHandler(web.RequestHandler):
@@ -101,4 +103,17 @@ class CylcScanHandler(HubOAuthenticated, APIHandler):
         self.write(json.dumps(suites))
 
 
-__all__ = ["MainHandler", "UserProfileHandler", "CylcScanHandler"]
+class AddSlashHandler(web.RequestHandler):
+
+    def get(self, *args):
+        src = urlparse(self.request.uri)
+        dest = src._replace(path=src.path + '/')
+        self.redirect(urlunparse(dest))
+
+
+__all__ = [
+    "MainHandler",
+    "UserProfileHandler",
+    "CylcScanHandler",
+    "AddSlashHandler"
+]


### PR DESCRIPTION
Finally found a way to fix this one. Tested locally.

It worked before when the button was pointing to `/user/$USER/` with the trailing slash. Now it copies the behaviour of jupyterhub's [`AddSlashHandler`](https://github.com/jupyterhub/jupyterhub/commit/ad7867ff11426755ec752ed5b5fbfabd1d2462c3).

