### PR TITLE
UIS Delta subscriptions & GraphQL null stripping back-end

### DIFF
--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -99,6 +99,7 @@ class UIServerGraphQLHandler(HubOAuthenticated, TornadoGraphQLHandler):
         self.graphiql = graphiql
         self.batch = batch
         self.backend = backend or get_default_backend()
+        self.strip_null = True
         # Set extra attributes
         for key, value in kwargs.items():
             if hasattr(self, key):

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -99,7 +99,6 @@ class UIServerGraphQLHandler(HubOAuthenticated, TornadoGraphQLHandler):
         self.graphiql = graphiql
         self.batch = batch
         self.backend = backend or get_default_backend()
-        self.strip_null = True
         # Set extra attributes
         for key, value in kwargs.items():
             if hasattr(self, key):
@@ -117,6 +116,16 @@ class UIServerGraphQLHandler(HubOAuthenticated, TornadoGraphQLHandler):
     @web.authenticated
     def prepare(self):
         super().prepare()
+
+    async def execute(self, *args, **kwargs):
+        # Use own backend, and TornadoGraphQLHandler already does validation.
+        return await self.schema.execute(
+            *args,
+            backend=self.backend,
+            variable_values=kwargs.get('variables'),
+            validate=False,
+            **kwargs,
+        )
 
 
 class SubscriptionHandler(websocket.WebSocketHandler):

--- a/cylc/uiserver/main.py
+++ b/cylc/uiserver/main.py
@@ -28,6 +28,9 @@ from typing import Any, Tuple, Type
 
 from tornado import web, ioloop
 
+from cylc.flow.network.graphql import (
+    GraphQLCoreBackend, IgnoreFieldMiddleware
+)
 from cylc.flow.network.schema import schema
 from graphene_tornado.tornado_graphql_handler import TornadoGraphQLHandler
 from jupyterhub.services.auth import HubOAuthCallbackHandler
@@ -39,6 +42,9 @@ from .websockets.tornado import TornadoSubscriptionServer
 from .workflows_mgr import WorkflowsManager
 
 logger = logging.getLogger(__name__)
+
+# Avoid re-instantiation
+MIDDLEWARE = [IgnoreFieldMiddleware()]
 
 
 class MyApplication(web.Application):
@@ -76,7 +82,7 @@ class CylcUIServer(object):
         self.workflows_mgr = WorkflowsManager(self)
         self.data_store_mgr = DataStoreMgr(self.workflows_mgr)
         self.resolvers = Resolvers(
-            self.data_store_mgr.data,
+            self.data_store_mgr,
             workflows_mgr=self.workflows_mgr)
 
     def _create_static_handler(
@@ -140,6 +146,8 @@ class CylcUIServer(object):
             clazz,
             schema=schema,
             resolvers=self.resolvers,
+            backend=GraphQLCoreBackend(),
+            middleware=MIDDLEWARE,
             **kwargs
         )
 
@@ -151,7 +159,11 @@ class CylcUIServer(object):
         """
         logger.info(self._static)
         # subscription/websockets server
-        subscription_server = TornadoSubscriptionServer(schema)
+        subscription_server = TornadoSubscriptionServer(
+            schema,
+            backend=GraphQLCoreBackend(),
+            middleware=MIDDLEWARE,
+        )
         return MyApplication(
             static_path=self._static,
             debug=debug,
@@ -166,14 +178,20 @@ class CylcUIServer(object):
                 self._create_handler("userprofile",
                                      UserProfileHandler),
                 # graphql handlers
-                self._create_graphql_handler("graphql",
-                                             UIServerGraphQLHandler),
-                self._create_graphql_handler("graphql/batch",
-                                             UIServerGraphQLHandler,
-                                             batch=True),
-                self._create_graphql_handler("graphql/graphiql",
-                                             GraphiQLHandler,
-                                             graphiql=True),
+                self._create_graphql_handler(
+                    "graphql",
+                    UIServerGraphQLHandler,
+                ),
+                self._create_graphql_handler(
+                    "graphql/batch",
+                    UIServerGraphQLHandler,
+                    batch=True
+                ),
+                self._create_graphql_handler(
+                    "graphql/graphiql",
+                    GraphiQLHandler,
+                    graphiql=True
+                ),
                 # subscription/websockets handler
                 self._create_handler("subscriptions",
                                      SubscriptionHandler,

--- a/cylc/uiserver/main.py
+++ b/cylc/uiserver/main.py
@@ -29,7 +29,7 @@ from typing import Any, Tuple, Type
 from tornado import web, ioloop
 
 from cylc.flow.network.graphql import (
-    GraphQLCoreBackend, IgnoreFieldMiddleware
+    CylcGraphQLBackend, IgnoreFieldMiddleware
 )
 from cylc.flow.network.schema import schema
 from graphene_tornado.tornado_graphql_handler import TornadoGraphQLHandler
@@ -42,9 +42,6 @@ from .websockets.tornado import TornadoSubscriptionServer
 from .workflows_mgr import WorkflowsManager
 
 logger = logging.getLogger(__name__)
-
-# Avoid re-instantiation
-MIDDLEWARE = [IgnoreFieldMiddleware()]
 
 
 class MyApplication(web.Application):
@@ -146,8 +143,8 @@ class CylcUIServer(object):
             clazz,
             schema=schema,
             resolvers=self.resolvers,
-            backend=GraphQLCoreBackend(),
-            middleware=MIDDLEWARE,
+            backend=CylcGraphQLBackend(),
+            middleware=[IgnoreFieldMiddleware],
             **kwargs
         )
 
@@ -161,8 +158,8 @@ class CylcUIServer(object):
         # subscription/websockets server
         subscription_server = TornadoSubscriptionServer(
             schema,
-            backend=GraphQLCoreBackend(),
-            middleware=MIDDLEWARE,
+            backend=CylcGraphQLBackend(),
+            middleware=[IgnoreFieldMiddleware],
         )
         return MyApplication(
             static_path=self._static,


### PR DESCRIPTION
These changes partially address: 
https://github.com/cylc/cylc-admin/blob/master/docs/proposal-subscriptions.md
As a back-end solution required to bring the proposal to fruition. 

Depends on:  https://github.com/cylc/cylc-flow/pull/3500
(They should be merge together, as there is one change that is breaking to the `BaseResolvers`)

Doesn't break Web UI.

**Features:**
- Published deltas of a single main loop iteration grouped into a single message are received (as topic `all`) and applied to the local data-store (instead of the same multi-topic ones).
- Use of Imported Cylc-Flow GraphQL backend and middleware to set undesired/empty field values to null, and strip these out of the execution result.
- New/Working GraphQL subscription of received Workflow Scheduler deltas:
![uis_delta_subs_final](https://user-images.githubusercontent.com/11400777/74085106-8bfa8b00-4ada-11ea-8126-4b56300a4165.gif)



**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Already covered by existing tests.
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
