### PR TITLE
Make doctring more informative

### DIFF
--- a/cylc/uiserver/authorise.py
+++ b/cylc/uiserver/authorise.py
@@ -476,9 +476,9 @@ class AuthorizationMiddleware:
 def get_groups(username: str) -> List[str]:
     """Return list of system groups for given user.
 
-    Utilizes `os.getgrouplist` alongside `os.NGROUPS_MAX` to return system
-    groups for a given user. `grp.getgrgid` will then parse these to return a
-    list of group names.
+    Uses `os.getgrouplist` and `os.NGROUPS_MAX` to get system groups for a
+    given user. `grp.getgrgid` then parses these to return a list of group
+    names.
 
     Args:
         username: username used to check system groups.


### PR DESCRIPTION
For linking in documentation, this method should have more information which could help users diagnose any group problems linked to authorisation.

One review should do (docstring change).

This is a small change with no associated Issue.
**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why - docstring change).
- [x] No change log entry required (why - docstring change).
- [x] No documentation update required.
- [x] No dependency changes.
