### PR TITLE
Add dependabot to GH repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This is a small change with no associated Issue.

Maybe worth a try here before considering adding it to cylc-flow? It's a free service, used by other projects. It runs daily, and reports any dependency in our dependency range that can be updated.

I normally go through the main dependencies in our `setup.py` and look them up at PYPI. But dependabot will handle that.

Furthermore, it is probably already enabled in GitHub if our repository settings has not disabled the dependabot security checks (click settings / security I think, then look for dependabot security).

I enabled it for one of my repositories with Python. It executed almost immediately.

![image](https://user-images.githubusercontent.com/304786/111050941-76f9e380-84b4-11eb-9b95-fd91a22b85c9.png)

Each PR created by dependabot will run the CI pipeline too, confirming whether there was any build/test failures due to the new version. Developers can also check out the branch and try the code.

![image](https://user-images.githubusercontent.com/304786/111050982-b9bbbb80-84b4-11eb-9a5a-799c715d7afb.png)

So I think it could be helpful to use this, instead of relying on us remembering to update the dependencies before a release?

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
