### PR TITLE
actions: test build on project metadata change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+# build the project whenever the configuration is changed
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'README.md'       # check markdown is valid
+      - 'MANIFEST.in'     # check packaging
+      - 'pyproject.toml'  # check build config
+      - 'setup.cfg'       # check deps and project config
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+        python: ['3.7', '3.8', '3.9']
+        include:
+          - os: 'macos-latest'
+            python: '3.7'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Build
+        uses: cylc/release-actions/build-python-package@v1
+
+      - name: Inspect
+        run: |
+          unzip -l dist/*.whl | tee files
+          grep 'cylc/uiserver/py.typed' files
+          grep 'cylc/uiserver/ui' files

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include cylc/uiserver/py.typed
 include cylc/uiserver/logging_config.json
 include cylc/uiserver/logo.svg
+include cylc/uiserver/py.typed
 recursive-include cylc/uiserver/ui/ *


### PR DESCRIPTION
~Markdown is fairly non-standard. PyPi and GitHub use different "flavours".~

~Adapt our markdown to make it PyPi compliant and add a test.~

~GitHub seems happy with the PyPi flavour.~

Build the project when its configuration changes. This can help to identify packaging errors which might only turn up at release time early on.