### PR TITLE
Suppress exception logging in pytest workflow test (caplog)

### DIFF
--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -35,7 +35,9 @@ async def test_workflow_request_client_timeout(
 
 
 @pytest.mark.asyncio
-async def test_workflow_request_client_error(async_client: AsyncClientFixture):
+async def test_workflow_request_client_error(
+        async_client: AsyncClientFixture, caplog):
+    caplog.set_level(logging.CRITICAL, logger='cylc')
     async_client.will_return(ClientError)
     ctx, msg = await workflow_request(client=async_client, command='')
     assert not ctx

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -47,7 +47,7 @@ async def workflow_request(client, command, args=None,
     """Workflow request command.
 
     Args:
-        client (object): Instantiated workflow client.
+        client (SuiteRuntimeClient): Instantiated workflow client.
         command (str): Command/Endpoint name.
         args (dict): Endpoint arguments.
         timeout (float): Client request timeout (secs).


### PR DESCRIPTION
This is a small change with no associated Issue.

Using the pytest [caplog](https://docs.pytest.org/en/stable/logging.html#caplog-fixture) fixture to suppress the exception error message when running tests.

Last week I was running some tests in cylc-uiserver for a change I did, and it was bothering me that I had to look at the log and ignore the exceptions :) 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
