### PR TITLE
Adds version hierarchy to config files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@ ones in. -->
 
 ### Enhancements
 
+[#301](https://github.com/cylc/cylc-uiserver/pull/301) -
+Version hierarchy added to jupyter_config.py files, to match cylc-flow. Config
+files are now sourced from `.cylc/uiserver/<version>` rather than `.cylc/hub`.
+
 [#297](https://github.com/cylc/cylc-uiserver/pull/297) -
 Updated for the new Global Universal ID.
 

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -90,7 +90,7 @@ from cylc.uiserver.workflows_mgr import WorkflowsManager
 
 # UIS configuration dirs
 UISERVER_DIR = 'uiserver'
-USER_CONF_ROOT: Path = Path(f'~/.cylc/{UISERVER_DIR}').expanduser()
+USER_CONF_ROOT = Path.home() / '.cylc' / UISERVER_DIR
 SITE_CONF_ROOT: Path = Path(
     os.getenv('CYLC_SITE_CONF_PATH')
     or GlobalConfig.DEFAULT_SITE_CONF_PATH,

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -41,7 +41,6 @@ Cylc specific configurations are documented here.
 """
 
 import getpass
-import os
 from pathlib import Path, PurePath
 import sys
 from typing import List
@@ -62,7 +61,6 @@ from traitlets import (
 
 from jupyter_server.extension.application import ExtensionApp
 
-from cylc.flow.cfgspec.globalcfg import GlobalConfig
 from cylc.flow.network.graphql import (
     CylcGraphQLBackend, IgnoreFieldMiddleware
 )
@@ -81,21 +79,15 @@ from cylc.uiserver.handlers import (
     UIServerGraphQLHandler,
     UserProfileHandler,
 )
-from cylc.uiserver.jupyterhub_config import get_conf_dir_hierarchy
+from cylc.uiserver.jupyterhub_config import (
+    get_conf_dir_hierarchy,
+    SITE_CONF_ROOT,
+    USER_CONF_ROOT
+)
 from cylc.uiserver.resolvers import Resolvers
 from cylc.uiserver.schema import schema
 from cylc.uiserver.websockets.tornado import TornadoSubscriptionServer
 from cylc.uiserver.workflows_mgr import WorkflowsManager
-
-
-# UIS configuration dirs
-UISERVER_DIR = 'uiserver'
-USER_CONF_ROOT = Path.home() / '.cylc' / UISERVER_DIR
-SITE_CONF_ROOT: Path = Path(
-    os.getenv('CYLC_SITE_CONF_PATH')
-    or GlobalConfig.DEFAULT_SITE_CONF_PATH,
-    UISERVER_DIR
-)
 
 
 class PathType(TraitType):

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -88,11 +88,12 @@ from cylc.uiserver.workflows_mgr import WorkflowsManager
 
 
 # UIS configuration dirs
-USER_CONF_ROOT: Path = Path('~/.cylc/hub').expanduser()
+UISERVER_DIR = 'uiserver'
+USER_CONF_ROOT: Path = Path(f'~/.cylc/{UISERVER_DIR}').expanduser()
 SITE_CONF_ROOT: Path = Path(
     os.getenv('CYLC_SITE_CONF_PATH')
     or GlobalConfig.DEFAULT_SITE_CONF_PATH,
-    'hub'
+    UISERVER_DIR
 )
 
 
@@ -227,7 +228,7 @@ class CylcUIServer(ExtensionApp):
             ''' + AUTH_DESCRIPTION + '''
 
             Example configuration, residing in
-            ``~/.cylc/hub/jupyter_config.py``:
+            ``~/.cylc/uiserver/jupyter_config.py``:
 
             .. code-block:: python
 

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -17,9 +17,9 @@
 """
 Cylc UI Server can be configured using a ``jupyter_config.py`` file, loaded
 from a hierarchy of locations. This hierarchy includes the prepackaged
-configuration, the site directory, which defaults to ``/etc/cylc/uiserver`` but can be set with the
-environment variable ``$CYLC_SITE_CONF_PATH`` ) and the user directory
-(``~/.cylc/uiserver``).
+configuration, the site directory, which defaults to ``/etc/cylc/uiserver`` but
+can be set with the environment variable ``$CYLC_SITE_CONF_PATH`` ) and
+the user directory (``~/.cylc/uiserver``).
 For example, at Cylc UI Server version 0.6.0, the hierarchy (highest priority
 at the bottom) would be:
 

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -17,8 +17,8 @@
 """
 Cylc UI Server can be configured using a ``jupyter_config.py`` file, loaded
 from a hierarchy of locations. This hierarchy includes the prepackaged
-configuration, the site directory, which defaults to ``/etc/cylc/uiserver`` but
-can be set with the environment variable ``$CYLC_SITE_CONF_PATH`` ) and
+configuration, the site directory (which defaults to ``/etc/cylc/uiserver`` but
+can be set with the environment variable ``$CYLC_SITE_CONF_PATH``) and
 the user directory (``~/.cylc/uiserver``).
 For example, at Cylc UI Server version 0.6.0, the hierarchy (highest priority
 at the bottom) would be:

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -15,11 +15,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Cylc UI Server can be configured using a ``jupyter_config.py`` file located in:
+Cylc UI Server can be configured using a ``jupyter_config.py`` file, loaded
+from a hierarchy of locations. Including the site directory,
+(defaults to ``/etc/cylc/uiserver``) and the user directory
+(``~/.cylc/uiserver``).
+For example, at Cylc UI Server version 0.6.0, the hierarchy would be:
 
-* ``$CYLC_SITE_CONF_PATH/hub/jupyter_config.py`` (for site-level configuration)
-* ``/etc/cylc/hub/jupyter_config.py`` (for system-level configuration)
-* ``~/.cylc/hub/jupyter_config.py`` (for user-level configuration)
+* ``$CYLC_SITE_CONF_PATH/uiserver/jupyter_config.py``
+* ``/etc/cylc/uiserver/jupyter_config.py``
+* ``/etc/cylc/uiserver/0/jupyter_config.py``
+* ``/etc/cylc/uiserver/0.6/jupyter_config.py``
+* ``/etc/cylc/uiserver/0.6.0/jupyter_config.py``
+* ``~/.cylc/uiserver/jupyter_config.py``
+* ``~/.cylc/uiserver/0/jupyter_config.py``
+* ``~/.cylc/uiserver/0.6/jupyter_config.py``
+* ``~/.cylc/uiserver/0.6.0/jupyter_config.py``
+
 
 An example configuration might look like this:
 
@@ -404,6 +415,7 @@ class CylcUIServer(ExtensionApp):
                 for key, value in self.config['CylcUIServer'].items()
             )
         )
+        print(f"{self.scan_interval}<<<<<<<<<<<<<<<<scan interval used")
         # configure the scan
         ioloop.PeriodicCallback(
             self.workflows_mgr.update,

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -16,9 +16,9 @@
 
 """
 Cylc UI Server can be configured using a ``jupyter_config.py`` file, loaded
-from a hierarchy of locations. Including the site directory, which defaults
-to ``/etc/cylc/uiserver`` but can be set with the environment variable
-``$CYLC_SITE_CONF_PATH`` ) and the user directory
+from a hierarchy of locations. This hierarchy includes the prepackaged
+configuration, the site directory, which defaults to ``/etc/cylc/uiserver`` but can be set with the
+environment variable ``$CYLC_SITE_CONF_PATH`` ) and the user directory
 (``~/.cylc/uiserver``).
 For example, at Cylc UI Server version 0.6.0, the hierarchy (highest priority
 at the bottom) would be:

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -81,6 +81,7 @@ from cylc.uiserver.handlers import (
     UIServerGraphQLHandler,
     UserProfileHandler,
 )
