### PR TITLE
Add decorator for websockets authentication

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ None or N/A.
 
 [#125](https://github.com/cylc/cylc-uiserver/pull/125) - Use Tornado
 default WebSocket check_origin function.
+[#124](https://github.com/cylc/cylc-uiserver/pull/124) - Add decorator
+for websockets authentication.
 
 ### Fixes
 

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -26,6 +26,8 @@ from jupyterhub.services.auth import HubOAuthenticated
 from tornado import web, websocket
 from tornado.ioloop import IOLoop
 
+from .websockets import authenticated as websockets_authenticated
+
 
 class BaseHandler(web.RequestHandler):
 
@@ -135,7 +137,8 @@ class UIServerGraphQLHandler(HubOAuthenticated, TornadoGraphQLHandler):
         )
 
 
-class SubscriptionHandler(BaseHandler, websocket.WebSocketHandler):
+class SubscriptionHandler(BaseHandler, HubOAuthenticated,
+                          websocket.WebSocketHandler):
 
     def initialize(self, sub_server, resolvers):
         self.queue = Queue(100)
@@ -145,6 +148,7 @@ class SubscriptionHandler(BaseHandler, websocket.WebSocketHandler):
     def select_subprotocol(self, subprotocols):
         return GRAPHQL_WS
 
+    @websockets_authenticated
     def open(self, *args, **kwargs):
         IOLoop.current().spawn_callback(self.subscription_server.handle, self,
                                         self.context)


### PR DESCRIPTION
These changes partially address #110

The default `tornado.web.authenticated` decorator, with the settings from JupyterHub that we have in our application, will try to redirected unauthenticated requests to the log-in form.

This redirect may succeed if the user is already logged-in, and is using a browser. But for a JS client initiating the WebSocket communication, it fails in the backend:

```bash
RuntimeError: Method not supported for Web Sockets
2020-02-24 10:51:05,126 tornado.application ERROR    Uncaught exception GET /user/kinow/subscriptions (127.0.0.1)
HTTPServerRequest(protocol='http', host='localhost:8000', method='GET', uri='/user/kinow/subscriptions', version='HTTP/1.1', remote_ip='127.0.0.1')
Traceback (most recent call last):
  File "/home/kinow/Development/python/workspace/cylc-uiserver/venv/lib/python3.7/site-packages/tornado/websocket.py", line 956, in _accept_connection
    open_result = handler.open(*handler.open_args, **handler.open_kwargs)
  File "/home/kinow/Development/python/workspace/cylc-uiserver/venv/lib/python3.7/site-packages/tornado/web.py", line 3162, in wrapper
    url = self.get_login_url()
  File "/home/kinow/Development/python/workspace/cylc-uiserver/venv/lib/python3.7/site-packages/jupyterhub/services/auth.py", line 830, in get_login_url
    state = self.hub_auth.set_state_cookie(self, next_url=self.request.uri)
  File "/home/kinow/Development/python/workspace/cylc-uiserver/venv/lib/python3.7/site-packages/jupyterhub/services/auth.py", line 701, in set_state_cookie
    handler.set_secure_cookie(cookie_name, b64_state, **kwargs)
  File "/home/kinow/Development/python/workspace/cylc-uiserver/venv/lib/python3.7/site-packages/tornado/web.py", line 716, in set_secure_cookie
    **kwargs
  File "/home/kinow/Development/python/workspace/cylc-uiserver/venv/lib/python3.7/site-packages/tornado/websocket.py", line 627, in _raise_not_supported_for_websockets
    raise RuntimeError("Method not supported for Web Sockets")
RuntimeError: Method not supported for Web Sockets
```

For the WebSocket client, it's better to simply fail, and avoid polluting users' logs. So here we simply return HTTP status code 403, and log in debug level that there was an unauthenticated request to WebSocket.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] I have opened a documentation PR at https://github.com/cylc/cylc-doc/pull/116
