### PR TITLE
Use Cylc logo in JupyterHub.

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -306,7 +306,7 @@
 #c.JupyterHub.load_groups = {}
 
 ## Specify path to a logo image to override the Jupyter logo in the banner.
-#c.JupyterHub.logo_file = ''
+c.JupyterHub.logo_file = '../cylc-ui/dist/img/logo.png'
 
 ## File to write PID Useful for daemonizing JupyterHub.
 #c.JupyterHub.pid_file = ''


### PR DESCRIPTION
The logo is configurable in JupyterHub.

(Currently assumes relative path to cylc-ui project, as we already do elsewhere in the config file; this might not be the permanent solution to that problem?)

We might have to contribute a small change to JupyterHub to make the X'd words similarly configurable:

![jhub-logo](https://user-images.githubusercontent.com/2362137/60843554-1cae7700-a22b-11e9-9be5-f9d5bab793ca.png)
