### PR TITLE
Missing xsrf token 

### DIFF
--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -162,7 +162,8 @@ class CylcAppHandler(JupyterHandler):
     3800ceaf9edf33a0171922b93ea3d94f87aa8d91/jupyterhub/
     singleuser/mixins.py#L826
     """
-
+    # Without this, there is no xsrf token from the GET which causes a 403 and
+    # a missing _xsrf argument error on the first POST.
     def prepare(self):
         _ = self.xsrf_token
 
@@ -197,7 +198,6 @@ class CylcStaticHandler(CylcAppHandler, web.StaticFileHandler):
     def get(self, path):
         # authenticate the static handler
         # this provides us with login redirection and token cashing
-
         return web.StaticFileHandler.get(self, path)
 
 


### PR DESCRIPTION
Fixes ` 403 POST /user/username/cylc/graphql (::ffff:127.0.0.1): '_xsrf' argument missing from POST` errors.
To reproduce, checkout master ui-server, clear all cookies and run `cylc hub`. 
On loading the UI, you should get the above error in the UI Server logs.

Checkout this branch and do the same, you should see no error.

Alternative demonstration of the problem:
 
Re-running @kinow's suggestion to inspect the cookies on the cli, detailed in the issue...

`curl -XGET -k -L -I https://localhost:8000/user/<username>/cylc/ | grep set-cookie`
`curl -XPOST -k -L -I https://localhost:8000/user/<username>/cylc/graphql | grep set-cookie`

The Fix:
From https://www.tornadoweb.org/en/stable/guide/security.html:

> application that does not use any regular forms you may need to access self.xsrf_token manually (just reading the property is enough to set the cookie as a side effect).

We can override [`RequestHandler.prepare()`](RequestHandler.prepare()) in `CylcAppHandler` to force a `Set-Cookie` for the `_xsrf`. Note you'll see 2 separate `set-cookie` but this is normal behaviour to multiple Set-Cookie headers in the same response. ([MDN Web Docs Set-Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)).

These changes close https://github.com/cylc/cylc-ui/issues/796

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why- accessing a token).
- [x] No change log entry required (why- bug fix for unreleased ui-server).
- [x] No documentation update required.
- [x] No dependency changes.
