### PR TITLE
Use JupyterHub 1.3.* and Tornado 6.1.*. Auto spawn UI Server (new JHub feature)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@ None or N/A.
 
 ### Enhancements
 
+[#167](https://github.com/cylc/cylc-uiserver/pull/167) - Upgrade
+JupyterHub to 1.3.x, and Tornado to 6.1.x. Set auto spawn timeout
+to 1 second (effectively enabling it) in our demo configuration.
+
 [#125](https://github.com/cylc/cylc-uiserver/pull/125) - Use Tornado
 default WebSocket check_origin function.
 [#124](https://github.com/cylc/cylc-uiserver/pull/124) - Add decorator

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -41,6 +41,7 @@ c.Spawner.cmd = ['cylc-uiserver']
 #  Should be a subclass of Spawner.
 c.JupyterHub.spawner_class = 'jupyterhub.spawner.LocalProcessSpawner'
 
+c.JupyterHub.implicit_spawn_seconds = 0.01
 
 # --- Cylc-ise Jupyterhub
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def find_version(*file_paths):
 install_requires = [
     ('cylc-flow @ https://github.com/cylc/cylc-flow'
      '/tarball/master#egg=cylc-8.0a3.dev'),
-    'jupyterhub==1.1.*',
+    'jupyterhub==1.3.*',
     'tornado==6.0.*',
     'graphene-tornado==2.6.*',
     'graphql-ws>=0.3.1,<0.4'

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ install_requires = [
     ('cylc-flow @ https://github.com/cylc/cylc-flow'
      '/tarball/master#egg=cylc-8.0a3.dev'),
     'jupyterhub==1.3.*',
-    'tornado==6.0.*',
+    'tornado==6.1.*',
     'graphene-tornado==2.6.*',
     'graphql-ws>=0.3.1,<0.4'
 ]


### PR DESCRIPTION
These changes close #66 
These changes close #163 

Our fix for #66 was included in 1.1 but I missed that. Via Element (hurrah to Gitter's integration) I saw today's announcement in the JupyterHub room about 1.3.0.

This PR upgrades JupyterHub to 1.3.0. Manual testing found nothing wrong. ~And we might also be able to automatic spawn the Cylc UI Server now. I think this feature was either in 1.1 or 1.2 of JupyterHub. So we shouldn't need to click that button to launch the UI Server any longer after restarting JupyterHub and accessing it for the first time (can't recall if we need to enable a flag in JupyterHub configuration file).~ Changed the JupyterHub configuration file that we provide as demo to include the auto spawn of 1 second (effectively enabling that setting, which is set to `0` by default, forcing us to click to launch the UI Server).

Also upgraded to Tornado 6.1, fixing #163. 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] Created an issue at [cylc-uiserver conda-forge repository](https://github.com/conda-forge/cylc-uiserver-feedstock) with version changes (if you changed dependencies in `setup.py`, see `recipe/meta.yaml`). - https://github.com/conda-forge/cylc-uiserver-feedstock/pull/11
