### PR TITLE
async scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,15 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# vim backup files
+*.swp
+
+# emacs backup files
+*~
+
+# vscode
+.vscode
+
 # C extensions
 *.so
 

--- a/cylc/uiserver/conftest.py
+++ b/cylc/uiserver/conftest.py
@@ -1,0 +1,16 @@
+import asyncio
+
+import pytest
+
+
+@pytest.fixture
+def event_loop():
+    """This fixture defines the event loop used for each test."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    # gracefully exit async generators
+    loop.run_until_complete(loop.shutdown_asyncgens())
+    # cancel any tasks still running in this event loop
+    for task in asyncio.all_tasks(loop):
+        task.cancel()
+    loop.close()

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -75,6 +75,7 @@ class DataStoreMgr:
         blocking the main loop.
 
         """
+        print(f'$ sync_workflow({w_id})')
         if self.loop is None:
             self.loop = asyncio.get_running_loop()
         if w_id in self.w_subs:
@@ -91,6 +92,7 @@ class DataStoreMgr:
         await self.entire_workflow_update(ids=[w_id])
 
     async def register_workflow(self, w_id, name, owner):
+        print(f'$ register_workflow({w_id})')
         data = deepcopy(DATA_TEMPLATE)
         flow = data[WORKFLOW]
         flow.id = w_id
@@ -99,8 +101,15 @@ class DataStoreMgr:
         flow.status = 'stopped'
         self.data[w_id] = data
 
+    def stop_workflow(self, w_id):
+        print(f'$ stop_workflow({w_id})')
+        self.data[w_id]['status'] = 'stopped'
+        self.data[w_id]['host'] = None
+        self.data[w_id]['port'] = None
+
     def purge_workflow(self, w_id):
         """Purge the manager of a workflow's subscription and data."""
+        print(f'$ purge_workflow({w_id})')
         if w_id in self.w_subs:
             self.w_subs[w_id].stop()
             del self.w_subs[w_id]

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -48,6 +48,7 @@ from cylc.flow.data_store_mgr import (
     apply_delta, generate_checksum, create_delta_store
 )
 from cylc.flow.suite_files import ContactFileFields as CFF
+from cylc.flow.suite_status import SuiteStatus
 
 from .workflows_mgr import workflow_request
 
@@ -90,7 +91,7 @@ class DataStoreMgr:
             flow.port = 0
             # flow.pub_port = 0
             flow.api_version = 0
-            flow.status = 'stopped'
+            flow.status = SuiteStatus.STOPPED.value
 
         # Apply to existing workflow data
         apply_delta(WORKFLOW, delta, self.data[w_id])
