### PR TITLE
setup: remove dependency caps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ cylc.command =
 
 [options.extras_require]
 hub =
-    jupyterhub==1.4.*
+    jupyterhub>=1.4.0
 tests =
     coverage>=5.0.0
     flake8-broken-line>=0.3.0


### PR DESCRIPTION
I don't think there is a good reason for these dependency caps.

Only JupyterHub has the potential to be a breaking change at the moment, will need to test out v2.

(sites will likely install jupyterhub separately so we need to ensure compatibility in the 1.0 series anyway).