### PR TITLE
New tests for the data store manager

### DIFF
--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -133,7 +133,7 @@ class DataStoreMgr:
         )
         await self.entire_workflow_update(ids=[w_id])
 
-    async def register_workflow(self, w_id, name, owner):
+    async def register_workflow(self, w_id):
         logger.debug(f'register_workflow({w_id})')
         self.delta_queues[w_id] = {}
 

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -118,3 +118,16 @@ async def test_entire_workflow_update_gather_error(
     mocked_exception_function.assert_called_once()
     assert mocked_exception_function.call_args[1][
                'exc_info'].__class__ == error_type
+
+
+@pytest.mark.asyncio
+async def test_register_workflow(
+    data_store_mgr: DataStoreMgr
+):
+    """Passing a workflow ID through register_workflow creates
+    an entry for the workflow in the data store .data map, and another
+    entry in the data store .delta_queues map."""
+    w_id = 'user|workflow_id'
+    await data_store_mgr.register_workflow(w_id=w_id)
+    assert w_id in data_store_mgr.data
+    assert w_id in data_store_mgr.delta_queues

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -165,3 +165,26 @@ async def test_update_contact_with_contact_data(
     }
     data_store_mgr.update_contact(w_id=w_id, contact_data=contact_data)
     assert api_version == data_store_mgr.data[w_id]['workflow'].api_version
+
+
+@pytest.mark.asyncio
+async def test_stop_workflow(
+    data_store_mgr: DataStoreMgr
+):
+    """Telling a data store to stop a workflow, is the same as updating
+    contact with no contact data."""
+    w_id = 'user|workflow_id'
+    api_version = 1
+    await data_store_mgr.register_workflow(w_id=w_id)
+    contact_data = {
+        'name': 'workflow_id',
+        'owner': 'cylc',
+        CFF.HOST: 'localhost',
+        CFF.PORT: 40000,
+        CFF.API: api_version
+    }
+    data_store_mgr.update_contact(w_id=w_id, contact_data=contact_data)
+    assert api_version == data_store_mgr.data[w_id]['workflow'].api_version
+
+    data_store_mgr.stop_workflow(w_id=w_id)
+    assert 0 == data_store_mgr.data[w_id]['workflow'].api_version


### PR DESCRIPTION
This is a small change with no associated Issue.

Just adding a few more tests for Cylc UI Server :+1: 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
