### PR TITLE
WFS Data Store Sync

### DIFF
--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -42,7 +42,7 @@ from time import sleep
 from cylc.flow.network.server import PB_METHOD_MAP
 from cylc.flow.network.scan import MSG_TIMEOUT
 from cylc.flow.network.subscriber import WorkflowSubscriber, process_delta_msg
-from cylc.flow.ws_data_mgr import (
+from cylc.flow.data_store_mgr import (
     EDGES, FAMILIES, FAMILY_PROXIES, JOBS, TASKS, TASK_PROXIES, WORKFLOW,
     DELTAS_MAP, apply_delta, generate_checksum
 )
@@ -51,7 +51,7 @@ from .workflows_mgr import workflow_request
 logger = logging.getLogger(__name__)
 
 
-class DataManager:
+class DataStoreMgr:
     """Manage the local data-store acquisition/updates for all workflows."""
 
     INIT_DATA_WAIT_TIME = 5.  # seconds
@@ -184,7 +184,7 @@ class DataManager:
                 self.loop
             )
             try:
-                _, new_delta_msg = future.result(5.0)
+                _, new_delta_msg = future.result(self.RECONCILE_TIMEOUT)
             except asyncio.TimeoutError:
                 logger.info(
                     f'The reconcile update coroutine {w_id} {topic}'

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -23,7 +23,7 @@ from cylc.flow.ws_data_mgr import WORKFLOW
 class Resolvers(BaseResolvers):
     """UI Server context GraphQL query and mutation resolvers."""
 
-    ws_mgr = None
+    workflows_mgr = None
 
     def __init__(self, data, **kwargs):
         super().__init__(data)
@@ -46,7 +46,7 @@ class Resolvers(BaseResolvers):
             'request_string': req_str,
             'variables': variables,
         }
-        return self.ws_mgr.multi_request('graphql', w_ids, graphql_args)
+        return self.workflows_mgr.multi_request('graphql', w_ids, graphql_args)
 
     async def nodes_mutator(self, info, *m_args):
         """Mutate node items of associated workflows."""
@@ -63,5 +63,5 @@ class Resolvers(BaseResolvers):
             'variables': variables,
         }
         multi_args = {w_id: graphql_args for w_id in w_ids}
