### PR TITLE
Use tornado's addslash decorator

### DIFF
--- a/cylc_singleuser.py
+++ b/cylc_singleuser.py
@@ -86,7 +86,7 @@ class CylcUIServer(object):
                     self._jupyter_hub_service_prefix, 'suites'),
                     CylcScanHandler),
 
-                (self._jupyter_hub_service_prefix,
+                (rf"{self._jupyter_hub_service_prefix}?",
                     MainHandler, {"path": self._static}),
 
                 # graphql
@@ -101,13 +101,7 @@ class CylcUIServer(object):
                 (url_path_join(self._jupyter_hub_service_prefix,
                                '/graphql/graphiql'),
                     TornadoGraphQLHandler,
-                    dict(graphiql=True, schema=schema)),
-
-                # since jupyterhub 1.0.0, the "My Server link the hub page
-                # removed the last slash from the URL. This handler is based
-                # on the handler with the same name in jupyterhub 1.0.0,
-                # and adds back the last `/` to every URL in the app.
-                (r".*", AddSlashHandler)
+                    dict(graphiql=True, schema=schema))
             ],
             # FIXME: decide (and document) whether cookies will be permanent
             # after server restart.

--- a/handlers.py
+++ b/handlers.py
@@ -19,8 +19,6 @@ import os
 import re
 from subprocess import Popen, PIPE
 from typing import List, Union
-from urllib.parse import urlparse
-from urllib.parse import urlunparse
 
 from jupyterhub import __version__ as jupyterhub_version
 from jupyterhub.services.auth import HubOAuthenticated
@@ -52,6 +50,7 @@ class MainHandler(HubOAuthenticated, BaseHandler):
     def initialize(self, path):
         self._static = path
 
+    @web.addslash
     @web.authenticated
     def get(self):
         """Render the UI prototype."""
@@ -102,17 +101,8 @@ class CylcScanHandler(HubOAuthenticated, APIHandler):
         self.write(json.dumps(suites))
 
 
-class AddSlashHandler(web.RequestHandler):
-
-    def get(self, *args):
-        src = urlparse(self.request.uri)
-        dest = src._replace(path=src.path + '/')
-        self.redirect(urlunparse(dest))
-
-
 __all__ = [
     "MainHandler",
     "UserProfileHandler",
-    "CylcScanHandler",
-    "AddSlashHandler"
+    "CylcScanHandler"
 ]


### PR DESCRIPTION
@sadielbartholomew found a neater solution for the missing slashes instead of the one implemented in #39. One that if that works we can even suggest to JupyterHub (which is a nice thing to do, as we are using so much of their work for free).

[Docs here](https://www.tornadoweb.org/en/stable/web.html#tornado.web.addslash) for the decorator. @sadielbartholomew , could you review this one? Here are the steps to reproduce:

- Check out this pull request
- Remove the annotation
- Create a venv/conda environment
- `pip install -e .` (editable so you don't have to re-install later)
- Start `cylc/cylc-ui` in another directory with `npm run build:watch`, copy the directory where `cylc-ui` is now running
- Edit `jupyterhub_config.py`, looking for `c.Spawner.args` and specify the location of the `cylc-ui/dist` directory (absolute path might be easier)
- Start `cylc-uiserver` by running `jupyterhub`
- Go to `http://localhost:8000` and log in with your local user (it will use PAM to authenticate). You should either see a new page that is either a page with two buttons ("Stop My Server", "My Server"), or a page with one button ("Launch Server"), or the `cylc-ui` landing page.
- If you are on the `cylc-ui` landing page, there should be a link to the "Hub" on the menu to the left, at the bottom
- From the Hub page, after logged in, you should see a blue button that says "My Server". Hover over the link, and you should notice that the link is something like `/user/$yourusernoslash`
- Click on that button, and confirm it works. If you would like to try, you can remove the decorator `addslash` from the `handlers.py` `MainHandler` class. Restarting `jupyterhub`, and re-doing the previous steps, instead of showing the `cylc-ui` landing page, you should see either a blank page or a 404 (it might be blank, because now instead of `/`, we followed the docs of `addslash` and used `/?`, so the `/` is optional, but then it is also matching static paths, causing a major confusion to the roles).
- If you reached this point, you are ready to review this PR with aye/nay :) one review should be enough for this one for now.

Cheers
Bruno