### PR TITLE
Protect GraphQL endpoint

### DIFF
--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -107,7 +107,7 @@ class CylcScanHandler(HubOAuthenticated, APIHandler):
 # This is needed in order to pass the server context in addition to existing.
 # It's possible to just overwrite TornadoGraphQLHandler.context but we would
 # somehow need to pass the request info (headers, username ...etc) in also
-class UIServerGraphQLHandler(TornadoGraphQLHandler):
+class UIServerGraphQLHandler(HubOAuthenticated, TornadoGraphQLHandler):
 
     # Declare extra attributes
     resolvers = None
@@ -139,6 +139,10 @@ class UIServerGraphQLHandler(TornadoGraphQLHandler):
             'resolvers': self.resolvers,
         }
         return wider_context
+
+    @web.authenticated
+    def prepare(self):
+        super().prepare()
 
 
 __all__ = [


### PR DESCRIPTION
Closes #72 

Tested first the happy-path, by querying GraphQL after starting hub + uiserver, and authenticating with my user. Appeared to work fine with no issues.

Then copied the GraphiQL URL and pasted on an incognito window, and was redirected to the Hub login page (instead of accessing GraphiQL unauthenticated).

Finally, after authenticating, executed a query in GraphiQL, then in another tab logged out of the hub, and upon submitting the query again, got an error in GraphiQL, showing that the endpoint was protected against `GET` and `POST` requests.

![image](https://user-images.githubusercontent.com/304786/64500848-12842400-d313-11e9-824a-1abee2375ad4.png)
