### PR TITLE
site config + logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The Cylc Hub will load the following files in order:
 
 2) Site Config
 
-   This file confugures the Hub/UIS for all users. The default path can be
+   This file configures the Hub/UIS for all users. The default path can be
    changed by the ``CYLC_SITE_CONF_PATH`` environment variable.
 
    (`/etc/cylc/hub/config.py`)
@@ -104,10 +104,11 @@ The UI Server is (currently) also configured from the same configuration file(s)
 as the hub using the
 `UIServer` namespace.
 
-Currently the UI Server accepts two configurations:
+Currently the UI Server accepts three configurations:
 
 * `c.UIServer.ui_build_dir`
 * `c.UIServer.ui_version`
+* `c.UIServer.logging_config`
 
 See the `cylc.uiserver.main.UIServer` file for details.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ See the `cylc.uiserver.main.UIServer` file for details.
    > **Note:**
    >
    > If you want to run with a development copy of Cylc Flow you must install
-   > it first else `pip` will dowload the latest version from PyPi.
+   > it first else `pip` will download the latest version from PyPi.
 
 4) For UI development set the following configuration to use your UI build
    (rather than the default bundled UI build):

--- a/README.md
+++ b/README.md
@@ -6,29 +6,50 @@
 # Cylc UI Server
 
 This project contains the Cylc UI Server. A JupyterHub-compatible application,
-used to display the Cylc UI (or simply UI) to users, and to communicate with
-Workflow Services (WFS).
+used to serve the Cylc UI, and to communicate with running Cylc Schedulers.
 
 [Cylc Website](https://cylc.org/) |
-[Contributing](CONTRIBUTING.md)
+[Contributing](CONTRIBUTING.md) |
+[Developing](DEVELOPING.md)
 
 ## Contents
 
 - [Installation](#installation)
+- [Introduction](#introduction)
 - [Copyright](#copyright-and-terms-of-use)
+
+## Introduction
+
+The functionality in this repository is required to run the Cylc web user
+interface.
+
+This repository provides the following components of the Cylc system.
+
+* The UI
+
+  This is the Cylc web app that provides control and monitoring functionalities
+  for Cylc workflows.
+
+* The UI Server
+
+  This is a web server which serves the Cylc web UI. It connects to running
+  workflows and workflow databases to provide the information the UI displays.
+
+* The Hub
+
+  This launches UI Servers, provides a proxy for running server and handles
+  authentication. It is a JupyterHub server.
 
 ## Installation
 
 For production:
 
 ```console
+# via conda (preferred)
+$ conda install cylc-uiserver
+
+# via pip
 $ pip install cylc-uiserver
-```
-
-For development run the following from a clone of the project git repository:
-
-```console
-$ pip install -e .[all]
 ```
 
 ## Running
@@ -39,15 +60,48 @@ $ cylc hub
 
 The default URL is [http://localhost:8000](http://localhost:8000).
 
-# Configuring
+## Configuring
 
-The default "base" configuration is defined in
-`cylc.uiserver.config_defaults.py`, these values can be overridden by the
-user config in `~/.cylc/hub/config.py`.
+### Hub
+
+The Cylc Hub will load the following files in order:
+
+1) System Config
+
+   These are the Cylc defaults which are hardcoded within the repository.
+
+   (`<python-installation>/cylc/uiserver/config_defaults.py`)
+
+2) Site Config
+
+   This file confugures the Hub/UIS for all users. The default path can be
+   changed by the ``CYLC_SITE_CONF_PATH`` environment variable.
+
+   (`/etc/cylc/hub/config.py`)
+
+3) User Config
+
+   This file
+
+   (`~/.cylc/cylc/hub/config.py`)
+
+Alternatively a single config file can be provided on the command line.
+
+```console
+$ cylc hub --config
+```
+
+> **Warning:**
+>
+> If specifying a config file on the command line the system config containing
+> the hardcoded Cylc default will **not** be loaded.
 
 See the Jupyterhub documentation for details on configuration options.
 
-The UI Server is (currently) also configured from this file using the
+### UI Server
+
+The UI Server is (currently) also configured from the same configuration file(s)
+as the hub using the
 `UIServer` namespace.
 
 Currently the UI Server accepts two configurations:
@@ -55,17 +109,32 @@ Currently the UI Server accepts two configurations:
 * `c.UIServer.ui_build_dir`
 * `c.UIServer.ui_version`
 
-See `cylc.uiserver.main.UIServer` for details.
+See the `cylc.uiserver.main.UIServer` file for details.
 
-# Developing
+## Developing
 
-For UI development set the following configuration to use your UI build
-(rather than the default bundled UI build):
+1) Read the [Contributing](CONTRIBUTING.md) page.
 
-```
-# ~/.cylc/hub/config.py
-c.UIServer.ui_build_dir = '~/cylc-ui/dist'  # path to build
-```
+2) Fork and clone this repo.
+
+3) Install from source into your Python environment:
+
+   ```console
+   $ pip install -e .[all]
+   ```
+
+   > **Note:**
+   >
+   > If you want to run with a development copy of Cylc Flow you must install
+   > it first else `pip` will dowload the latest version from PyPi.
+
+4) For UI development set the following configuration to use your UI build
+   (rather than the default bundled UI build):
+
+   ```python
+   # ~/.cylc/hub/config.py
+   c.UIServer.ui_build_dir = '~/cylc-ui/dist'  # path to build
+   ```
 
 ## Copyright and Terms of Use
 

