### PR TITLE
Close socket used by pyzmq when deleting the client

### DIFF
--- a/workflows_mgr.py
+++ b/workflows_mgr.py
@@ -27,6 +27,8 @@ import sys
 import socket
 import asyncio
 
+from contextlib import suppress
+
 from cylc.flow import flags
 from cylc.flow.exceptions import ClientError, ClientTimeout
 from cylc.flow.hostuserutil import is_remote_host, get_host_ip_by_name
@@ -109,8 +111,14 @@ class WorkflowsManager(object):
             if w_id in scanflows:
                 if (info['host'] == scanflows[w_id]['host'] and
                         info['port'] == scanflows[w_id]['port']):
+                    client = scanflows[w_id]['req_client']
+                    with suppress(IOError):
+                        client.socket.close()
                     scanflows.pop(w_id)
                 continue
+            client = self.workflows[w_id]['req_client']
+            with suppress(IOError):
+                client.socket.close()
             self.workflows.pop(w_id)
 
         # update with new


### PR DESCRIPTION
Closes #44 

Spent some minutes understanding better how we create cylc-flow pyzmq clients, and from what I could tell, we create one client per suite/workflow found in `cylc-run`.

The clients are normally present afterwards in tuples or dicts, and are re-used later if we need to perform more operations to fetch more data.

When a suite started, a new client would be created. Creating the client (i.e. `SuiteRuntimeClient(reg, host=host, port=port, timeout=timeout)`) increases the number of file descriptors in at least 3. More precisely, that happens when the `ZMQClient` (`SuiteRuntimeClient`'s parent) constructor calls `self.socket = CONTEXT.socket(zmq.REQ)`.

So far so good. Every time we poll the backend for running suites/workflows, we check if we have already found that suite in a previous polling. If so, we don't need to bother adding it again, and **discard** the returned object, which includes a client.

So this is the first issue, where when discarding the object (i.e. popping from the list) we actually needed to remember to close the client's socket.

Likewise, later, once the suite finished running, that item would also be pop'ed from the list, without the socket being closed.