### PR TITLE
expanded workflow status deltas

### DIFF
--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -376,9 +376,11 @@ async def test_unregister(
     workflow from the data store attributes, and call the necessary
     functions."""
     workflow_name = 'unregister-me'
+    workflow_id = f'{getuser()}{ID_DELIM}{workflow_name}'
+    await uiserver.workflows_mgr._register(workflow_id, None)
 
     uiserver.workflows_mgr._scan_pipe = empty_aiter()
-    uiserver.workflows_mgr.inactive.add(workflow_name)
+    uiserver.workflows_mgr.inactive.add(workflow_id)
     # NOTE: here we will yield a workflow that is not running, it does
     #       not have the contact data and is inactive.
     #       This is what forces the .update() to call unregister()!
@@ -386,7 +388,7 @@ async def test_unregister(
     await uiserver.workflows_mgr.update()
 
     # now the workflow is not active, nor inactive, it is unregistered
-    assert workflow_name not in uiserver.workflows_mgr.inactive
+    assert workflow_id not in uiserver.workflows_mgr.inactive
 
 
 @pytest.mark.asyncio
@@ -400,7 +402,7 @@ async def test_connect(
     If a workflow is running, but in the inactive state,
     then the connect method will be called."""
     workflow_name = 'connect'
-    workflow_id = f'{getuser()}|{workflow_name}'
+    workflow_id = f'{getuser()}{ID_DELIM}{workflow_name}'
     uiserver.workflows_mgr.inactive.add(workflow_id)
 
     assert workflow_id not in uiserver.workflows_mgr.active

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -213,14 +213,13 @@ class WorkflowsManager:
 
     async def _unregister(self, wid):
         """Unregister a workflow from the data store."""
-        self.uiserver.data_store_mgr.purge_workflow(wid)
+        await self.uiserver.data_store_mgr.unregister_workflow(wid)
 
     async def _stop(self, wid):
         """Mark a workflow as stopped.
 
         The workflow can't do this itself, because it's not running.
         """
-        self.uiserver.data_store_mgr.purge_workflow(wid, data=False)
         self.uiserver.data_store_mgr.stop_workflow(wid)
 
     async def update(self):
@@ -266,7 +265,8 @@ class WorkflowsManager:
             if before == 'active':
                 self.active.pop(wid)
             elif before == 'inactive':
-                self.inactive.remove(wid)
+                if wid in self.inactive:
+                    self.inactive.remove(wid)
             if after == 'active':
                 self.active[wid] = flow
             elif after == 'inactive':


### PR DESCRIPTION
These changes partially address https://github.com/cylc/cylc-ui/pull/543

Sibling to https://github.com/cylc/cylc-flow/pull/4206
(that one should go in first)

This PR:
- Adds statuses `installed`/`uninstalled` as seen at the UI Server in the form of deltas.
- Waits until all deltas are send to subscribers on unregistering the workflow and before purging.

Needed for the UI to know when it can remove old/uninstalled workflows.

From Element (Oliver) (note: `held => paused`):
> There are a number of other exotic state transitions that are possible between scans (ran into this with the scan work).
> 
> Here are the rules I would expect and the full state transition matrix (basically the same as the [scan code](https://github.com/cylc/cylc-uiserver/blob/831a528a4c05faa1136a125cc7d43138c2fc140a/cylc/uiserver/workflows_mgr.py#L246-L264)).
> ## The Flow States
> - none (not installed)
> - held (running, task pool held)
> - running (running, task pool unheld)
> - stopping (running, will shutdown soon)
> - stopped (previously run, no active scheduler)
> ## Delta Rules
> 
> <before> -> <after>
> When the state changes from <before> to <after> (over any time period)
> the UI would expect to receive...
> 
> none -> *
> An added delta.
> - -> none
> A pruned delta.
> 
> {held,running,stopping} -> stopped
> A shutdown and an update delta.
> 
> {held,running,stopping,stopped} -> {held,running,stopping,stopped}
> An update delta.
> 
> *(UUID1) -> *(UUID2)
> (scheduler UUID has change i.e. flow has been restarted)
> A shutdown? and an update delta.
> ## All State Transitions
> 
> <before> -> <after>
> (description)
> - delta component 1
> - delta component 2
> - ...
> 
> none -> stopped
> (installed)
> - added(state=stopped)
> 
> none -> held
> (installed and run in held mode)
> - added(state=held)
> 
> none -> running
> (installed and run)
> - added(state=running)
> 
> none -> stopping
> (installed, run and requested to stop)
> - added(state=stopping)
> 
> held -> none
> (was running, deleted)
> - shutdown
> - pruned
> 
> held -> running
> (held held, running)
> - updated(state=running)
> 
> held -> stopping
> (requested to stop)
> - updated(state=stopping)
> 
> held -> stopped
> (stopped)
> - shutdown
> - updated(state=stopped)
> 
> running -> none
> (was running, deleted)
> - shutdown
> - pruned
> 
> running -> held
> (paused)
> - updated(state=held)
> 
> running -> stopping
> (requested to stop)
> - updated(state=stopping)
> 
> running -> stopped
> (shutdown)
> - shutdown
> - updated(state=stopped)
> 
> stopping -> none
> (was running, deleted)
> - shutdown
> - pruned
> 
> stopping -> held
> (pending shutdown canceled)
> - updated(state=held)
> 
> stopping -> running
> (pending shutdown canceled)
> - updated(state=running)
> 
> stopping -> stopped
> (stopped)
> - updated(state=stopped)
> 
> stopped -> none
> (uninstalled)
> - pruned
> 
> stopped -> held
> (running, held mode)
> - updated(state=held)
> 
> stopped -> running
> (running)
> - updated(state=running)
> 
> stopped -> stopping
> (running, requested to stop)
> - updated(state=stopping)

To test this I ran the following:
```
#!/bin/bash

cylc install fox
sleep 6
rm -rf ~/cylc-run/fox
sleep 3
cylc install fox
sleep 6
cylc play --pause fox/run1
sleep 3
cylc play fox/run1
sleep 3
rm -rf ~/cylc-run/fox
sleep 1
pkill -f '/home/sutherlander/.envs/flow/bin/python /home/sutherlander/.envs/flow/bin/cylc play --pause fox/run1'
sleep 5
cylc install fox
sleep 4
cylc play --pause fox/run1
sleep 3
cylc play fox/run1
sleep 3
cylc stop fox/run1
sleep 8
while true; do
    if ! cylc ping $suite 2>/dev/null || \
       $(( $(cylc scan | wc -l) == 0 )); then
        echo 'workflow not running!!'
        break
    else
        echo 'workflow still running'
        sleep 3
    fi
done
# if the suite is in the process of·
sleep 4
rm -rf ~/cylc-run/fox
pkill -f '/home/sutherlander/.envs/flow/bin/python /home/sutherlander/.envs/flow/bin/cylc play --pause fox/run1'
```
![workflow_status](https://user-images.githubusercontent.com/11400777/115982358-8bbab280-a5ee-11eb-997e-9bbbd564bac4.gif)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
