### PR TITLE
Use recv_nowait for asyncio Queue, to avoid blocking it, and allow the coroutine to exit if the connection was closed

### DIFF
--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -138,6 +138,9 @@ class SubscriptionHandler(websocket.WebSocketHandler):
     async def recv(self):
         return await self.queue.get()
 
+    def recv_nowait(self):
+        return self.queue.get_nowait()
+
     def check_origin(self, origin: str) -> bool:
         return True
 

--- a/cylc/uiserver/websockets/tornado.py
+++ b/cylc/uiserver/websockets/tornado.py
@@ -22,6 +22,8 @@ from typing import Union, Awaitable, Any, List, Tuple, Dict
 
 setup_observable_extension()
 
+NO_MSG_DELAY = 1.0
+
 
 class TornadoConnectionContext(BaseConnectionContext):
     async def receive(self):
@@ -76,7 +78,8 @@ class TornadoSubscriptionServer(BaseSubscriptionServer):
                 task = ensure_future(
                     self.on_message(connection_context, message), loop=self.loop)
                 pending.add(task)
-            await sleep(1)
+            else:
+                await sleep(NO_MSG_DELAY)
 
         self.on_close(connection_context)
         for task in pending:

--- a/cylc/uiserver/websockets/tornado.py
+++ b/cylc/uiserver/websockets/tornado.py
@@ -6,7 +6,7 @@
 
 from inspect import isawaitable
 
-from asyncio import ensure_future, gather, wait, shield, sleep
+from asyncio import create_task, gather, wait, shield, sleep
 from asyncio.queues import QueueEmpty
 from tornado.websocket import WebSocketClosedError
 from graphql.execution.executors.asyncio import AsyncioExecutor
@@ -74,8 +74,8 @@ class TornadoSubscriptionServer(BaseSubscriptionServer):
                     (_, pending) = await wait(pending, timeout=0, loop=self.loop)
 
             if message:
-                task = ensure_future(
-                    self.on_message(connection_context, message), loop=self.loop)
+                task = create_task(
+                    self.on_message(connection_context, message))
                 pending.add(task)
             else:
                 await sleep(NO_MSG_DELAY)

--- a/cylc/uiserver/websockets/tornado.py
+++ b/cylc/uiserver/websockets/tornado.py
@@ -26,10 +26,9 @@ NO_MSG_DELAY = 1.0
 
 
 class TornadoConnectionContext(BaseConnectionContext):
-    async def receive(self):
+    def receive(self):
         try:
-            msg = self.ws.recv_nowait()
-            return msg
+            return self.ws.recv_nowait()
         except WebSocketClosedError:
             raise ConnectionClosedException()
 
@@ -65,7 +64,7 @@ class TornadoSubscriptionServer(BaseSubscriptionServer):
             try:
                 if connection_context.closed:
                     raise ConnectionClosedException()
-                message = await connection_context.receive()
+                message = connection_context.receive()
             except ConnectionClosedException:
                 break
             except QueueEmpty:


### PR DESCRIPTION
This is a small change with no associated Issue.

The coroutine has a `while True`, the exists once the connection is closed. However, the `queue.get()` call is blocking, and it appears it won't leave the coroutine get to the line of code where it checks the connection status.

This PR uses the `recv_nowait`, combined with `asyncio.sleep(0)`. This seems to work fine for me, tested with the following diff:

```diff
diff --git a/cylc/uiserver/workflows_mgr.py b/cylc/uiserver/workflows_mgr.py
index 48f327f..20d3914 100644
--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -111,6 +111,7 @@ class WorkflowsManager:
 
     async def gather_workflows(self):
         """Scan, establish, and discard workflows."""
+        print(f"We have {len(asyncio.all_tasks())} tasks")
         scanflows = {}
         cre_owner, cre_name = re_compile_filters(None, ['.*'])
         scan_args = (
```

And also looking at `htop` resident memory.

The memory stayed at ~63MB for me, and with no clients, it displayed 1 task. An extra client created 5 new tasks, leaving it at 6 tasks. Another client, and then 11 tasks. Closing one client, back to 6. Closing another tab then 1 task.

Memory stable the whole time. Closing the workflow didn't seem to have affected the memory, but I cannot tell whether it needs a GC, or if it will simply keep some of the old structure (Protobuf, schema, resolvers, etc). But at least this seems to be a fix in the right direction to solve the problem of resident memory?

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? not easy to write a test for this I think).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
