### PR TITLE
Next development version 0.3.dev

### DIFF
--- a/cylc/uiserver/__init__.py
+++ b/cylc/uiserver/__init__.py
@@ -13,4 +13,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "0.2"
+__version__ = "0.3.dev"

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ def find_version(*file_paths):
 #     don't pin versions, we will get whatever cylc-flow needs, and not
 #     the bleeding-edge version.
 install_requires = [
-    'cylc-flow==8.0a2',
+    ('cylc-flow @ https://github.com/cylc/cylc-flow'
+     '/tarball/master#egg=cylc-8.0a3.dev'),
     'jupyterhub==1.1.*',
     'tornado==6.0.*',
     'graphene-tornado==2.6.*',


### PR DESCRIPTION
This is a small change with no associated Issue.

For the next release. I used 0.3.dev, but happy to change it to another value if others prefer. For me that's useful as I keep switching branches and venvs, and doing `pip list` when using a version like this, it's easier to confirm you are using the version you expect to, not one accidentally installed from PYPI (though there's also the link location in the output, example below)

![image](https://user-images.githubusercontent.com/304786/87601607-89672600-c749-11ea-9d11-16dea54f5efd.png)

Furthermore, if a user - by any chance - is using the version from the `master` branch, the version could tell us that s/he is doing so, and we could then ask to install from tag/PYPI/Conda/etc, or work around any issues in the latest version - I think :o) 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
