### PR TITLE
data_store_mgr: catch possible error

### DIFF
--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -190,7 +190,8 @@ class DataStoreMgr:
 
     async def unregister_workflow(self, w_id):
         self.log.debug(f'unregister_workflow({w_id})')
-        self.update_contact(w_id, pruned=True)
+        if w_id in self.data:
+            self.update_contact(w_id, pruned=True)
         while any(
             not delta_queue.empty()
             for delta_queue in self.delta_queues.get(w_id, {}).values()


### PR DESCRIPTION
Small enough we can sneak this in whilst getting RC1 PRs in.

* Closes #305
* Catches a possible error where a workflow might not be in the store
  at the time is is requested to be removed from the store

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
