### PR TITLE
Set version back to 0.1

### DIFF
--- a/cylc/uiserver/__init__.py
+++ b/cylc/uiserver/__init__.py
@@ -13,4 +13,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "1.0"
+__version__ = "0.1"


### PR DESCRIPTION
In JS normally I see `0.0.0`. But in Python I am not so sure whether 0.1 or 0.1.0 would be the best option. Happy to update the PR if necessary.

Also thought about raising the issue of using a `-dev` or `-something` suffix too, to display a different version for using installing from github (but I didn't do that for the cylc-ui project, so I think we can do it in a next PR)