### PR TITLE
Use argparse parse_known_args to allow extra params/args

### DIFF
--- a/cylc_singleuser.py
+++ b/cylc_singleuser.py
@@ -133,7 +133,7 @@ def main():
                         default=8888)
     parser.add_argument('-s', '--static', action="store", dest="static",
                         required=True)
-    args = parser.parse_args()
+    args = parser.parse_known_args()[0]
 
     jupyterhub_service_prefix = os.environ.get(
         'JUPYTERHUB_SERVICE_PREFIX', '/')


### PR DESCRIPTION
Close #48 

Tested by running `$ cylc-singleuser -s $(pwd)/../cylc-ui/dist/ -p 9999`, which works fine.

The tested the scenario that is broken:

```bash
$ cylc-singleuser -s $(pwd)/../cylc-ui/dist/ -p 9999 --debug
usage: cylc-singleuser [-h] [-p PORT] -s STATIC
cylc-singleuser: error: unrecognized arguments: --debug
```

With the fix in this PR, the `--debug` is simply ignored (or any other value passed by the `jupyterhub` command, after reading the `jupyterhub_config.py` settings).

Cheers
Bruno