### PR TITLE
Use one Queue object per handler instance

### DIFF
--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -115,11 +115,9 @@ class UIServerGraphQLHandler(HubOAuthenticated, TornadoGraphQLHandler):
 
 
 class SubscriptionHandler(websocket.WebSocketHandler):
-    subscription_server = None
-    resolvers = None
-    queue = Queue(100)
 
     def initialize(self, sub_server, resolvers):
+        self.queue = Queue(100)
         self.subscription_server = sub_server
         self.resolvers = resolvers
 


### PR DESCRIPTION
These changes close #106

This prevents the `Queue` of being shared across multiple connections (multiple browser tabs), and message sent accidentally to the wrong client.

This bug does not exist in the original code, which is in a pending PR for `graphql-ws`. I added the bug while porting the code to our handlers.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
