### PR TITLE
uis: authorise endpoint for multi-user use

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,10 @@ each release.
 -------------------------------------------------------------------------------
 ## __cylc-uiserver-0.4 (2020-??-??)__
 
-### Enhancements
+### Enhancements
+
+[#202](https://github.com/cylc/cylc-uiserver/pull/202) -
+Add authorisation for multi-user setups.
 
 [#197](https://github.com/cylc/cylc-uiserver/pull/197) -
 Make the workflow scan interval configurable.

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -51,7 +51,7 @@ def _authorised(req):
     user = req.get_current_user()
     username = user.get('name', '?')
     if username != ME:
-        logger.warn(f'Authorisation failed for {username}')
+        logger.warning(f'Authorisation failed for {username}')
         return False
     return True
 

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -65,7 +65,7 @@ def async_authorised(fun):
     return _inner
 
 
-class BaseHandler(web.RequestHandler):
+class BaseHandler(HubOAuthenticated, web.RequestHandler):
 
     def set_default_headers(self) -> None:
         self.set_header("X-JupyterHub-Version", jupyterhub_version)
@@ -80,7 +80,7 @@ class StaticHandler(BaseHandler, web.StaticFileHandler):
     """A static handler that extends BaseHandler (for headers)."""
 
 
-class MainHandler(HubOAuthenticated, BaseHandler):
+class MainHandler(BaseHandler):
 
     # hub_users = ["kinow"]
     # hub_groups = []
@@ -102,7 +102,7 @@ class MainHandler(HubOAuthenticated, BaseHandler):
         self.render(index, python_base_url=base_url)
 
 
-class UserProfileHandler(HubOAuthenticated, BaseHandler):
+class UserProfileHandler(BaseHandler):
 
     def set_default_headers(self) -> None:
         super().set_default_headers()
@@ -117,7 +117,7 @@ class UserProfileHandler(HubOAuthenticated, BaseHandler):
 # This is needed in order to pass the server context in addition to existing.
 # It's possible to just overwrite TornadoGraphQLHandler.context but we would
 # somehow need to pass the request info (headers, username ...etc) in also
-class UIServerGraphQLHandler(HubOAuthenticated, TornadoGraphQLHandler):
+class UIServerGraphQLHandler(BaseHandler, TornadoGraphQLHandler):
 
     # Declare extra attributes
     resolvers = None
@@ -176,8 +176,7 @@ class UIServerGraphQLHandler(HubOAuthenticated, TornadoGraphQLHandler):
         await TornadoGraphQLHandler.run(self, *args, **kwargs)
 
 
-class SubscriptionHandler(BaseHandler, HubOAuthenticated,
-                          websocket.WebSocketHandler):
+class SubscriptionHandler(BaseHandler, websocket.WebSocketHandler):
 
     def initialize(self, sub_server, resolvers):
         self.queue = Queue(100)

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -62,7 +62,7 @@ def authorised(fun):
     def _inner(self, *args, **kwargs):
         nonlocal fun
         if not _authorised(self):
-            raise web.HTTPError(403)
+            raise web.HTTPError(403, reason='authorisation insufficient')
         return fun(self, *args, **kwargs)
     return _inner
 
@@ -73,7 +73,7 @@ def async_authorised(fun):
     async def _inner(self, *args, **kwargs):
         nonlocal fun
         if not _authorised(self):
-            raise web.HTTPError(403)
+            raise web.HTTPError(403, reason='authorisation insufficient')
         return await fun(self, *args, **kwargs)
     return _inner
 

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -197,11 +197,13 @@ def authorisation_true(monkeypatch):
 @pytest.fixture
 def mock_authentication(monkeypatch):
 
-    def _mock_authentication(username=None, server=None):
+    def _mock_authentication(user=None, server=None, none=False):
         ret = {
-            'name': username or getuser(),
+            'name': user or getuser(),
             'server': server or gethostname()
         }
+        if none:
+            ret = None
         monkeypatch.setattr(
             'cylc.uiserver.handlers.BaseHandler.get_current_user',
             lambda x: ret
@@ -210,3 +212,13 @@ def mock_authentication(monkeypatch):
     _mock_authentication()
 
     return _mock_authentication
+
+
+@pytest.fixture
+def mock_authentication_yossarian(mock_authentication):
+    mock_authentication(user='yossarian')
+
+
+@pytest.fixture
+def mock_authentication_none(mock_authentication):
+    mock_authentication(none=True)

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -15,15 +15,16 @@
 """Test code and fixtures."""
 
 import asyncio
+from getpass import getuser
 import inspect
 from pathlib import Path
 from shutil import rmtree
+from socket import gethostname
 from tempfile import TemporaryDirectory
 from textwrap import dedent
 
 import pytest
 import zmq
-
 
 from cylc.flow.data_messages_pb2 import (  # type: ignore
     PbEntireWorkflow,
@@ -182,3 +183,30 @@ def mock_config(monkeypatch):
     )
 
     yield _write
+
+
+@pytest.fixture
+def authorisation_true(monkeypatch):
+    """Disabled request authorisation for test purposes."""
+    monkeypatch.setattr(
+        'cylc.uiserver.handlers._authorised',
+        lambda x: True
+    )
+
+
+@pytest.fixture
+def mock_authentication(monkeypatch):
+
+    def _mock_authentication(username=None, server=None):
+        ret = {
+            'name': username or getuser(),
+            'server': server or gethostname()
+        }
+        monkeypatch.setattr(
+            'cylc.uiserver.handlers.BaseHandler.get_current_user',
+            lambda x: ret
+        )
+
+    _mock_authentication()
+
+    return _mock_authentication


### PR DESCRIPTION
This adds a trivial authorisation scheme to the UIS which rejects anyone but the UIS user.

addresses: #10, #171
opens and closes #203 

This will be followed by a configurable authorisation scheme in due course.

For testing, change the value of `ME` or try with a second user account. For now manual testing only, can implement automated next release.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (see above)
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