--- a/cylc/uiserver/logging_config.json
+++ b/cylc/uiserver/logging_config.json
@@ -26,8 +26,8 @@
         "handlers": ["console"],
         "propagate": false
       },
-      "cylc.flow": {
-        "level": "DEBUG",
+      "cylc": {
+        "level": "INFO",
         "handlers": ["console"],
         "propagate": false
       },

--- a/cylc/uiserver/tests/test_config.py
+++ b/cylc/uiserver/tests/test_config.py
@@ -1,0 +1,67 @@
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from pathlib import Path
+
+import pytest
+
+from cylc.uiserver import __file__ as UIS_PKG
+from cylc.uiserver.config import load
+
+
+SYS_CONF = Path(UIS_PKG).parent / 'config_defaults.py'
+USER_CONF = Path('~/.cylc/hub/config.py').expanduser()
+SITE_CONF = Path('/etc/cylc/hub/config.py')
+
+
+@pytest.fixture
+def clear_env(monkeypatch):
+    for envvar in ('CYLC_SITE_CONF_PATH',):
+        if envvar in os.environ:
+            monkeypatch.delenv(envvar)
+
+
+@pytest.fixture
+def capload(monkeypatch):
+    """Capture config file load events.
+
+    Prevents the config files from being loaded, equivalent to having
+    empty config files.
+    """
+    files = []
+    monkeypatch.setattr('cylc.uiserver.config._load', files.append)
+    return files
+
+
+def test_config(clear_env, capload):
+    """It should load the system, site and user configs in that order."""
+    load()
+    assert capload == [
+        SYS_CONF,
+        SITE_CONF,
+        USER_CONF,
+    ]
+
+
+def test_cylc_site_conf_path(clear_env, capload, monkeypatch):
+    """The site config should change to $CYLC_SITE_CONF_PATH if set."""
+    monkeypatch.setenv('CYLC_SITE_CONF_PATH', 'elephant')
+    load()
+    assert capload == [
+        SYS_CONF,
+        Path('elephant/hub/config.py'),
+        USER_CONF,
+    ]


### PR DESCRIPTION
Requires: https://github.com/cylc/cylc-flow/pull/4141

Add a site (global) config file to complement the user config file.

We will need this for beta deployment as we are expecting users to run their own single-user hubs so a site config is required to set sane defaults for users.

The logging was missing Cylc Flow log messages (because we use a single logger called `cylc` for all Cylc messages rather than using one per module).

Made the logging config a regular config to allow sites to configure defaults for that too.

No tests for the logging just yet, to confirm this works try running a UI server, either with `cylc uis` or indirectly via the hub. The logging should include the config files, service prefix, port and UI path, example logging from spawning a UIS via the Hub:

```
[I 2021-03-24T17:06:45.290 JupyterHub spawner:1451] Spawning cylc uiserver --port=54514
Failed to set groups [Errno 1] Operation not permitted
Loading config file: /Users/oliver/cylc-uiserver/cylc/uiserver/config_defaults.py
Loading config file: /Users/oliver/.cylc/hub/config.py
2021-03-24 17:06:45,988 cylc.uiserver.main INFO     Starting Cylc UI Server
2021-03-24 17:06:45,988 cylc.uiserver.main INFO     JupyterHub Service Prefix: /user/oliver/
2021-03-24 17:06:45,988 cylc.uiserver.main INFO     Listening on port: 54514
2021-03-24 17:06:45,989 cylc.uiserver.main INFO     Serving UI from: /Users/oliver/cylc-uiserver/cylc/uiserver/ui/0.3.dev
```

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
