### PR TITLE
Replace NBSP by space

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ include = cylc*
 console_scripts =
     jupyter-cylc = cylc.uiserver.scripts.gui:main
     jupyter-cylchubapp = cylc.uiserver.scripts.hubapp:main [hub]
-# cylc commands
+# cylc commands
 cylc.command =
     gui = cylc.uiserver.scripts.gui:main
     hub = cylc.uiserver.scripts.hub:main [hub]


### PR DESCRIPTION
This is a small change with no associated Issue.

Trivial issue. Was reading the `setup.py` file and noticed the NBSP. My IDE distinguishes spaces from NBSP. Harmless to have it, except if you grep or batch-replace something like `# ` (hash and a space). NBSP gives different results depending on the tool.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