-        return self.ws_mgr.multi_request(
+        return self.workflows_mgr.multi_request(
             'graphql', w_ids, multi_args=multi_args)

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -17,7 +17,7 @@
 """GraphQL resolvers for use in data accessing and mutation of workflows."""
 
 from cylc.flow.network.resolvers import BaseResolvers
-from cylc.flow.ws_data_mgr import WORKFLOW
+from cylc.flow.data_store_mgr import WORKFLOW
 
 
 class Resolvers(BaseResolvers):

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -17,16 +17,15 @@
 import inspect
 
 import pytest
+import zmq
 
-from cylc.flow.network.client import ZMQClient
+from cylc.flow.network import ZMQSocketBase
 
 
-class AsyncClientFixture(ZMQClient):
+class AsyncClientFixture(ZMQSocketBase):
+    pattern = zmq.REQ
     host = ''
     port = 0
-    encode_method = None
-    decode_method = None
-    secret_method = None
 
     def __init__(self):
         self.returns = None

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -140,12 +140,12 @@ async def test_est_workflow(
 
 
 def test_workflows_manager_constructor():
-    mgr = WorkflowsManager()
+    mgr = WorkflowsManager(None)
     assert not mgr.workflows
 
 
 def test_workflows_manager_spawn_workflow():
-    mgr = WorkflowsManager()
+    mgr = WorkflowsManager(None)
     mgr.spawn_workflow()
     assert not mgr.workflows
 

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -43,28 +43,30 @@ async def test_workflow_request_client_error(async_client: AsyncClientFixture):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("returns,command,context,expected_ctx,expected_msg", [
-    pytest.param(
-        42, 'cmd', None, 'cmd', 42
-    ),
-    pytest.param(
-        42, '', None, '', 42
-    ),
-    pytest.param(
-        42, 'cmd', 'some-context', 'some-context', 42
-    )
-])
+@pytest.mark.parametrize(
+    "returns,command,req_context,expected_ctx,expected_msg",
+    [
+        pytest.param(
+            42, 'cmd', None, 'cmd', 42
+        ),
+        pytest.param(
+            42, '', None, '', 42
+        ),
+        pytest.param(
+            42, 'cmd', 'some-context', 'some-context', 42
+        )
+    ])
 async def test_workflow_request(
         async_client: AsyncClientFixture,
         returns,
         command,
-        context,
+        req_context,
         expected_ctx,
         expected_msg
 ):
     async_client.will_return(returns)
     ctx, msg = await workflow_request(
-        client=async_client, command=command, context=context)
+        client=async_client, command=command, req_context=req_context)
     assert expected_ctx == ctx
     assert expected_msg == msg
 
@@ -86,19 +88,19 @@ async def test_est_workflow_socket_error(
     def side_effect(*_, **__):
         raise socket.error
     mocked_get_host_ip_by_name.side_effect = side_effect
-    reg, host, port, client = await est_workflow(
+    reg, host, port, pub_port, client = await est_workflow(
         '', '', 0, 0)
-    assert not any([reg, host, port, client])
+    assert not any([reg, host, port, pub_port, client])
     assert client is None
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('reg,host,port,timeout,expected_host', [
+@pytest.mark.parametrize('reg,host,port,pub_port,timeout,expected_host', [
         pytest.param(
-            'remote', 'remote', 8000, 1, 'remote_host'
+            'remote', 'remote', 8000, 8002, 1, 'remote_host'
         ),
         pytest.param(
-            'local', 'localhost', 4000, 2, 'localhost'
+            'local', 'localhost', 4000, 4001, 2, 'localhost'
         )
     ])
 async def test_est_workflow(
@@ -107,6 +109,7 @@ async def test_est_workflow(
         reg,
         host,
         port,
+        pub_port,
         timeout,
         expected_host
 ):
@@ -124,11 +127,12 @@ async def test_est_workflow(
     mocked_get_host_ip_by_name.side_effect = lambda x: f'remote_host' \
         if x == 'remote' else x
 
-    r_reg, r_host, r_port, r_client, r_result = await est_workflow(
-        reg, host, port, timeout)
+    r_reg, r_host, r_port, r_pub_port, r_client, r_result = await est_workflow(
+        reg, host, port, pub_port, timeout)
     assert reg == r_reg
     assert expected_host == r_host
     assert port == r_port
+    assert pub_port == r_pub_port
     assert r_client.__class__ == AsyncClientFixture
 
 

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -123,12 +123,12 @@ class WorkflowsManager:
                         info['port'] == scanflows[w_id]['port']):
                     client = scanflows[w_id]['req_client']
                     with suppress(IOError):
-                        client.socket.close()
+                        client.stop(stop_loop=False)
                     scanflows.pop(w_id)
                 continue
             client = self.workflows[w_id]['req_client']
             with suppress(IOError):
-                client.socket.close()
+                client.stop(stop_loop=False)
             self.workflows.pop(w_id)
 
         # update with new

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ install_requires = [
     'jupyterhub==1.0.*',
     'tornado==6.0.*',
     'graphene-tornado==2.1.*',
-    'cylc-flow==8.0a1'
+    ('cylc-flow @ https://github.com/cylc/cylc-flow'
+     '/tarball/master#egg=cylc-8.0a2.dev')
 ]
 
 # Only include pytest-runner in setup_requires if we're invoking tests


### PR DESCRIPTION
These changes partially address https://github.com/cylc/cylc-flow/issues/3207

This branch is the companion of and needs to be merged **after** https://github.com/cylc/cylc-flow/pull/3389
(CI will fail until the [PR](https://github.com/cylc/cylc-flow/pull/3389) is merged)

**Functional/Done:**
- [x] Updates to the data-store via subscriptions to workflow published deltas.
- [x] Verification of  data-store, and reconciliation with the workflow data-store.

**To Do:** (excluding below)
- [ ] Investigate alternative to threading the subscription/sync loops?


The sync appears solid; verification seldom fails (I haven't seen one yet), and there's reconciliation on failure..
- The data-store is split-up-into/published-as "topics" (i.e. `task_proxies`, `jobs`, `workflow`...etc), and these topic messages/deltas/updates are subscribed-to/received, processed, and verified independently. This means update frequency can differ between topics, while order and content is orchestrated by the workflow service (WFS).
- The subscription is started first (in a separate thread), and messages wait in the zmq Queue for initial data request (for ~3sec, then moves onto the next and waits again).
- The entire workflow is requested in the main thread.
- The subscription message/delta handler then works through the queue (via recv_multi ZeroMQ holds messages up to the High Water Mark (HWM)), only applying deltas that were created **after** the initial data and then **after** last applied delta.
- The local data-store topic elements (i.e. `task_proxies`) are verified against the respective WFS, via a checksum sent with the delta, and a new set is requested on failure.

(deltas only contain the elements and fields that were updated)

We need to figure out if creating threads for each subscription loop (i.e. one per workflow), is scalable..  As in, do they yield execution to other threads while `await`ing a publish..  I did it to avoid blocking the main asyncio loop with subscription loops.. Sockets can't be passed between threads, but I think it's fine for them to exist in their lifetime on one thread. (will see what happens with a large load of workflows)
    Perhaps if we can dynamically update (`add/remove`) an `asyncio.gather` (or something), then we could avoid threads?...

But for now it's fully functional! 🎉 



**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes.
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
