### PR TITLE
allow for tilde expansion in dev config paths

### DIFF
--- a/cylc/uiserver/main.py
+++ b/cylc/uiserver/main.py
@@ -98,7 +98,7 @@ class PathType(TraitType):
 
     def validate(self, obj, value):
         if isinstance(value, str):
-            return Path(value)
+            return Path(value).expanduser()
         if isinstance(value, PurePath):
             return value
         if value == Undefined:


### PR DESCRIPTION
Follow on from #188 

We specify the use of Tilde in the README when setting up a UIS using a development UI:
```
# ~/.cylc/hub/config.py
c.UIServer.ui_build_dir = '~/cylc-ui/dist'  # path to build
```
However, it's not currently expanded:
```
in _check_ui_build_dir_exists
    raise TraitError(f'ui_build_dir does not exist: {proposed["value"]}')
traitlets.traitlets.TraitError: ui_build_dir does not exist: ~/cylc/cylc-ui/dist
```
This PR addresses this by using [expanduser](https://docs.python.org/3/library/pathlib.html#pathlib.Path.expanduser)


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
