### PR TITLE
Fix Delta clashes & upgrade graphql-ws & graphql-tornado-ws

### DIFF
--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -395,4 +395,5 @@ class SubscriptionHandler(CylcAppHandler, websocket.WebSocketHandler):
             'current_user': parse_current_user(
                 self.get_current_user()
             ).get('name'),
+            'ops_queue': {},
         }

--- a/cylc/uiserver/websockets/tornado.py
+++ b/cylc/uiserver/websockets/tornado.py
@@ -11,9 +11,12 @@ import socket
 from asyncio import create_task, gather, wait, shield, sleep
 from asyncio.queues import QueueEmpty
 from tornado.websocket import WebSocketClosedError
-from graphql.execution.executors.asyncio import AsyncioExecutor
 from graphql.execution.middleware import MiddlewareManager
-from graphql_ws.base import ConnectionClosedException, BaseConnectionContext, BaseSubscriptionServer
+from graphql_ws.base import ConnectionClosedException
+from graphql_ws.base_async import (
+    BaseAsyncConnectionContext,
+    BaseAsyncSubscriptionServer
+)
 from graphql_ws.observable_aiter import setup_observable_extension
 from graphql_ws.constants import (
     GQL_CONNECTION_ACK,
@@ -29,8 +32,8 @@ setup_observable_extension()
 NO_MSG_DELAY = 1.0
 
 
-class TornadoConnectionContext(BaseConnectionContext):
-    def receive(self):
+class TornadoConnectionContext(BaseAsyncConnectionContext):
+    async def receive(self):
         try:
             return self.ws.recv_nowait()
         except WebSocketClosedError:
@@ -49,7 +52,7 @@ class TornadoConnectionContext(BaseConnectionContext):
         await self.ws.close(code)
 
 
-class TornadoSubscriptionServer(BaseSubscriptionServer):
+class TornadoSubscriptionServer(BaseAsyncSubscriptionServer):
     def __init__(
         self, schema,
         keep_alive=True,
@@ -89,7 +92,6 @@ class TornadoSubscriptionServer(BaseSubscriptionServer):
         return dict(
             params,
             return_promise=True,
-            executor=AsyncioExecutor(loop=self.loop),
             backend=self.backend,
             middleware=MiddlewareManager(
                 *middleware,
@@ -97,155 +99,31 @@ class TornadoSubscriptionServer(BaseSubscriptionServer):
             ),
         )
 
-    async def _handle(self, ws, request_context):
+    async def _handle(self, ws, request_context=None):
         connection_context = TornadoConnectionContext(ws, request_context)
         await self.on_open(connection_context)
-        pending = set()
         while True:
             message = None
             try:
                 if connection_context.closed:
                     raise ConnectionClosedException()
-                message = connection_context.receive()
-            except ConnectionClosedException:
-                break
+                message = await connection_context.receive()
             except QueueEmpty:
                 pass
-            finally:
-                if pending:
-                    (_, pending) = await wait(pending, timeout=0, loop=self.loop)
-
+            except ConnectionClosedException:
+                break
             if message:
-                task = create_task(
-                    self.on_message(connection_context, message))
-                pending.add(task)
+                self.on_message(connection_context, message)
             else:
                 await sleep(NO_MSG_DELAY)
 
-        self.on_close(connection_context)
-        for task in pending:
-            task.cancel()
+        await self.on_close(connection_context)
 
     async def handle(self, ws, request_context=None):
         await shield(self._handle(ws, request_context), loop=self.loop)
 
-    async def on_open(self, connection_context):
-        pass
-
-    def on_close(self, connection_context):
-        remove_operations = list(connection_context.operations.keys())
-        for op_id in remove_operations:
-            self.unsubscribe(connection_context, op_id)
-
-    async def on_connect(self, connection_context, payload):
-        pass
-
-    async def on_connection_init(self, connection_context, op_id, payload):
-        try:
-            await self.on_connect(connection_context, payload)
-            await self.send_message(connection_context, op_type=GQL_CONNECTION_ACK)
-        except Exception as e:
-            await self.send_error(connection_context, op_id, e, GQL_CONNECTION_ERROR)
-            await connection_context.close(1011)
-
-    def execute(self, request_context, params):
-        params['context_value'] = request_context
-        return super().execute(request_context, params)
-
-    async def send_execution_result(self, connection_context, op_id,
-                                    execution_result):
-        """
-        Our schema contains a subscription ObjectType that contains other
-        ObjectType's. These are resolved with functions that are awaitable,
-        but the GraphQL is not able to understand that during a subscription
-        operation.
-
-        This workaround will iterate the schema object, and resolve/await
-        each awaitable. Not elegant, but works.
-
-        From: https://github.com/graphql-python/graphql-ws/issues/12#issuecomment-476989150
-        """
-        resolving_items: List[Awaitable[Any]] = []
-
-        queue: List[Tuple[Any, Optional[Union[int, str]], Any]] = [
-            (
-                None,
-                None,
-                execution_result.data,
-            ),
-        ]
-
-        while queue:
-            container, key, item = queue.pop(0)
-
-            if isinstance(item, list):
-                self.__extend_list_item(queue, item)
-
-            elif isinstance(item, dict):
-                self.__extend_dict_item(queue, item)
-
-            elif isawaitable(item):
-                container = container if container is not None else queue
-                key: Union[int, str] = key if key is not None else 0
-
-                resolving_items.append(
-                    self.__resolve_container_item(container, key, item))
-
-        # FIXME: If we have multiple items in the queue, and one of them
-        #        fails, then we won't send the execution results.
-        #        We could use return_exceptions=True here, but it is not
-        #        clear how we should proceed. Should we re-queue the
-        #        failed item? Send the error? Ignore it? Log?
-        await gather(*resolving_items)
-
-        await super().send_execution_result(connection_context, op_id,
-                                            execution_result)
-
-        return None
-
-    async def __resolve_container_item(
-            self,
-            container: Any,
-            key: Union[int, str],
-            item: Awaitable[Any],
-    ) -> None:
-        container[key] = await item
-
-    def __extend_list_item(
-            self,
-            queue: List[Tuple[
-                Union[List[Any], Dict[Union[int, str], Any]], Union[
-                    int, str], Any]],
-            item: List[Any],
-    ) -> None:
-        queue.extend(
-            (
-                item,
-                index,
-                value,
-            )
-            for index, value in enumerate(item)
-        )
-
-    def __extend_dict_item(
-            self,
-            queue: List[Tuple[
-                Union[List[Any], Dict[Union[int, str], Any]], Union[
-                    int, str], Any]],
-            item: Dict[Union[int, str], Any],
-    ) -> None:
-        queue.extend(
-            (
-                item,
-                key,
-                value,
-            )
-            for key, value in item.items()
-        )
-
     async def on_start(self, connection_context, op_id, params):
-        execution_result = self.execute(
-            connection_context.request_context, params)
+        execution_result = self.execute(params)
 
         if isawaitable(execution_result):
             execution_result = await execution_result
@@ -260,6 +138,3 @@ class TornadoSubscriptionServer(BaseSubscriptionServer):
                     break
                 await self.send_execution_result(connection_context, op_id, single_result)
             await self.send_message(connection_context, op_id, GQL_COMPLETE)
-
-    async def on_stop(self, connection_context, op_id):
-        self.unsubscribe(connection_context, op_id)

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     cylc-flow>=8.0b2
     graphene
     graphene-tornado==2.6.*
-    graphql-ws>=0.3.1,<0.4
+    graphql-ws==0.4.4
     jupyter_server>=1.10.2
     tornado>=6.1.0  # matches jupyter_server value
     traitlets>=5


### PR DESCRIPTION
Sibling to https://github.com/cylc/cylc-flow/pull/4479
**Merge both together**

Together with the sibling this PR fixes the following graphql subscription problems:
- Duplicate deltas.
- The `None` errors observed recently:
```
graphql.error.located_error.GraphQLLocatedError: 'id'
```
```
graphql.error.located_error.GraphQLLocatedError: argument of type 'NoneType' is not iterable
```
- Subscription server / `graphql-ws` updates.


**Tasks**
- [x] Upgrade `graphql-ws` to rule out the bespoke implementation of our maintained `graphql-tornado-ws` bundle.
- [x] Utilize sibling feature for making deltas from the same workflow sequential.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests TODO (requires WS <=> UIS <=> UI functional test).
- [x] No change log entry required (fixes issue only visible in between releases).
- [x] No documentation update required.
- [x] No dependency changes.
