### PR TITLE
don't disconnect unless there is something to disconnect

### DIFF
--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -206,9 +206,13 @@ class WorkflowsManager:
 
     async def _disconnect(self, wid):
         """Disconnect from a running workflow."""
-        client = self.active[wid]['req_client']
-        with suppress(IOError):
-            client.stop(stop_loop=False)
+        try:
+            client = self.active[wid]['req_client']
+        except KeyError:
+            pass
+        else:
+            with suppress(IOError):
+                client.stop(stop_loop=False)
 
     async def _unregister(self, wid):
         """Unregister a workflow from the data store."""


### PR DESCRIPTION
This is a small change with no associated Issue.

Don't try to disconnect unless there is something to disconnect from.

I think this has been preventing the cleanup of some stopped flows which continue to be visible in the UI.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
