### PR TITLE
setup: bump traitlets version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,14 +44,13 @@ def find_version(*file_paths):
 #     the bleeding-edge version.
 # NB: no graphene version specified; we only make light use of it in our own
 #     code, so graphene-tornado's transitive version should do.
-#     Same for traitlets via jupyterhub transitive deps.
 install_requires = [
     'cylc-flow>=8.0b0',
     'jupyterhub==1.3.*',
     'tornado==6.1.*',
     'graphene-tornado==2.6.*',
     'graphql-ws>=0.3.1,<0.4'
-    'traitlets',
+    'traitlets>5',
     'graphene',
 ]
 


### PR DESCRIPTION
Jupyterhub brings in traitlets v4, our usage requires v5.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] Created an issue https://github.com/conda-forge/cylc-uiserver-feedstock/issues/13