### PR TITLE
Pass authenticated user to cylc-flow

### DIFF
--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -194,8 +194,10 @@ class Resolvers(BaseResolvers):
     # Mutations
     async def mutator(self, info, *m_args):
         """Mutate workflow."""
+        req_meta = {}
         _, w_args, _, _ = m_args
-        auth_user = info.context.get('current_user', 'unknown user')
+        req_meta['auth_user'] = info.context.get(
+            'current_user', 'unknown user')
         w_ids = [
             flow[WORKFLOW].id
             for flow in await self.get_workflows_data(w_args)]
@@ -215,7 +217,7 @@ class Resolvers(BaseResolvers):
             'variables': variables,
         }
         return await self.workflows_mgr.multi_request(
-            'graphql', w_ids, graphql_args, auth_user=auth_user
+            'graphql', w_ids, graphql_args, req_meta=req_meta
         )
 
     async def service(self, info, *m_args):

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -194,7 +194,8 @@ class Resolvers(BaseResolvers):
     # Mutations
     async def mutator(self, info, *m_args):
         """Mutate workflow."""
-        _, w_args, _ = m_args
+        _, w_args, _, _ = m_args
+        auth_user = info.context.get('current_user', 'unknown user')
         w_ids = [
             flow[WORKFLOW].id
             for flow in await self.get_workflows_data(w_args)]
@@ -214,7 +215,7 @@ class Resolvers(BaseResolvers):
             'variables': variables,
         }
         return await self.workflows_mgr.multi_request(
-            'graphql', w_ids, graphql_args
+            'graphql', w_ids, graphql_args, auth_user=auth_user
         )
 
     async def service(self, info, *m_args):
@@ -234,6 +235,8 @@ class Resolvers(BaseResolvers):
         if not w_ids:
             return [{
                 'response': (False, 'No matching workflows')}]
+        auth_user = info.context.get('current_user', 'unknown user')
+
         # Pass the multi-node request to the workflow GraphQL endpoints
         _, variables, _, _ = info.context.get('graphql_params')
 
@@ -248,5 +251,5 @@ class Resolvers(BaseResolvers):
         }
         multi_args = {w_id: graphql_args for w_id in w_ids}
         return await self.workflows_mgr.multi_request(
-            'graphql', w_ids, multi_args=multi_args
+            'graphql', w_ids, multi_args=multi_args, auth_user=auth_user
         )

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -52,7 +52,9 @@ class AsyncClientFixture(ZMQSocketBase):
     def will_return(self, returns):
         self.returns = returns
 
-    async def async_request(self, command, args=None, timeout=None):
+    async def async_request(
+        self, command, args=None, timeout=None, auth_user=None
+    ):
         if (
             inspect.isclass(self.returns)
             and issubclass(self.returns, Exception)

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -53,7 +53,7 @@ class AsyncClientFixture(ZMQSocketBase):
         self.returns = returns
 
     async def async_request(
-        self, command, args=None, timeout=None, auth_user=None
+        self, command, args=None, timeout=None, req_meta=None
     ):
         if (
             inspect.isclass(self.returns)

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -53,6 +53,7 @@ async def workflow_request(
     req_context=None,
     *,
     log=None,
+    auth_user=None
 ):
     """Workflow request command.
 
@@ -70,7 +71,8 @@ async def workflow_request(
     if req_context is None:
         req_context = command
     try:
-        result = await client.async_request(command, args, timeout)
+        result = await client.async_request(
+            command, args, timeout, auth_user=auth_user)
         return (req_context, result)
     except ClientTimeout as exc:
         if log:
@@ -271,7 +273,8 @@ class WorkflowsManager:
         workflows,
         args=None,
         multi_args=None,
-        timeout=None
+        timeout=None,
+        auth_user=None
     ):
         """Send requests to multiple workflows."""
         if args is None:
@@ -288,7 +291,12 @@ class WorkflowsManager:
             if w_id in self.active
         }
         gathers = [
-            workflow_request(req_context=info, *request_args, log=self.log)
+            workflow_request(
+                req_context=info,
+                *request_args,
+                log=self.log,
+                auth_user=auth_user
+            )
             for info, request_args in req_args.items()
         ]
         results = await asyncio.gather(*gathers, return_exceptions=True)

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -53,7 +53,7 @@ async def workflow_request(
     req_context=None,
     *,
     log=None,
-    auth_user=None
+    req_meta=None
 ):
     """Workflow request command.
 
@@ -63,6 +63,7 @@ async def workflow_request(
         args (dict): Endpoint arguments.
         timeout (float): Client request timeout (secs).
         req_context (str): A string to identifier.
+        req_meta (dict): Meta data related to request, e.g. auth_user
 
     Returns:
         tuple: (req_context, result)
@@ -72,7 +73,7 @@ async def workflow_request(
         req_context = command
     try:
         result = await client.async_request(
-            command, args, timeout, auth_user=auth_user)
+            command, args, timeout, req_meta=req_meta)
         return (req_context, result)
     except ClientTimeout as exc:
         if log:
@@ -274,13 +275,15 @@ class WorkflowsManager:
         args=None,
         multi_args=None,
         timeout=None,
-        auth_user=None
+        req_meta=None
     ):
         """Send requests to multiple workflows."""
         if args is None:
             args = {}
         if multi_args is None:
             multi_args = {}
+        if req_meta is None:
+            req_meta = {}
         req_args = {
             w_id: (
                 self.active[w_id]['req_client'],
@@ -295,7 +298,7 @@ class WorkflowsManager:
                 req_context=info,
                 *request_args,
                 log=self.log,
-                auth_user=auth_user
+                req_meta=req_meta
             )
             for info, request_args in req_args.items()
         ]


### PR DESCRIPTION
This is necessary for logging which authenticated user executes the command on the UI.
Sibling pr: https://github.com/cylc/cylc-flow/pull/4522
These changes close https://github.com/cylc/cylc-uiserver/issues/224 and https://github.com/cylc/cylc-flow/issues/4294

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests - can not test this currently due to no multi user testing in the automated test battery.
- [x] No change log entry required -invisible to users.
- [x] No documentation update required.
- [x] No dependency changes.
