### PR TITLE
Change log level for config loading

### DIFF
--- a/cylc/uiserver/jupyterhub_config.py
+++ b/cylc/uiserver/jupyterhub_config.py
@@ -34,6 +34,7 @@ from cylc.uiserver.config_util import (
 )
 
 LOG = logging.getLogger(__name__)
+LOG.setLevel(20)
 
 
 def _load(path):


### PR DESCRIPTION
Config loading line for `cylc hub` is not useful at the minute, the log level has a default of warning and we are currently logging at info level for this log message.
 
This is possibly not the correct fix, but setting the log level to info seems more sensible than changing the logging of the config to a warning. 

This is a small change with no associated Issue (raised by @MetRonnie in https://github.com/cylc/cylc-uiserver/pull/301#issuecomment-1026034366). Note the initial logging problem faced ([in app.py](https://github.com/cylc/cylc-uiserver/blob/aa31dea3df52dbf08226c66acc37cf8c67364694/cylc/uiserver/app.py#L379-L384)) is solved with configuration).
I don't believe the second one can be fixed with configuration, unless there is a command line option (?) which at the minute does not come to mind, since the config has not been loaded yet.  If there is such a setting, feel free to reject the PR.
Rather than skipping this logging, it now looks like this...

![image](https://user-images.githubusercontent.com/37735232/153414582-58567c90-0927-46d6-93dc-7337689ab099.png)

Not sure if there is a better way of getting this displayed, hooking into one of the other loggers maybe?

Putting this as milestone 1.1.0 as low priority, although since it is small and may be useful for debugging the release candidate could maybe be bumped to 1.0.0?
 

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (logging).
- [x] No change log entry required (why? logging).
- [x] No documentation update required.
- [x] No dependency changes.
