### PR TITLE
Force dependency on graphql-core < 3 in the module (to avoid transitive dependencies conflicts)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ install_requires = [
     'graphene-tornado==2.1.*',
     ('cylc-flow @ https://github.com/cylc/cylc-flow'
      '/tarball/master#egg=cylc-8.0a2.dev'),
+    'graphql-core<3,>=2.1',  # TODO: graphql-python/graphql-ws#39
     'graphql-ws==0.3.*'
 ]
 


### PR DESCRIPTION
This is a small change with no associated Issue.

Due to a typo in the `setup.py` of `graphql-ws`, we have a dependency conflict which prevents `jupyterhub` of initializing the Cylc UI Server.

See https://github.com/graphql-python/graphql-ws/pull/39 for more

This PR forces that the `graphql-core` version installed is less than 3.0.0, which fixes the conflicts. I've also added a TODO marker as this can be removed if/when the PR is merged and a new release is pushed to PYPI.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? dependency change).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
