### PR TITLE
Support internal SSL, load certfile and keyfile from JHub env vars

### DIFF
--- a/cylc/uiserver/main.py
+++ b/cylc/uiserver/main.py
@@ -462,12 +462,16 @@ class CylcUIServer(Application):
         app = self._make_app(debug)
         signal.signal(signal.SIGINT, app.signal_handler)
 
-        http_server = web.HTTPServer(
-            app,
-            ssl_options={
+        ssl_options = None
+        if self.certfile and self.keyfile:
+            ssl_options = {
                 "certfile": self.certfile,
                 "keyfile": self.keyfile
             }
+
+        http_server = web.HTTPServer(
+            app,
+            ssl_options=ssl_options
         )
         http_server.listen(self._port)
         # pass in server object for clean exit


### PR DESCRIPTION
These changes close #103 

Got internal SSL working. At some point I think it worked in the past (see #103 for example) but we must have changed or discarded the code along the way. This probably needs some tests to avoid the same happening, but better get it reviewed/tested first.

My first approach was extending the mixing for SingleUserApp, but that resulted in further changes to make it work with the parent class design. Apparently it's easier to use if you have a SingleUserApp calling another App (that extends JupyterApp from jupyter_core, this last one not in our dependency stack...).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
