### PR TITLE
Cleanup threads

### DIFF
--- a/cylc/uiserver/main.py
+++ b/cylc/uiserver/main.py
@@ -55,7 +55,8 @@ class MyApplication(web.Application):
             for sub in uis.data_store_mgr.w_subs.values():
                 sub.stop()
             # Shutdown the thread pool executor
-            uis.data_store_mgr.executor.shutdown(wait=False)
+            for executor in uis.data_store_mgr.executors.values():
+                executor.shutdown(wait=False)
             # Destroy ZeroMQ context of all sockets
             uis.workflows_mgr.context.destroy()
             ioloop.IOLoop.instance().stop()


### PR DESCRIPTION
This is a small change with no associated Issue.
(One reviewer should do)

Sibling PR to https://github.com/cylc/cylc-flow/pull/3604
(As non-blocking receive on subscription won't hang on stoppage)

The threads weren't being cleaned up after workflow shutdown, this PR fixes the issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
