### PR TITLE
Add mypy to Travis CI and use PEP-484 type hints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ python: 3.7
 before_install:
   - pip install pycodestyle mypy==0.770
   - pycodestyle --exclude=".git,.tox,__pycache,venv,.eggs,build,jupyterhub_config.py,cylc/uiserver/websockets/"
-  - python -m mypy --namespace-packages --config-file mypy.ini -p cylc.uiserver
+  - python -m mypy -v --namespace-packages --config-file mypy.ini -p cylc.uiserver
 install:
   - pip install .[all]
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ python: 3.7
 before_install:
   - pip install pycodestyle mypy==0.770
   - pycodestyle --exclude=".git,.tox,__pycache,venv,.eggs,build,jupyterhub_config.py,cylc/uiserver/websockets/"
-  - python -m mypy -v --namespace-packages --config-file mypy.ini -p cylc.uiserver
 install:
   - pip install .[all]
 script:
+  - python -m mypy --namespace-packages --config-file mypy.ini -p cylc.uiserver
   - python setup.py test
 after_success:
   # Report metrics, such as coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ language: python
 python: 3.7
 
 before_install:
-  - pip install pycodestyle mypy
+  - pip install pycodestyle mypy==0.770
   - pycodestyle --exclude=".git,.tox,__pycache,venv,.eggs,build,jupyterhub_config.py,cylc/uiserver/websockets/"
   - python -m mypy --namespace-packages --config-file mypy.ini -p cylc.uiserver
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,9 @@ language: python
 python: 3.7
 
 before_install:
-  - pip install pycodestyle
+  - pip install pycodestyle mypy
   - pycodestyle --exclude=".git,.tox,__pycache,venv,.eggs,build,jupyterhub_config.py,cylc/uiserver/websockets/"
+  - python -m mypy --namespace-packages --config-file mypy.ini -p cylc.uiserver
 install:
   - pip install .[all]
 script:

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -66,7 +66,7 @@ class DataStoreMgr:
         self.w_subs: Dict[Any, Any] = {}
         self.topics = {topic.encode('utf-8') for topic in DELTAS_MAP}
         self.topics.add(b'shutdown')
-        self.loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        self.loop: Any = None
         # Might be options other than threads to achieve
         # non-blocking subscriptions, but this works.
         self.executor = ThreadPoolExecutor()
@@ -83,6 +83,8 @@ class DataStoreMgr:
         blocking the main loop.
 
         """
+        if self.loop is None:
+            self.loop = asyncio.get_running_loop()
         if w_id in self.w_subs:
             return
         self.executor.submit(

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -95,7 +95,7 @@ class UIServerGraphQLHandler(
             graphiql: bool = False,
             pretty: bool = False,
             batch: bool = False,
-            backend: GraphQLBackend = None,
+            backend: Optional[GraphQLBackend] = None,
             **kwargs: Dict[Any, Any]) -> None:
         super(TornadoGraphQLHandler, self).initialize()
 

--- a/cylc/uiserver/main.py
+++ b/cylc/uiserver/main.py
@@ -24,7 +24,7 @@ import signal
 from functools import partial
 from logging.config import dictConfig
 from os.path import join, abspath, dirname
-from typing import Any, Tuple, Type
+from typing import Any, Dict, Tuple, Type
 
 from tornado import web, ioloop
 
@@ -42,13 +42,13 @@ logger = logging.getLogger(__name__)
 
 
 class MyApplication(web.Application):
-    is_closing = False
+    is_closing: bool = False
 
-    def signal_handler(self, signum, frame):
+    def signal_handler(self, signum: Any, frame: Any) -> None:
         logger.info('exiting...')
         self.is_closing = True
 
-    def try_exit(self, uis):
+    def try_exit(self, uis: "CylcUIServer") -> None:
         # clean up and stop in here
         if self.is_closing:
             # stop the subscribers running in the thread pool executor
@@ -64,7 +64,8 @@ class MyApplication(web.Application):
 
 class CylcUIServer(object):
 
-    def __init__(self, port, static, jupyter_hub_service_prefix):
+    def __init__(self, port: int, static: str,
+                 jupyter_hub_service_prefix: str) -> None:
         self._port = port
         if os.path.isabs(static):
             self._static = static
@@ -72,16 +73,16 @@ class CylcUIServer(object):
             script_dir = os.path.dirname(__file__)
             self._static = os.path.abspath(os.path.join(script_dir, static))
         self._jupyter_hub_service_prefix = jupyter_hub_service_prefix
-        self.workflows_mgr = WorkflowsManager(self)
+        self.workflows_mgr: Any = WorkflowsManager(self)
         self.data_store_mgr = DataStoreMgr(self.workflows_mgr)
         self.resolvers = Resolvers(
-            self.data_store_mgr.data,
+            data=self.data_store_mgr.data,
             workflows_mgr=self.workflows_mgr)
 
     def _create_static_handler(
             self,
             path: str
-    ) -> Tuple[str, Type[web.StaticFileHandler], dict]:
+    ) -> Tuple[str, Type[web.StaticFileHandler], Dict[Any, Any]]:
         """
         Create a static content handler.
 
@@ -101,7 +102,7 @@ class CylcUIServer(object):
             path: str,
             clazz: Type[web.RequestHandler],
             **kwargs: Any
-    ) -> Tuple[str, Type[web.RequestHandler], dict]:
+    ) -> Tuple[str, Type[web.RequestHandler], Dict[Any, Any]]:
         """
         Create a Tornado handler.
 
@@ -121,9 +122,9 @@ class CylcUIServer(object):
     def _create_graphql_handler(
             self,
             path: str,
-            clazz: Type[TornadoGraphQLHandler],
+            clazz: Any,
             **kwargs: Any
-    ) -> Tuple[str, Type[web.RequestHandler], dict]:
+    ) -> Tuple[str, Type[web.RequestHandler], Dict[Any, Any]]:
         """
         Create a GraphQL handler.
 
