### PR TITLE
Use same SSL cert/key for internal SSL with the UI Server/tornado app

### DIFF
--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -43,6 +43,10 @@ class BaseHandler(web.RequestHandler):
 
 class APIHandler(BaseHandler):
 
+    def initialize(self, certfile, keyfile):
+        self.certfile = certfile
+        self.keyfile = keyfile
+
     def set_default_headers(self) -> None:
         super().set_default_headers()
         self.set_header("Content-Type", 'application/json')

--- a/cylc/uiserver/main.py
+++ b/cylc/uiserver/main.py
@@ -25,11 +25,12 @@ import ssl
 from functools import partial
 from logging.config import dictConfig
 from os.path import join, abspath, dirname
-from typing import Union
+from typing import Any, Union, Tuple, Type
 
 from tornado import web, ioloop
 
 from cylc.flow.network.schema import schema
+from graphene_tornado.tornado_graphql_handler import TornadoGraphQLHandler
 from jupyterhub.services.auth import HubOAuthCallbackHandler
 from jupyterhub.utils import url_path_join
 from .data_store_mgr import DataStoreMgr
@@ -74,6 +75,8 @@ class MyApplication(web.Application):
 class CylcUIServer(object):
 
     def __init__(self, port, static, jupyter_hub_service_prefix):
+        self.certfile = None
+        self.keyfile = None
         self._port = port
         if os.path.isabs(static):
             self._static = static
@@ -87,19 +90,91 @@ class CylcUIServer(object):
             self.data_store_mgr.data,
             workflows_mgr=self.workflows_mgr)
 
-    @staticmethod
-    def _get_ssl_options(keyfile: str,
-                         certfile: str) -> Union[dict, None]:
+    def _get_ssl_options(self) -> Union[dict, None]:
+        """
+        Create Tornado SSL options.
+        Returns:
+            Either None or a dictionary with the certificate and the key
+            file locations
+        """
         logger.info(os.environ.items())
-        if not certfile:
+        if not self.certfile:
             logger.info("No SSL context created: missing certificate")
             return None
-        logger.info(f"Creating SSL context with certificate file [{certfile}]"
-                    f" and keyfile [{keyfile}]")
+        logger.info(f"Creating SSL context with certificate"
+                    f" file [{self.certfile}] and keyfile [{self.keyfile}]")
         return {
-            "certfile": certfile,
-            "keyfile": keyfile
+            "certfile": self.certfile,
+            "keyfile": self.keyfile
         }
+
+    def _create_static_handler(
+            self,
+            path: str
+    ) -> Tuple[str, Type[web.StaticFileHandler], dict]:
+        """
+        Create a static content handler.
+
+        Args:
+            path (str): handler path (supports regular expressions)
+        Returns:
+            Tornado handler tuple
+        """
+        return (
+            rf"{self._jupyter_hub_service_prefix}({path})",
+            web.StaticFileHandler,
+            {"path": self._static}
+        )
+
+    def _create_handler(
+            self,
+            path: str,
+            clazz: Type[web.RequestHandler],
+            **kwargs: Any
+    ) -> Tuple[str, Type[web.RequestHandler], dict]:
+        """
+        Create a Tornado handler.
+
+        Args:
+            path (str): handler path
+            clazz (class): handler class
+            kwargs: extra params
+        Returns:
+            Tornado handler tuple
+        """
+        return (
+            url_path_join(self._jupyter_hub_service_prefix, path),
+            clazz,
+            dict(
+                certfile=self.certfile,
+                keyfile=self.keyfile,
+                **kwargs
+            )
+        )
+
+    def _create_graphql_handler(
+            self,
+            path: str,
+            clazz: Type[TornadoGraphQLHandler],
+            **kwargs: Any
+    ) -> Tuple[str, Type[web.RequestHandler], dict]:
+        """
+        Create a GraphQL handler.
+
+        Args:
+            path (str): handler path
+            clazz (class): handler class
+            kwargs: extra params
+        Returns:
+            Tornado handler tuple
+        """
+        return self._create_handler(
+            url_path_join(self._jupyter_hub_service_prefix, path),
+            clazz,
+            schema=schema,
+            resolvers=self.resolvers,
+            **kwargs
+        )
 
     def _make_app(self, debug: bool):
         """Crete a Tornado web application.
@@ -108,53 +183,41 @@ class CylcUIServer(object):
             debug (bool): flag to set debugging in the Tornado application
         """
         logger.info(self._static)
