### PR TITLE
Revert "[failure] Prepare release: 0.4.0"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 -------------------------------------------------------------------------------
-## __cylc-uiserver-0.4.0 (<span actions:bind='release-date'>Released 2021-04-16</span>)__
+## __cylc-uiserver-0.4.0 (<span actions:bind='release-date'>2021-04-?</span>)__
 
 ### Enhancements
 

--- a/cylc/uiserver/__init__.py
+++ b/cylc/uiserver/__init__.py
@@ -13,4 +13,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "0.4.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
Reverts cylc/cylc-uiserver#209

Release failed due to missing PyPi token, reverting to go through the process again at a later date.

(note the tag has not been created and the milestone has not been closed).

> **Note:** We should bump the cylc-flow version to b1 due to the host/platform change before releasing.