### PR TITLE
Cylc-ise the Cylc Hub

### DIFF
--- a/cylc/uiserver/templates/page.html
+++ b/cylc/uiserver/templates/page.html
@@ -1,0 +1,3 @@
+{% extends "templates/page.html" %}
+
+{% block title %}Cylc Hub{% endblock %}

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -17,7 +17,7 @@
 # Configuration file for jupyterhub.
 
 from pathlib import Path
-
+import pkg_resources
 
 HERE = Path(__file__).resolve().parent
 DIST = HERE.joinpath(Path('../cylc-ui/dist'))
@@ -35,11 +35,24 @@ c.Spawner.args = ['-s', str(DIST)]
 #  documentation for your spawner to verify!
 c.Spawner.cmd = ['cylc-uiserver']
 
-# --- Specify path to a logo image to override the Jupyter logo in the banner.
-
-c.JupyterHub.logo_file = str(DIST.joinpath(Path('img/logo.png')))
 
 # --- The class to use for spawning single-user servers.
 
 #  Should be a subclass of Spawner.
 c.JupyterHub.spawner_class = 'jupyterhub.spawner.LocalProcessSpawner'
+
+
+# --- Cylc-ise Jupyterhub
+
+# TODO: move logo to a shared location
+# https://github.com/cylc/cylc-admin/issues/69
+c.JupyterHub.logo_file = str(DIST.joinpath(Path('img/logo.svg')))
+# use ISO8601 (expanded) date format for logging
+c.JupyterHub.log_datefmt = '%Y-%m-%dT%H:%M:%S'
+# specifiy custom HTML templates
+c.JupyterHub.template_paths = [
+    pkg_resources.resource_filename(
+        'cylc.uiserver',
+        'templates'
+    )
+]


### PR DESCRIPTION
Related to #50 

* Fix Cylc logo location (note https://github.com/cylc/cylc-ui/pull/344)
* Rename Jupyterhub => Cylc Hub