### PR TITLE
Update jupyterhub (1.1.*) and graphene-tornado (2.6.*)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@ None or N/A.
 [#82](https://github.com/cylc/cylc-uiserver/pull/82) - Add subscriptions
 support to GraphQL.
 
+[#126](https://github.com/cylc/cylc-uiserver/pull/126) - Update JupyterHub
+dependency to 1.1.*, and Graphene-Tornado to 2.6.*.
+
 ### Fixes
 
 None.

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ def find_version(*file_paths):
 install_requires = [
     ('cylc-flow @ https://github.com/cylc/cylc-flow'
      '/tarball/master#egg=cylc-8.0a2.dev'),
-    'jupyterhub==1.0.*',
+    'jupyterhub==1.1.*',
     'tornado==6.0.*',
-    'graphene-tornado==2.1.*',
+    'graphene-tornado==2.6.*',
     'graphql-core<3,>=2.1',  # TODO: graphql-python/graphql-ws#39
     'graphql-ws==0.3.*'
 ]


### PR DESCRIPTION
These changes close #105 and #102 

The `graphene-tornado` update should work fine. The conda recipe was using it since the alpha 1 release. Tested this morning, and everything worked fine.

Spent some time reading the JupyterHub changelog, found nothing that seemed likely to break Cylc. Tested (tree/graph/mutations/user profile).

Here's what I think will be installed with this update (final message of `pip install -e .` after updating it):

```bash
Successfully installed attrs-19.3.0 cylc-uiserver graphene-tornado-2.6.1 importlib-metadata-1.5.0 jsonschema-3.2.0 jupyter-telemetry-0.0.5 jupyterhub-1.1.0 pyrsistent-0.15.7 python-json-logger-0.1.11 ruamel.yaml-0.16.10 ruamel.yaml.clib-0.2.0 zipp-3.1.0
```

We still cannot upgrade the Python GraphQL libraries to those `-next` new libraries (e.g. `graphql-core-next`) due to https://github.com/graphql-python/graphql-ws/pull/39, as the version of `graphql-ws` we use hasn't been updated to use the `graphql-core-next`.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? updated existing dependencies only).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
