### PR TITLE
Reinstate/fix multi-workflow request filter

### DIFF
--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -190,6 +190,9 @@ class Resolvers(BaseResolvers):
         w_ids = [
             flow[WORKFLOW].id
             for flow in await self.get_workflows_data(w_args)]
+        if not w_ids:
+            return [{
+                'response': (False, 'No matching workflows')}]
         # Pass the request to the workflow GraphQL endpoints
         req_str, variables, _, _ = info.context.get('graphql_params')
         graphql_args = {
@@ -215,7 +218,8 @@ class Resolvers(BaseResolvers):
             flow[WORKFLOW].id
             for flow in await self.get_workflows_data(w_args)]
         if not w_ids:
-            return 'Error: No matching Workflow'
+            return [{
+                'response': (False, 'No matching workflows')}]
         # Pass the multi-node request to the workflow GraphQL endpoints
         req_str, variables, _, _ = info.context.get('graphql_params')
         graphql_args = {

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -284,7 +284,8 @@ class WorkflowsManager:
                 command,
                 multi_args.get(w_id, args),
                 timeout,
-            ) for w_id in self.active
+            ) for w_id in workflows
+            if w_id in self.active
         }
         gathers = [
             workflow_request(req_context=info, *request_args, log=self.log)


### PR DESCRIPTION
These changes close https://github.com/cylc/cylc-uiserver/issues/269
Need to retest for https://github.com/cylc/cylc-uiserver/issues/250

The fix was to use the matching workflows and test against active workflows (not just send to all active workflows).

**no workflows:**
![mutation_no_workflow](https://user-images.githubusercontent.com/11400777/140879513-b4a8fa8a-df43-463b-875c-4fcbf9c8cb04.png)


**matching workflow**
![mutation_send_matching_workflow](https://user-images.githubusercontent.com/11400777/140879570-744dce6c-e1c8-4f86-b360-f0f742de5857.png)

**wildcard**
![mutation_wildcards_still_work](https://user-images.githubusercontent.com/11400777/140879594-6b41ceda-d458-40d3-8400-0a6098f49f34.png)


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Cross project tests needed at some point.
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
