### PR TITLE
Update to JupyterHub 1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def find_version(*file_paths):
 #     code, so graphene-tornado's transitive version should do.
 install_requires = [
     'cylc-flow>=8.0b0',
-    'jupyterhub==1.3.*',
+    'jupyterhub==1.4.*',
     'tornado==6.1.*',
     'graphene-tornado==2.6.*',
     'graphql-ws>=0.3.1,<0.4'


### PR DESCRIPTION
This is a small change with no associated Issue.

Was having a look at the code and comparing with a checked out `jupyterhub` when I realized the latest tag (`1.4.0`) didn't match the version installed with `pip`.

Looks like they released it some time ago and we didn't update it.

>JupyterHub 1.4 is a small release, with several enhancements, bug fixes, and new configuration options.
>
>There are no database schema changes requiring migration from 1.3 to 1.4.
>
>1.4 is also the first version to start publishing docker images for arm64.
>
>In particular, OAuth tokens stored in user cookies, used for accessing single-user servers and hub-authenticated services, have changed their expiration from one hour to the expiry of the cookie in which they are stored (default: two weeks). This is now also configurable via JupyterHub.oauth_token_expires_in.
>
>The result is that it should be much less likely for auth tokens stored in cookies to expire during the lifetime of a server.

Tested with `five` just now, found no errors :+1: 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [ ] Created an issue at [cylc-uiserver conda-forge repository](https://github.com/conda-forge/cylc-uiserver-feedstock) with version changes (if you changed dependencies in `setup.py`, see `recipe/meta.yaml`).