@@ -142,7 +143,7 @@ class CylcUIServer(object):
             **kwargs
         )
 
-    def _make_app(self, debug: bool):
+    def _make_app(self, debug: bool) -> MyApplication:
         """Crete a Tornado web application.
 
         Args:
@@ -190,7 +191,7 @@ class CylcUIServer(object):
             cookie_secret="cylc-secret-cookie"
         )
 
-    def start(self, debug: bool):
+    def start(self, debug: bool) -> None:
         app = self._make_app(debug)
         signal.signal(signal.SIGINT, app.signal_handler)
         app.listen(self._port)
@@ -210,7 +211,7 @@ class CylcUIServer(object):
             ioloop.IOLoop.instance().stop()
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Start Cylc UI"
     )

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -19,22 +19,25 @@
 from cylc.flow.network.resolvers import BaseResolvers
 from cylc.flow.data_store_mgr import WORKFLOW
 
+from typing import Any, Dict, List, Optional, Union
 
-class Resolvers(BaseResolvers):
+
+class Resolvers(BaseResolvers):  # type: ignore
     """UI Server context GraphQL query and mutation resolvers."""
 
-    workflows_mgr = None
+    workflows_mgr: Any = None
 
-    def __init__(self, data, **kwargs):
+    def __init__(self, data: Dict[Any, Any],
+                 **kwargs: Dict[Any, Any]) -> None:
         super().__init__(data)
-
+        self.workflows_mgr = None
         # Set extra attributes
         for key, value in kwargs.items():
             if hasattr(self, key):
                 setattr(self, key, value)
 
     # Mutations
-    async def mutator(self, info, *m_args):
+    async def mutator(self, info: Any, *m_args: List[str]) -> List[Any]:
         """Mutate workflow."""
         _, w_args, _ = m_args
         w_ids = [
@@ -48,7 +51,8 @@ class Resolvers(BaseResolvers):
         }
         return self.workflows_mgr.multi_request('graphql', w_ids, graphql_args)
 
-    async def nodes_mutator(self, info, *m_args):
+    async def nodes_mutator(self, info: Any, *m_args: List[str]) \
+            -> Union[str, List[Any]]:
         """Mutate node items of associated workflows."""
         _, _, w_args, _ = m_args
         w_ids = [

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -88,7 +88,7 @@ async def test_est_workflow_socket_error(
     def side_effect(*_, **__):
         raise socket.error
     mocked_get_host_ip_by_name.side_effect = side_effect
-    reg, host, port, pub_port, client = await est_workflow(
+    reg, host, port, pub_port, client, result = await est_workflow(
         '', '', 0, 0)
     assert not any([reg, host, port, pub_port, client])
     assert client is None

--- a/cylc/uiserver/websockets/tornado.py
+++ b/cylc/uiserver/websockets/tornado.py
@@ -44,7 +44,7 @@ class TornadoConnectionContext(BaseConnectionContext):
 
 
 class TornadoSubscriptionServer(BaseSubscriptionServer):
-    def __init__(self, schema, keep_alive=True, loop=None):
+    def __init__(self, schema, keep_alive=True, loop=None) -> None:
         self.loop = loop
         super().__init__(schema, keep_alive)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -35,6 +35,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-zmq.*]
 ignore_missing_imports = True
+[mypy-tornado.*]
+ignore_missing_imports = True
 
 [mypy-cylc.uiserver.tests.*]
 ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,40 @@
+[mypy]
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_subclassing_any = True
+warn_no_return = True
+strict_optional = True
+strict_equality = True
+no_implicit_optional = True
+disallow_any_generics = True
+disallow_any_unimported = False
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_unused_configs = True
+show_traceback = True
+show_error_codes = True
+pretty = True
+python_version = 3.7
+
+[mypy-cylc.uiserver.websockets.*]
+ignore_errors = True
+
+[mypy-cylc.flow.*]
+ignore_missing_imports = True
+[mypy-graphene_tornado.*]
+ignore_missing_imports = True
+[mypy-jupyterhub.*]
+ignore_missing_imports = True
+[mypy-graphql.*]
+ignore_missing_imports = True
+[mypy-graphql_ws.*]
+ignore_missing_imports = True
+[mypy-graphene.*]
+ignore_missing_imports = True
+[mypy-zmq.*]
+ignore_missing_imports = True
+
+[mypy-cylc.uiserver.tests.*]
+ignore_errors = True


### PR DESCRIPTION
This is a small change with no associated Issue.

Not sure if the right time, as there is ongoing work in Cylc UI Server for the deltas. This PR can be closed or postponed for later too.

I think adding MyPy to Cylc Flow and Cylc UI Server would be great. It reduces errors (not adding links here, but PEP-484, Dropbox, Guido himself, and others have links and blogs about it) and also helps if you use IDE or other tools like linters that support types.

For Cylc Flow it would be a major work due to the size of the code base. We can use it later in specific packages there. But for Cylc UI Server, I think we should be able to adopt it sooner as its code base is more recent and smaller.

It uses PEP 484 type hints such as `def fn(param: int, param2: str)`, even though we also have the docstring comments. The reason being that that was the only way I could fix MyPy issues. Looks to me like it doesn't know how to parse the types from docstrings (or purposefully chose to use only type hints?). 

Any thoughts? Tests are passing, did some manual testing with Cylc UI and 2 workflows, and it looks OK. The command in `.travis.yml` shows how to run MyPy. I will comment in a few places MyPy found something interesting too :+1: 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