@@ -291,11 +292,6 @@ class DataStoreMgr:
         """
         if ids is None:
             ids = []
-
-        # Prune old data
-        # for w_id in list(self.data):
-        #     if w_id not in self.workflows_mgr.active:
-        #         del self.data[w_id]
 
         # Request new data
         req_method = 'pb_entire_workflow'

--- a/cylc/uiserver/main.py
+++ b/cylc/uiserver/main.py
@@ -215,7 +215,7 @@ class CylcUIServer(object):
         # If the client is already established it's not overridden,
         # so the following callbacks can happen at the same time.
         ioloop.PeriodicCallback(
-            self.workflows_mgr.update, 1000).start()
+            self.workflows_mgr.update, 5000).start()
         try:
             ioloop.IOLoop.current().start()
         except KeyboardInterrupt:

--- a/cylc/uiserver/main.py
+++ b/cylc/uiserver/main.py
@@ -211,11 +211,11 @@ class CylcUIServer(object):
             partial(app.try_exit, uis=self), 100).start()
         # Discover workflows on initial start up.
         ioloop.IOLoop.current().add_callback(
-            self.workflows_mgr.gather_workflows)
+            self.workflows_mgr.update)
         # If the client is already established it's not overridden,
         # so the following callbacks can happen at the same time.
         ioloop.PeriodicCallback(
-            self.workflows_mgr.gather_workflows, 7000).start()
+            self.workflows_mgr.update, 1000).start()
         try:
             ioloop.IOLoop.current().start()
         except KeyboardInterrupt:

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -13,12 +13,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from itertools import product
+from pathlib import Path
 import pytest
+from random import random
 
 from pytest_mock import MockFixture
 
-from cylc.uiserver.workflows_mgr import *
+from cylc.flow import ID_DELIM
 from cylc.flow.exceptions import ClientTimeout
+from cylc.flow.network import API
+from cylc.flow.suite_files import (
+    ContactFileFields as CFF,
+    SuiteFiles
+)
+
+from cylc.uiserver.workflows_mgr import *
 
 from .conftest import AsyncClientFixture
 
@@ -141,14 +151,110 @@ async def test_est_workflow(
 # --- WorkflowsManager
 
 
-def test_workflows_manager_constructor():
-    mgr = WorkflowsManager(None)
-    assert not mgr.workflows
-
-
 def test_workflows_manager_spawn_workflow():
     mgr = WorkflowsManager(None)
     mgr.spawn_workflow()
-    assert not mgr.workflows
+    assert not mgr.active
 
 # TODO: add tests for remaining methods in WorkflowsManager
+
+
+def mk_flow(path, reg, active=True):
+    """Make a workflow appear on the filesystem for scan purposes.
+
+    Args:
+        path (pathlib.Path):
+            The directory to create the mocked workflow in.
+        reg (str):
+            The registered name for this workflow.
+        active (bool):
+            If True then a contact file will be written.
+
+    """
+    run_dir = path / reg
+    srv_dir = run_dir / SuiteFiles.Service.DIRNAME
+    contact = srv_dir / SuiteFiles.Service.CONTACT
+    fconfig = run_dir / SuiteFiles.FLOW_FILE
+    run_dir.mkdir()
+    fconfig.touch()  # cylc uses this to identify a dir as a workflow
+    srv_dir.mkdir()
+    if active:
+        with open(contact, 'w+') as contact_file:
+            contact_file.write(
+                '\n'.join([
+                    f'{CFF.API}={API}',
+                    f'{CFF.HOST}=42',
+                    f'{CFF.PORT}=42',
+                    f'{CFF.UUID}=42'
+                ])
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    # generate all possile state changes
+    'active_before,active_after',
+    product(['active', 'inactive', None], repeat=2)
+)
+async def test_workflow_state_changes(tmp_path, active_before, active_after):
+    """It correctly identifies workflow state changes from the filesystem."""
+    tmp_path /= str(random())
+    tmp_path.mkdir()
+
+    # mock the results of the previous scan
+    wfm = WorkflowsManager(None, context=None, run_dir=tmp_path)
+    wid = f'{wfm.owner}{ID_DELIM}a'
+    if active_before == 'active':
+        wfm.active[wid] = {
+            CFF.API: API,
+            CFF.UUID: '42'
+        }
+    elif active_before == 'inactive':
+        wfm.inactive.add(wid)
+
+    # mock the filesystem in the new state
+    if active_after == 'active':
+        mk_flow(tmp_path, 'a', active=True)
+    if active_after == 'inactive':
+        mk_flow(tmp_path, 'a', active=False)
+
+    # see what state changes the workflow manager detects
+    changes = []
+    async for change in wfm._workflow_state_changes():
+        changes.append(change)
+
+    # compare those changes to expectations
+    if active_before == active_after:
+        assert changes == []
+    else:
+        assert len(changes) == 1
+        assert (wid, active_before, active_after) == changes[0][:3]
+
+
+@pytest.mark.asyncio
+async def test_workflow_state_change_restart(tmp_path):
+    """It identifies workflows which have restarted between scans."""
+    # mock the result of the previous scan
+    wfm = WorkflowsManager(None, context=None, run_dir=tmp_path)
+    wid = f'{wfm.owner}{ID_DELIM}a'
+    wfm.active[wid] = {
+            CFF.API: API,
+            CFF.UUID: '41'
+    }
+
+    # create a new workflow with the same name but a different UUID
+    mk_flow(tmp_path, 'a', active=True)
+
+    # see what state changes the workflow manager detects
+    changes = []
+    async for change in wfm._workflow_state_changes():
+        changes.append(change)
+
+    # the flow should be marked as becomming inactive then active again
+    assert [change[:3] for change in changes] == [
+        (wid, 'active', 'inactive'),
+        (wid, 'inactive', 'active')
+    ]
+
+    # it should have picked up the new uuid too
+    assert changes[1][3][CFF.UUID] == '42'

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -144,8 +144,6 @@ class WorkflowsManager:
                 The scan data (i.e. the contents of the contact file).
 
         """
-        owner = getuser()
-
         active_before = set(self.active)
         inactive_before = set(self.inactive)
 
@@ -153,7 +151,8 @@ class WorkflowsManager:
         inactive = set()
 
         async for flow in self._scan_pipe:
-            wid = f'{owner}{ID_DELIM}{flow["name"]}'
+            flow['owner'] = self.owner
+            wid = f'{flow["owner"]}{ID_DELIM}{flow["name"]}'
             flow['id'] = wid
 
             if not flow.get('contact'):
@@ -197,7 +196,7 @@ class WorkflowsManager:
         """Register a new workflow with the data store."""
         print(f'_register({wid})')
         await self.uiserver.data_store_mgr.register_workflow(
-            wid, flow['name'], self.owner
+            wid, flow['name'], flow['owner']
         )
 
     async def _connect(self, wid, flow):
@@ -207,9 +206,7 @@ class WorkflowsManager:
         flow['req_client'] = SuiteRuntimeClient(flow['name'])
         await self.uiserver.data_store_mgr.sync_workflow(
             wid,
-            flow['name'],
-            flow[CFF.HOST],
-            flow[CFF.PUBLISH_PORT]
+            flow
         )
 
     async def _disconnect(self, wid):


### PR DESCRIPTION
Addresses: https://github.com/cylc/cylc-uiserver/issues/96
Sibling: https://github.com/cylc/cylc-flow/pull/3724 [MERGED]

This utilises the new scan interface for listing fows.

> **Note:** I was hoping to use this to add stopped flows to the data store, however, I've been having issues there as once you add a stopped flow the resolvers kick in straight away causing errors.
    @dwsutherland any ideas on how best to prevent the UIS from trying to sync with stopped flows?


**Highlights:**

* Async scanning.
* Create flow clients only when added.
* Track stopped flows.


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
