### PR TITLE
Imitate JupyterHub's cookie_secret feature, re-creating a new random secret on every spawn

### DIFF
--- a/cylc/uiserver/main.py
+++ b/cylc/uiserver/main.py
@@ -185,9 +185,10 @@ class CylcUIServer(object):
                     {"path": self._static}
                 )
             ],
-            # FIXME: decide (and document) whether cookies will be permanent
-            # after server restart.
-            cookie_secret="cylc-secret-cookie"
+            # always generate a new cookie secret on launch
+            # ensures that each spawn clears any cookies from
+            # previous session, triggering OAuth again
+            cookie_secret=os.urandom(32)
         )
 
     def start(self, debug: bool):


### PR DESCRIPTION
These changes close #69 

Better err on the side of being too cautious I think. Instead of using a static value, this PR sets a random value upon each spawn. JupyterHub's default singleuser app does the same, but also
supports loading it from an external file (using a Traitlets feature, that we can either use too if #123 is done, or re-implement) which can be done later.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
