### PR TITLE
Remove Tornado from server header

### DIFF
--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -36,6 +36,7 @@ class BaseHandler(web.RequestHandler):
         self.set_header("Access-Control-Allow-Origin", "*")
         self.set_header("Access-Control-Allow-Headers", "x-requested-with")
         self.set_header('Access-Control-Allow-Methods', 'POST, GET, OPTIONS')
+        self.set_header('Server', '')
 
 
 class APIHandler(BaseHandler):

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -39,6 +39,10 @@ class BaseHandler(web.RequestHandler):
         self.set_header('Server', '')
 
 
+class StaticHandler(BaseHandler, web.StaticFileHandler):
+    """A static handler that extends BaseHandler (for headers)."""
+
+
 class APIHandler(BaseHandler):
 
     def set_default_headers(self) -> None:
@@ -86,6 +90,9 @@ class UIServerGraphQLHandler(HubOAuthenticated, TornadoGraphQLHandler):
     # Declare extra attributes
     resolvers = None
 
+    def set_default_headers(self) -> None:
+        self.set_header('Server', '')
+
     def initialize(self, schema=None, executor=None, middleware=None,
                    root_value=None, graphiql=False, pretty=False,
                    batch=False, backend=None, **kwargs):
@@ -129,7 +136,7 @@ class UIServerGraphQLHandler(HubOAuthenticated, TornadoGraphQLHandler):
         )
 
 
-class SubscriptionHandler(websocket.WebSocketHandler):
+class SubscriptionHandler(BaseHandler, websocket.WebSocketHandler):
 
     def initialize(self, sub_server, resolvers):
         self.queue = Queue(100)
@@ -179,6 +186,7 @@ class GraphiQLHandler(UIServerGraphQLHandler):
 
 __all__ = [
     "MainHandler",
+    "StaticHandler",
     "UserProfileHandler",
     "UIServerGraphQLHandler",
     "SubscriptionHandler",

--- a/cylc/uiserver/main.py
+++ b/cylc/uiserver/main.py
@@ -85,7 +85,7 @@ class CylcUIServer(object):
     def _create_static_handler(
             self,
             path: str
-    ) -> Tuple[str, Type[web.StaticFileHandler], dict]:
+    ) -> Tuple[str, Type[StaticHandler], dict]:
         """
         Create a static content handler.
 
@@ -96,7 +96,7 @@ class CylcUIServer(object):
         """
         return (
             rf"{self._jupyter_hub_service_prefix}({path})",
-            web.StaticFileHandler,
+            StaticHandler,
             {"path": self._static}
         )
 

--- a/cylc/uiserver/tests/test_uiserver.py
+++ b/cylc/uiserver/tests/test_uiserver.py
@@ -49,7 +49,7 @@ def test_cylcuiserver_create_static_handler():
     cylc_uiserver = CylcUIServer(8000, './static', '/prefix/')
     handler = cylc_uiserver._create_static_handler('(imgs/*.png)')
     assert "/prefix/((imgs/*.png))" == handler[0]
-    assert handler[1] == StaticFileHandler
+    assert issubclass(handler[1], StaticFileHandler)
     assert handler[2].get('path').endswith("/static")
 
 

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -56,3 +56,11 @@ c.JupyterHub.template_paths = [
         'templates'
     )
 ]
+c.JupyterHub.tornado_settings = {
+    'headers': {
+      # 'Access-Control-Allow-Origin': '*',
+      # 'Access-Control-Allow-Headers': '*',
+      # 'Access-Control-Allow-Methods': '*',
+      'Server': ''
+   },
+}


### PR DESCRIPTION
This is a small change with no associated Issue.

Harmless little change. Was looking at requests/responses in Firefox today while playing with deltas, and noticed the Server signature in the response headers.

So to prevent [server fingerprinting](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server) we just omit the value.

I think in real production environments there may be other tools like reverse proxies that could hide the header too. But doesn't hurt to remove it.

While attackers could still guess we are using Tornado (if targetting a host with Cylc, and aware that we use Tornado), at least it won't give away the version installed in the server (the current header says Tornado/$version).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