+        # subscription/websockets server
+        subscription_server = TornadoSubscriptionServer(schema)
         return MyApplication(
             static_path=self._static,
             debug=debug,
             handlers=[
-                (rf"{self._jupyter_hub_service_prefix}(.*.(css|js))",
-                 web.StaticFileHandler, {"path": self._static}),
-                (rf"{self._jupyter_hub_service_prefix}((fonts|img)/.*)",
-                 web.StaticFileHandler, {"path": self._static}),
-                (rf"{self._jupyter_hub_service_prefix}(favicon.png)",
-                 web.StaticFileHandler, {"path": self._static}),
-
-                (r"/(.*.(css|js))",
-                 web.StaticFileHandler, {"path": self._static}),
-                (r"/((fonts|img)/.*)",
-                 web.StaticFileHandler, {"path": self._static}),
-                (r"/(favicon.png)",
-                 web.StaticFileHandler, {"path": self._static}),
-
-                (url_path_join(
-                    self._jupyter_hub_service_prefix, 'oauth_callback'),
-                    HubOAuthCallbackHandler),
-                (url_path_join(
-                    self._jupyter_hub_service_prefix, 'userprofile'),
-                    UserProfileHandler),
-
-                (rf"{self._jupyter_hub_service_prefix}?",
-                    MainHandler, {"path": self._static}),
-
-                # graphql
-                (url_path_join(self._jupyter_hub_service_prefix,
-                               '/graphql'),
-                    UIServerGraphQLHandler,
-                    dict(schema=schema, resolvers=self.resolvers)),
-                (url_path_join(self._jupyter_hub_service_prefix,
-                               '/graphql/batch'),
-                    UIServerGraphQLHandler,
-                    dict(schema=schema, resolvers=self.resolvers, batch=True)),
-                (url_path_join(self._jupyter_hub_service_prefix,
-                               '/graphql/graphiql'),
-                    GraphiQLHandler,
-                    dict(schema=schema, resolvers=self.resolvers,
-                         graphiql=True)),
-                (url_path_join(
-                    self._jupyter_hub_service_prefix, '/subscriptions'),
-                    SubscriptionHandler,
-                    dict(sub_server=TornadoSubscriptionServer(schema),
-                         resolvers=self.resolvers))
+                # static content
+                self._create_static_handler(".*.(css|js)"),
+                self._create_static_handler("(fonts|img)/.*"),
+                self._create_static_handler("favicon.png"),
+                # normal handlers, with auth
+                self._create_handler("oauth_callback",
+                                     HubOAuthCallbackHandler),
+                self._create_handler("userprofile",
+                                     UserProfileHandler),
+                # graphql handlers
+                self._create_graphql_handler("graphql",
+                                             UIServerGraphQLHandler),
+                self._create_graphql_handler("graphql/batch",
+                                             UIServerGraphQLHandler,
+                                             batch=True),
+                self._create_graphql_handler("graphql/graphiql",
+                                             GraphiQLHandler,
+                                             graphiql=True),
+                # subscription/websockets handler
+                self._create_handler("subscriptions",
+                                     SubscriptionHandler,
+                                     sub_server=subscription_server,
+                                     resolvers=self.resolvers),
+                # main handler
+                (
+                    rf"{self._jupyter_hub_service_prefix}?",
+                    MainHandler,
+                    {"path": self._static}
+                )
             ],
             # FIXME: decide (and document) whether cookies will be permanent
             # after server restart.
@@ -162,9 +225,11 @@ class CylcUIServer(object):
         )
 
     def start(self, debug: bool, keyfile: str, certfile: str):
+        self.certfile = certfile
+        self.keyfile = keyfile
         app = self._make_app(debug)
         signal.signal(signal.SIGINT, app.signal_handler)
-        ssl_options = CylcUIServer._get_ssl_options(keyfile, certfile)
+        ssl_options = self._get_ssl_options()
         app.listen(self._port, ssl_options=ssl_options)
         # pass in server object for clean exit
         ioloop.PeriodicCallback(


### PR DESCRIPTION
This is a small change with no associated Issue.

Change to enable SSL in Cylc UI Server's Tornado server. The Tornado HTTP Server is responsible for handling the connections proxied by the `configurable-http-server`, including the WebSockets connection - that may be `ws:` or `wss:`.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [ ] No documentation update required.
