### PR TITLE
config: fix config file load order

### DIFF
--- a/cylc/uiserver/__init__.py
+++ b/cylc/uiserver/__init__.py
@@ -15,6 +15,9 @@
 
 __version__ = "0.5.0"
 
+import os
+from typing import Dict
+
 from cylc.uiserver.app import CylcUIServer
 
 
@@ -29,3 +32,21 @@ def _jupyter_server_extension_points():
             'app': CylcUIServer
         }
     ]
+
+
+def getenv(*env_vars: str) -> Dict[str, str]:
+    """Extract env vars if set.
+
+    Returns a dict containing key:value pairs of environment variables
+    defined in env_vars providing they are present in the environment.
+
+    Examples:
+        >>> getenv('HOME', 'NOT_AN_ENVIRONMENT_VARIABLE')
+        {'HOME': ...}
+
+    """
+    env: Dict[str, str] = {}
+    for env_var in env_vars:
+        if env_var in os.environ:
+            env[env_var] = os.environ[env_var]
+    return env

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -252,10 +252,6 @@ class CylcUIServer(ExtensionApp):
         ioloop.IOLoop.current().add_callback(
             self.workflows_mgr.update
         )
-        ioloop.PeriodicCallback(
-            self.workflows_mgr.update,
-            self.scan_interval * 1000
-        ).start()
 
     def initialize_settings(self):
         """Update extension settings.
@@ -274,6 +270,11 @@ class CylcUIServer(ExtensionApp):
                 for key, value in self.config['CylcUIServer'].items()
             )
         )
+        # configure the scan
+        ioloop.PeriodicCallback(
+            self.workflows_mgr.update,
+            self.scan_interval * 1000
+        ).start()
 
     def initialize_handlers(self):
         self.handlers.extend([

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -89,15 +89,16 @@ class CylcUIServer(ExtensionApp):
         map(
             str,
             [
-                # base configuration - always used
-                Path(uis_pkg).parent,
+                # user configuration
+                Path('~/.cylc/hub').expanduser(),
                 # site configuration
                 Path(
                     os.getenv('CYLC_SITE_CONF_PATH')
-                    or Path(GlobalConfig.DEFAULT_SITE_CONF_PATH, 'hub')
+                    or GlobalConfig.DEFAULT_SITE_CONF_PATH,
+                    'hub'
                 ),
-                # user configuration
-                Path('~/.cylc/hub').expanduser()
+                # base configuration - always used
+                Path(uis_pkg).parent,
             ]
         )
     )

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -268,6 +268,12 @@ class CylcUIServer(ExtensionApp):
         super().initialize_settings()
         self.log.info("Starting Cylc UI Server")
         self.log.info(f'Serving UI from: {self.ui_path}')
+        self.log.debug(
+            'CylcUIServer config:\n' + '\n'.join(
+                f'  * {key} = {repr(value)}'
+                for key, value in self.config['CylcUIServer'].items()
+            )
+        )
 
     def initialize_handlers(self):
         self.handlers.extend([

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -90,7 +90,7 @@ def is_token_authenticated(
 
     https://github.com/jupyter-server/jupyter_server/pull/562
     """
-    if isinstance(user, bytes):
+    if isinstance(user, bytes):  # noqa: SIM114
         # Cookie authentication:
         # * The URL token is added to a secure cookie, it can then be
         #   removed from the URL for subsequent requests, the cookie is

--- a/cylc/uiserver/jupyter_config.py
+++ b/cylc/uiserver/jupyter_config.py
@@ -15,10 +15,14 @@
 
 # Configuration file for jupyterhub.
 
+import os
 from pathlib import Path
 import pkg_resources
 
-from cylc.uiserver import __file__ as uis_pkg
+from cylc.uiserver import (
+    __file__ as uis_pkg,
+    getenv,
+)
 
 
 # the command the hub should spawn (i.e. the cylc uiserver itself)
@@ -26,6 +30,17 @@ c.Spawner.cmd = ['cylc', 'hubapp']
 
 # the spawner to invoke this command
 c.JupyterHub.spawner_class = 'jupyterhub.spawner.LocalProcessSpawner'
+
+# environment variables to pass to the spawner (if defined)
+c.Spawner.environment = getenv(
+    # site config path override
+    'CYLC_SITE_CONF_PATH',
+    # used to specify the Cylc version if using a wrapper script
+    'CYLC_VERSION',
+    'CYLC_ENV_NAME',
+    # may be used by Cylc UI developers to use a development UI build
+    'CYLC_DEV',
+)
 
 # this auto-spawns uiservers without user interaction
 c.JupyterHub.implicit_spawn_seconds = 0.01

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ addopts = """
 doctest_optionflags = """
     NORMALIZE_WHITESPACE
     IGNORE_EXCEPTION_DETAIL
+    ELLIPSIS
 """
 testpaths = [
     'cylc/uiserver'


### PR DESCRIPTION
* Turns out Jupyter Server config_file_paths are loaded in reverse order.
* Fixes the CYLC_SITE_CONF_PATH env var override (which wasn't adding
  `/hub` to the path.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional).
- [x] No changelog (bug has not been released).
- [x] No documentation update required.
- [x] No dependency changes.