+from cylc.uiserver.jupyterhub_config import get_conf_dir_hierarchy
 from cylc.uiserver.resolvers import Resolvers
 from cylc.uiserver.schema import schema
 from cylc.uiserver.websockets.tornado import TornadoSubscriptionServer
@@ -129,16 +130,18 @@ class CylcUIServer(ExtensionApp):
     config_file_paths = list(
         map(
             str,
-            [
-                # user configuration
-                USER_CONF_ROOT,
-                # site configuration
-                SITE_CONF_ROOT,
-                # base configuration - always used
-                Path(uis_pkg).parent,
-            ]
+            get_conf_dir_hierarchy(
+                [
+                    # user configuration
+                    USER_CONF_ROOT,
+                    # site configuration
+                    SITE_CONF_ROOT,
+                ], filename=False
+            )
         )
     )
+    config_file_paths.append(str(Path(uis_pkg).parent))
+    # TODO: Add a link to the access group table mappings in cylc documentation
     AUTH_DESCRIPTION = '''
             Authorization can be granted at operation (mutation) level, i.e.
             specifically grant user access to execute Cylc commands, e.g.

--- a/cylc/uiserver/config_util.py
+++ b/cylc/uiserver/config_util.py
@@ -1,0 +1,56 @@
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Utility functions for config loading.
+"""
+
+from itertools import product
+import os
+from pathlib import Path
+from typing import List
+
+from cylc.flow.cfgspec.globalcfg import (
+    GlobalConfig,
+    get_version_hierarchy
+)
+from cylc.uiserver import (
+    __file__ as uis_pkg,
+    __version__
+)
+
+# base configuration - always used
+DEFAULT_CONF_PATH: Path = Path(uis_pkg).parent / 'jupyter_config.py'
+UISERVER_DIR = 'uiserver'
+# UIS configuration dirs
+SITE_CONF_ROOT: Path = Path(
+    os.getenv('CYLC_SITE_CONF_PATH')
+    or GlobalConfig.DEFAULT_SITE_CONF_PATH,
+    UISERVER_DIR
+)
+USER_CONF_ROOT = Path.home() / '.cylc' / UISERVER_DIR
+
+
+def get_conf_dir_hierarchy(
+        config_paths: List[Path], filename: bool = True
+) -> List[str]:
+    """Takes list of config paths, adds version and filename to the path"""
+    conf_hierarchy = []
+    version_hierarchy = get_version_hierarchy(__version__)
+    for x in product(config_paths, version_hierarchy):
+        if filename:
+            conf_hierarchy.append(
+                str(Path(x[0], x[1], 'jupyter_config.py').expanduser()))
+        else:
+            conf_hierarchy.append(str(Path(x[0], x[1])))
+    return conf_hierarchy

--- a/cylc/uiserver/jupyterhub_config.py
+++ b/cylc/uiserver/jupyterhub_config.py
@@ -20,35 +20,20 @@ Note: Jupyterhub configs cannot be imported directly due to the way Jupyterhub
 provides the configuration object to the file when it is loaded.
 
 """
-from itertools import product
 import logging
 import os
 from pathlib import Path
-from typing import List
 
-from cylc.flow.cfgspec.globalcfg import (
-    GlobalConfig,
-    get_version_hierarchy
+from cylc.uiserver.config_util import (
+    DEFAULT_CONF_PATH,
+    UISERVER_DIR,
+    USER_CONF_ROOT,
+    SITE_CONF_ROOT,
+    get_conf_dir_hierarchy
+
 )
-
-from cylc.uiserver import (
-    __file__ as uis_pkg,
-    __version__
-)
-
 
 LOG = logging.getLogger(__name__)
-
-# base configuration - always used
-DEFAULT_CONF_PATH: Path = Path(uis_pkg).parent / 'jupyter_config.py'
-UISERVER_DIR = 'uiserver'
-# UIS configuration dirs
-SITE_CONF_ROOT: Path = Path(
-    os.getenv('CYLC_SITE_CONF_PATH')
-    or GlobalConfig.DEFAULT_SITE_CONF_PATH,
-    UISERVER_DIR
-)
-USER_CONF_ROOT = Path.home() / '.cylc' / UISERVER_DIR
 
 
 def _load(path):
@@ -56,20 +41,6 @@ def _load(path):
     if path.exists():
         LOG.info(f'Loading config file: {path}')
         exec(path.read_text())
-
-
-def get_conf_dir_hierarchy(
-        config_paths: List[Path], filename: bool = True
-) -> List[Path]:
-    """Takes list of config paths, adds version and filename to the path"""
-    conf_hierarchy = []
-    version_hierarchy = get_version_hierarchy(hub_version or __version__)
-    for x in product(config_paths, version_hierarchy):
-        if filename:
-            conf_hierarchy.append(Path(x[0], x[1], 'jupyter_config.py'))
-        else:
-            conf_hierarchy.append(Path(x[0], x[1]))
-    return conf_hierarchy
 
 
 def load() -> None:
@@ -87,7 +58,7 @@ def load() -> None:
     # Default conf path not currently versioned:
     config_paths.insert(0, DEFAULT_CONF_PATH)
     for path in config_paths:
-        _load(path)
+        _load(Path(path))
 
 
 hub_version = os.environ.get('CYLC_HUB_VERSION')

--- a/cylc/uiserver/jupyterhub_config.py
+++ b/cylc/uiserver/jupyterhub_config.py
@@ -24,7 +24,7 @@ from itertools import product
 import logging
 import os
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 from cylc.flow.cfgspec.globalcfg import (
     GlobalConfig,

--- a/cylc/uiserver/jupyterhub_config.py
+++ b/cylc/uiserver/jupyterhub_config.py
@@ -26,22 +26,29 @@ import os
 from pathlib import Path
 from typing import List, Optional
 
-from cylc.flow.cfgspec.globalcfg import get_version_hierarchy
+from cylc.flow.cfgspec.globalcfg import (
+    GlobalConfig,
+    get_version_hierarchy
+)
 
 from cylc.uiserver import (
     __file__ as uis_pkg,
     __version__
 )
-from cylc.uiserver.app import (
-    SITE_CONF_ROOT,
-    USER_CONF_ROOT,
-    UISERVER_DIR
-)
+
 
 LOG = logging.getLogger(__name__)
 
 # base configuration - always used
 DEFAULT_CONF_PATH: Path = Path(uis_pkg).parent / 'jupyter_config.py'
+UISERVER_DIR = 'uiserver'
+# UIS configuration dirs
+SITE_CONF_ROOT: Path = Path(
+    os.getenv('CYLC_SITE_CONF_PATH')
+    or GlobalConfig.DEFAULT_SITE_CONF_PATH,
+    UISERVER_DIR
+)
+USER_CONF_ROOT = Path.home() / '.cylc' / UISERVER_DIR
 
 
 def _load(path):

--- a/cylc/uiserver/jupyterhub_config.py
+++ b/cylc/uiserver/jupyterhub_config.py
@@ -56,7 +56,7 @@ def load() -> None:
     # add versioning to paths
     config_paths = get_conf_dir_hierarchy(base_config_paths)
     # Default conf path not currently versioned:
-    config_paths.insert(0, DEFAULT_CONF_PATH)
+    config_paths.insert(0, str(DEFAULT_CONF_PATH))
     for path in config_paths:
         _load(Path(path))
 

--- a/cylc/uiserver/jupyterhub_config.py
+++ b/cylc/uiserver/jupyterhub_config.py
@@ -30,6 +30,7 @@ from cylc.flow.cfgspec.globalcfg import get_version_hierarchy
 
 from cylc.uiserver import (
     __file__ as uis_pkg,
+    __version__
 )
 from cylc.uiserver.app import (
     SITE_CONF_ROOT,
@@ -57,7 +58,7 @@ def _load(path):
 def get_conf_dir_hierarchy(config_paths: List[Path]):
     """Takes list of config paths, adds version and filename to the path"""
     conf_hierarchy = []
-    version_hierarchy = get_version_hierarchy(hub_version)
+    version_hierarchy = get_version_hierarchy(hub_version or __version__)
     for x in product(config_paths, version_hierarchy):
         conf_hierarchy.append(Path(x[0], x[1], 'jupyter_config.py'))
     return conf_hierarchy

--- a/cylc/uiserver/tests/test_config.py
+++ b/cylc/uiserver/tests/test_config.py
@@ -55,10 +55,10 @@ def test_config(clear_env, capload, monkeypatch):
     load()
     assert capload == [
         SYS_CONF,
-        (SITE_CONF/'jupyter_config.py').expanduser(),
-        (SITE_CONF/'0/jupyter_config.py').expanduser(),
-        (USER_CONF/'jupyter_config.py').expanduser(),
-        (USER_CONF/'0/jupyter_config.py').expanduser()
+        (SITE_CONF/'jupyter_config.py'),
+        (SITE_CONF/'0/jupyter_config.py'),
+        (USER_CONF/'jupyter_config.py'),
+        (USER_CONF/'0/jupyter_config.py')
     ]
 
 

--- a/cylc/uiserver/tests/test_config.py
+++ b/cylc/uiserver/tests/test_config.py
@@ -27,7 +27,7 @@ from cylc.uiserver.jupyterhub_config import load
 
 SYS_CONF = Path(UIS_PKG).parent / 'jupyter_config.py'
 USER_CONF = Path('~/.cylc/uiserver').expanduser()
-SITE_CONF = Path('~/etc/cylc/uiserver').expanduser()
+SITE_CONF = Path('/etc/cylc/uiserver')
 
 
 @pytest.fixture

--- a/cylc/uiserver/tests/test_config.py
+++ b/cylc/uiserver/tests/test_config.py
@@ -15,17 +15,19 @@
 
 import os
 from pathlib import Path
+from cylc.uiserver import config_util
 
 import pytest
 
 from cylc.uiserver import __file__ as UIS_PKG
 from cylc.uiserver import jupyterhub_config
-from cylc.uiserver.jupyterhub_config import get_conf_dir_hierarchy, load
+from cylc.uiserver.config_util import get_conf_dir_hierarchy
+from cylc.uiserver.jupyterhub_config import load
 
 
 SYS_CONF = Path(UIS_PKG).parent / 'jupyter_config.py'
 USER_CONF = Path('~/.cylc/uiserver').expanduser()
-SITE_CONF = Path('/etc/cylc/uiserver')
+SITE_CONF = Path('~/etc/cylc/uiserver').expanduser()
 
 
 @pytest.fixture
@@ -49,21 +51,21 @@ def capload(monkeypatch):
 
 def test_config(clear_env, capload, monkeypatch):
     """It should load the system, site and user configs in that order."""
-    monkeypatch.setattr(jupyterhub_config, 'hub_version', '0')
+    monkeypatch.setattr(config_util, '__version__', '0')
     load()
     assert capload == [
         SYS_CONF,
-        Path(SITE_CONF/'jupyter_config.py'),
-        Path(SITE_CONF/'0/jupyter_config.py'),
-        Path(USER_CONF/'jupyter_config.py'),
-        Path(USER_CONF/'0/jupyter_config.py')
+        (SITE_CONF/'jupyter_config.py').expanduser(),
+        (SITE_CONF/'0/jupyter_config.py').expanduser(),
+        (USER_CONF/'jupyter_config.py').expanduser(),
+        (USER_CONF/'0/jupyter_config.py').expanduser()
     ]
 
 
 def test_cylc_site_conf_path(clear_env, capload, monkeypatch):
     """The site config should change to $CYLC_SITE_CONF_PATH if set."""
     monkeypatch.setenv('CYLC_SITE_CONF_PATH', 'elephant')
-    monkeypatch.setattr(jupyterhub_config, 'hub_version', '0')
+    monkeypatch.setattr(config_util, '__version__', '0')
     load()
     assert capload == [
         SYS_CONF,
@@ -78,14 +80,14 @@ def test_get_conf_dir_hierarchy(monkeypatch):
     """Tests hierarchy of versioning for config"""
     config_paths = ['config_path/one', 'config_path/two']
     expected = [
-        Path('config_path/one/jupyter_config.py'),
-        Path('config_path/one/0/jupyter_config.py'),
-        Path('config_path/one/0.6/jupyter_config.py'),
-        Path('config_path/one/0.6.0/jupyter_config.py'),
-        Path('config_path/two/jupyter_config.py'),
-        Path('config_path/two/0/jupyter_config.py'),
-        Path('config_path/two/0.6/jupyter_config.py'),
-        Path('config_path/two/0.6.0/jupyter_config.py')
+        ('config_path/one/jupyter_config.py'),
+        ('config_path/one/0/jupyter_config.py'),
+        ('config_path/one/0.6/jupyter_config.py'),
+        ('config_path/one/0.6.0/jupyter_config.py'),
+        ('config_path/two/jupyter_config.py'),
+        ('config_path/two/0/jupyter_config.py'),
+        ('config_path/two/0.6/jupyter_config.py'),
+        ('config_path/two/0.6.0/jupyter_config.py')
     ]
     monkeypatch.setattr(jupyterhub_config, 'hub_version', '0.6.0')
     actual = get_conf_dir_hierarchy(config_paths)

--- a/cylc/uiserver/tests/test_config.py
+++ b/cylc/uiserver/tests/test_config.py
@@ -89,4 +89,4 @@ def test_get_conf_dir_hierarchy(monkeypatch):
     ]
     monkeypatch.setattr(jupyterhub_config, 'hub_version', '0.6.0')
     actual = get_conf_dir_hierarchy(config_paths)
-    assert actual==expected
+    assert actual == expected


### PR DESCRIPTION
For hub_version `0.6.0`,  the load order can be seen below: 
![image](https://user-images.githubusercontent.com/37735232/151558893-47c1ec49-6a44-46b3-a10b-8e5191baf541.png)

These changes close #199 and #291 

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [ ] I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [x] No dependency changes.
