### PR TITLE
Fix number of parameters passed to workflow registration in data store mgr

### DIFF
--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -191,9 +191,7 @@ class WorkflowsManager:
 
     async def _register(self, wid, flow):
         """Register a new workflow with the data store."""
-        await self.uiserver.data_store_mgr.register_workflow(
-            wid, flow['name'], flow['owner']
-        )
+        await self.uiserver.data_store_mgr.register_workflow(wid)
 
     async def _connect(self, wid, flow):
         """Open a connection to a running workflow."""


### PR DESCRIPTION
This is a small change with no associated Issue.

I broke the workflow registration in #160, sorry. This PR just fixes the method call that I forgot to update after removing unused parameters.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
