### PR TITLE
Prevent asyncio.gather errors to be ignored, and allow execution to continue, logging errors when found

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@ default WebSocket check_origin function.
 [#124](https://github.com/cylc/cylc-uiserver/pull/124) - Add decorator
 for websockets authentication.
 
+[#151](https://github.com/cylc/cylc-uiserver/pull/151) - Prevent
+`asyncio.gather` errors to be ignored, and allow execution to continue,
+logging errors when found.
+
 ### Fixes
 
 [#153](https://github.com/cylc/cylc-uiserver/pull/153) - Fix websocket

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -302,10 +302,11 @@ class DataStoreMgr:
              'command': req_method,
              'req_context': w_id}
             for w_id, info in self.workflows_mgr.active.items())
-        gathers = ()
-        for kwargs in req_kwargs:
-            if not ids or kwargs['req_context'] in ids:
-                gathers += (workflow_request(**kwargs),)
+        gathers = [
+            workflow_request(**kwargs)
+            for kwargs in req_kwargs
+            if not ids or kwargs['req_context'] in ids
+        ]
         items = await asyncio.gather(*gathers)
         for w_id, result in items:
             if result is not None and result != MSG_TIMEOUT:

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -19,7 +19,8 @@ import inspect
 
 import pytest
 import zmq
-from cylc.flow.data_messages_pb2 import PbEntireWorkflow, PbWorkflow
+from cylc.flow.data_messages_pb2 import PbEntireWorkflow, PbWorkflow,\
+    PbFamilyProxy
 from cylc.flow.network import ZMQSocketBase
 
 from cylc.uiserver.data_store_mgr import DataStoreMgr
@@ -79,6 +80,9 @@ def make_entire_workflow():
         workflow.id = workflow_id
         entire_workflow = PbEntireWorkflow()
         entire_workflow.workflow.CopyFrom(workflow)
+        root_family = PbFamilyProxy()
+        root_family.name = 'root'
+        entire_workflow.family_proxies.extend([root_family])
         return entire_workflow
 
     return _make_entire_workflow

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -19,7 +19,11 @@ import inspect
 
 import pytest
 import zmq
+from cylc.flow.data_messages_pb2 import PbEntireWorkflow, PbWorkflow
 from cylc.flow.network import ZMQSocketBase
+
+from cylc.uiserver.data_store_mgr import DataStoreMgr
+from cylc.uiserver.workflows_mgr import WorkflowsManager
 
 
 class AsyncClientFixture(ZMQSocketBase):
@@ -56,3 +60,25 @@ def event_loop():
     for task in asyncio.all_tasks(loop):
         task.cancel()
     loop.close()
+
+
+@pytest.fixture
+def workflows_manager() -> WorkflowsManager:
+    return WorkflowsManager(None)
+
+
+@pytest.fixture
+def data_store_mgr(workflows_manager: WorkflowsManager) -> DataStoreMgr:
+    return DataStoreMgr(workflows_mgr=workflows_manager)
+
+
+@pytest.fixture
+def make_entire_workflow():
+    def _make_entire_workflow(workflow_id):
+        workflow = PbWorkflow()
+        workflow.id = workflow_id
+        entire_workflow = PbEntireWorkflow()
+        entire_workflow.workflow.CopyFrom(workflow)
+        return entire_workflow
+
+    return _make_entire_workflow

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -18,7 +18,6 @@
 import logging
 
 import pytest
-
 from cylc.flow.network.scan import MSG_TIMEOUT
 
 import cylc.uiserver.data_store_mgr as data_store_mgr_module

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -18,7 +18,7 @@
 import logging
 
 import pytest
-from cylc.flow.network.scan import MSG_TIMEOUT
+from cylc.flow.network import MSG_TIMEOUT
 
 import cylc.uiserver.data_store_mgr as data_store_mgr_module
 from cylc.uiserver.data_store_mgr import DataStoreMgr
@@ -70,7 +70,7 @@ async def test_entire_workflow_update_ignores_timeout_message(
     async_client.will_return(MSG_TIMEOUT)
 
     # Set the client used by our test workflow.
-    data_store_mgr.workflows_mgr.workflows[w_id] = {
+    data_store_mgr.workflows_mgr.active[w_id] = {
         'req_client': async_client
     }
 

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -1,0 +1,91 @@
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the ``data_store_mgr`` module and its objects and functions."""
+
+import logging
+
+import pytest
+
+import cylc.uiserver.data_store_mgr as data_store_mgr_module
+from cylc.uiserver.data_store_mgr import DataStoreMgr
+from .conftest import AsyncClientFixture
+
+
+@pytest.mark.asyncio
+async def test_entire_workflow_update(
+        async_client: AsyncClientFixture,
+        data_store_mgr: DataStoreMgr,
+        make_entire_workflow
+):
+    """Test that ``entire_workflow_update`` is executed successfully."""
+    w_id = 'workflow_id'
+    entire_workflow = make_entire_workflow(f'{w_id}')
+    async_client.will_return(entire_workflow.SerializeToString())
+
+    # Set the client used by our test workflow.
+    data_store_mgr.workflows_mgr.active[w_id] = {
+        'req_client': async_client
+    }
+
+    # Call the entire_workflow_update function.
+    # This should use the client defined above (``async_client``) when
+    # calling ``workflow_request``.
+    await data_store_mgr.entire_workflow_update()
+
+    # The ``DataStoreMgr`` sets the workflow data retrieved in its
+    # own ``.data`` dictionary, which will contain Protobuf message
+    # objects.
+    w_id_data = data_store_mgr.data[w_id]
+
+    # If everything went OK, we should have the Protobuf object
+    # de-serialized and added to the ``DataStoreMgr.data``
+    # (the workflow ID is its key).
+    assert entire_workflow.workflow.id == w_id_data['workflow'].id
+
+
+@pytest.mark.asyncio
+async def test_entire_workflow_update_gather_error(
+        async_client: AsyncClientFixture,
+        data_store_mgr: DataStoreMgr,
+        mocker
+):
+    """
+    Test that if ``asyncio.gather`` in ``entire_workflow_update``
+    has a coroutine raising an error, it will handle the error correctly.
+    """
+    # The ``AsyncClient`` will raise an error. This will happen when
+    # ``workflow_request`` is called via ``asyncio.gather``, which
+    # would be raised if ``return_exceptions`` is not given.
+    #
+    # This test wants to confirm this is not raised, but instead the
+    # error is returned, so that we can inspect, log, etc.
+    error_type = ValueError
+    async_client.will_return(error_type)
+
+    # Set the client used by our test workflow.
+    data_store_mgr.workflows_mgr.active['workflow_id'] = {
+        'req_client': async_client
+    }
+
+    # Call the entire_workflow_update function.
+    # This should use the client defined above (``async_client``) when
+    # calling ``workflow_request``.
+    logger = logging.getLogger(data_store_mgr_module.__name__)
+    mocked_exception_function = mocker.patch.object(logger, 'exception')
+    await data_store_mgr.entire_workflow_update()
+    mocked_exception_function.assert_called_once()
+    assert mocked_exception_function.call_args[1][
+               'exc_info'].__class__ == error_type

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -144,10 +144,10 @@ async def test_est_workflow(
 # --- WorkflowsManager
 
 
-def test_workflows_manager_spawn_workflow():
-    mgr = WorkflowsManager(None)
-    mgr.spawn_workflow()
-    assert not mgr.active
+def test_workflows_manager_spawn_workflow(workflows_manager):
+    workflows_manager.spawn_workflow()
+    assert not workflows_manager.active
+
 
 
 # TODO: add tests for remaining methods in WorkflowsManager

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -149,6 +149,7 @@ def test_workflows_manager_spawn_workflow():
     mgr.spawn_workflow()
     assert not mgr.active
 
+
 # TODO: add tests for remaining methods in WorkflowsManager
 
 

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -149,8 +149,6 @@ def test_workflows_manager_spawn_workflow(workflows_manager):
     workflows_manager.spawn_workflow()
     assert not workflows_manager.active
 
-
-
 # TODO: add tests for remaining methods in WorkflowsManager
 
 

--- a/cylc/uiserver/websockets/tornado.py
+++ b/cylc/uiserver/websockets/tornado.py
@@ -139,7 +139,7 @@ class TornadoSubscriptionServer(BaseSubscriptionServer):
         return super().execute(request_context, params)
 
     async def send_execution_result(self, connection_context, op_id,
-                              execution_result):
+                                    execution_result):
         """
         Our schema contains a subscription ObjectType that contains other
         ObjectType's. These are resolved with functions that are awaitable,

--- a/cylc/uiserver/websockets/tornado.py
+++ b/cylc/uiserver/websockets/tornado.py
@@ -177,6 +177,11 @@ class TornadoSubscriptionServer(BaseSubscriptionServer):
                 resolving_items.append(
                     self.__resolve_container_item(container, key, item))
 
+        # FIXME: If we have multiple items in the queue, and one of them
+        #        fails, then we won't send the execution results.
+        #        We could use return_exceptions=True here, but it is not
+        #        clear how we should proceed. Should we re-queue the
+        #        failed item? Send the error? Ignore it? Log?
         await gather(*resolving_items)
 
         await super().send_execution_result(connection_context, op_id,

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -282,15 +282,14 @@ class WorkflowsManager:
             args = {}
         if multi_args is None:
             multi_args = {}
-        req_args = {}
-        for w_id in workflows:
-            cmd_args = multi_args.get(w_id, args)
-            req_args[w_id] = (
+        req_args = {
+            w_id: (
                 self.active[w_id]['req_client'],
                 command,
-                cmd_args,
+                multi_args.get(w_id, args),
                 timeout,
-            )
+            ) for w_id in self.active
+        }
         gathers = [
             workflow_request(req_context=info, *request_args)
             for info, request_args in req_args.items()

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -291,11 +291,10 @@ class WorkflowsManager:
                 cmd_args,
                 timeout,
             )
-        gathers = ()
-        for info, request_args in req_args.items():
-            if request_args[0] is None:
-                continue
-            gathers += (workflow_request(req_context=info, *request_args),)
+        gathers = [
+            workflow_request(req_context=info, *request_args)
+            for info, request_args in req_args.items()
+        ]
         results = await asyncio.gather(*gathers)
         res = []
         for _, val in results:


### PR DESCRIPTION
This is a small change with no associated Issue.

With this change, if a coroutine passed to `asyncio.gather` in our code raises an exception, instead of raising the first received exception, the code now handles them with `return_exceptions=True`.

This way we will have a list of the returned values of the coroutines. At the moment the code is simply logging with `logger.exception()`. But we could raise a new exception, or re-raise one of the exceptions found.

I think this way we are less likely to have errors hidden away by `asyncio`. I've added an initial unit test, and will continue adding more now that I have learned more about `pytest-mock` and `pytest-async` :+1: Happy to add more tests afterwards in case this gets merged before I finish (I'm adding more tests for `asyncio.gather`, but also for other parts of `data_store_mgr` and `workflow_mgr` that were not covered yet).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
