### PR TITLE
removed the installed state

### DIFF
--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -131,7 +131,7 @@ async def test_register_workflow(
     an entry for the workflow in the data store .data map, and another
     entry in the data store .delta_queues map."""
     w_id = 'user|workflow_id'
-    await data_store_mgr.register_workflow(w_id=w_id)
+    await data_store_mgr.register_workflow(w_id=w_id, is_active=False)
     assert w_id in data_store_mgr.data
     assert w_id in data_store_mgr.delta_queues
 
@@ -144,7 +144,7 @@ async def test_update_contact_no_contact_data(
     for the workflow in the data store, like the API version set to zero."""
     w_id = 'user|workflow_id'
     api_version = 0
-    await data_store_mgr.register_workflow(w_id=w_id)
+    await data_store_mgr.register_workflow(w_id=w_id, is_active=False)
     data_store_mgr.update_contact(w_id=w_id, contact_data=None)
     assert api_version == data_store_mgr.data[w_id]['workflow'].api_version
 
@@ -157,7 +157,7 @@ async def test_update_contact_with_contact_data(
     for the workflow."""
     w_id = 'user|workflow_id'
     api_version = 1
-    await data_store_mgr.register_workflow(w_id=w_id)
+    await data_store_mgr.register_workflow(w_id=w_id, is_active=False)
     contact_data = {
         'name': 'workflow_id',
         'owner': 'cylc',
@@ -177,7 +177,7 @@ async def test_stop_workflow(
     contact with no contact data."""
     w_id = 'user|workflow_id'
     api_version = 1
-    await data_store_mgr.register_workflow(w_id=w_id)
+    await data_store_mgr.register_workflow(w_id=w_id, is_active=False)
     contact_data = {
         'name': 'workflow_id',
         'owner': 'cylc',

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -317,7 +317,7 @@ async def test_unregister(
     workflow_name = 'unregister-me'
     workflow_id = f'{getuser()}{ID_DELIM}{workflow_name}'
     uiserver = CylcUIServer()
-    await uiserver.workflows_mgr._register(workflow_id, None)
+    await uiserver.workflows_mgr._register(workflow_id, None, is_active=False)
 
     uiserver.workflows_mgr._scan_pipe = empty_aiter()
     uiserver.workflows_mgr.inactive.add(workflow_id)

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -179,9 +179,9 @@ class WorkflowsManager:
         for wid in inactive_before - (active | inactive):
             yield (wid, 'inactive', None, None)
 
-    async def _register(self, wid, flow):
+    async def _register(self, wid, flow, is_active):
         """Register a new workflow with the data store."""
-        await self.uiserver.data_store_mgr.register_workflow(wid)
+        await self.uiserver.data_store_mgr.register_workflow(wid, is_active)
 
     async def _connect(self, wid, flow):
         """Open a connection to a running workflow."""
@@ -240,11 +240,11 @@ class WorkflowsManager:
                 await self._unregister(wid)
 
             elif before is None and after == 'active':
-                await self._register(wid, flow)
+                await self._register(wid, flow, is_active=True)
                 await self._connect(wid, flow)
 
             elif before is None and after == 'inactive':
-                await self._register(wid, flow)
+                await self._register(wid, flow, is_active=False)
 
             elif before == 'inactive' and after == 'active':
                 await self._connect(wid, flow)


### PR DESCRIPTION
PR trio: https://github.com/cylc/cylc-flow/pull/4459, https://github.com/cylc/cylc-uiserver/pull/256, https://github.com/cylc/cylc-ui/pull/805

* The installed state was the same as "stopped" but with the additional
  information that the workflow had not yet been run.
* Added this information to the workflow status message in cylc-uiserver
  (as it is offline information).
* Improved the workflow status message provided by cylc-flow.
* Put the status message into the UI toolbar.
    ![workflow-status-message](https://user-images.githubusercontent.com/16705946/136787449-bc448dee-f374-4b95-979a-f26a5eaf0b86.gif)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
