### PR TITLE
Workflows manager

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,14 @@ updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
 -------------------------------------------------------------------------------
+## __cylc-uiserver-1.0.0 (<span actions:bind='release-date'>Under Development</span>)__
+
+### Fixes
+
+[#324](https://github.com/cylc/cylc-uiserver/pull/324) -
+Fix issues where workflow status could be incorrect.
+
+-------------------------------------------------------------------------------
 ## __cylc-uiserver-1.0.0 (<span actions:bind='release-date'>Released 2022-02-17</span>)__
 
 ### Enhancements

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -392,7 +392,7 @@ class CylcUIServer(ExtensionApp):
             workflows_mgr=self.workflows_mgr,
         )
         ioloop.IOLoop.current().add_callback(
-            self.workflows_mgr.update
+            self.workflows_mgr.run
         )
 
     def initialize_settings(self):
@@ -414,7 +414,7 @@ class CylcUIServer(ExtensionApp):
         )
         # configure the scan
         ioloop.PeriodicCallback(
-            self.workflows_mgr.update,
+            self.workflows_mgr.scan,
             self.scan_interval * 1000
         ).start()
 
@@ -522,6 +522,7 @@ class CylcUIServer(ExtensionApp):
         super().launch_instance(argv=argv, **kwargs)
 
     async def stop_extension(self):
+        await self.workflows_mgr.stop()
         for sub in self.data_store_mgr.w_subs.values():
             sub.stop()
         # Shutdown the thread pool executor

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -391,9 +391,6 @@ class CylcUIServer(ExtensionApp):
             log=self.log,
             workflows_mgr=self.workflows_mgr,
         )
-        ioloop.IOLoop.current().add_callback(
-            self.workflows_mgr.run
-        )
 
     def initialize_settings(self):
         """Update extension settings.
@@ -412,7 +409,11 @@ class CylcUIServer(ExtensionApp):
                 for key, value in self.config['CylcUIServer'].items()
             )
         )
-        # configure the scan
+        # start the async scan task running (do this on server start not init)
+        ioloop.IOLoop.current().add_callback(
+            self.workflows_mgr.run
+        )
+        # configure the scan interval
         ioloop.PeriodicCallback(
             self.workflows_mgr.scan,
             self.scan_interval * 1000
@@ -522,6 +523,7 @@ class CylcUIServer(ExtensionApp):
         super().launch_instance(argv=argv, **kwargs)
 
     async def stop_extension(self):
+        # stop the async scan task
         await self.workflows_mgr.stop()
         for sub in self.data_store_mgr.w_subs.values():
             sub.stop()

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -141,9 +141,9 @@ class DataStoreMgr:
                 contact_data[CFF.PUBLISH_PORT]
             )
         )
-        sucessfull_updates = await self._entire_workflow_update(ids=[w_id])
+        successful_updates = await self._entire_workflow_update(ids=[w_id])
 
-        if w_id not in sucessfull_updates:
+        if w_id not in successful_updates:
             # something went wrong, undo any changes to allow for subsequent
             # connection attempts
             self.log.debug(f'failed to connect to {w_id}')

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -150,29 +150,17 @@ class DataStoreMgr:
         Call this when a workflow has stopped.
         """
         self.log.debug(f'disconnect_workflow({w_id})')
+        self._update_contact(
+            w_id,
+            status=WorkflowStatus.STOPPED.value,
+            status_msg=self._get_status_msg(w_id, False),
+        )
         if w_id in self.w_subs:
             self.w_subs[w_id].stop()
             del self.w_subs[w_id]
         if w_id in self.executors:
             self.executors[w_id].shutdown(wait=True)
             del self.executors[w_id]
-
-    def stop_workflow(self, w_id):
-        """Inform the data store that a workflow has stopped.
-
-        Call this when the data store thinks a workflow is running but it
-        isn't. Normally the data store will be subscribed to the workflow
-        when it shuts down so will be sent a shutdown message. However, in
-        some circumstances the data store will not be subscribed so will not
-        receive this message and we have to call this method manually.
-        """
-        self.log.debug(f'stop_workflow({w_id})')
-        self.disconnect_workflow(w_id)
-        self._update_contact(
-            w_id,
-            status=WorkflowStatus.STOPPED.value,
-            status_msg=self._get_status_msg(w_id, False),
-        )
 
     def get_workflows(self):
         """Return all workflows the data store is currently tracking.

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -416,7 +416,6 @@ class DataStoreMgr:
             flow.owner = contact_data['owner']
             flow.host = contact_data[CFF.HOST]
             flow.port = int(contact_data[CFF.PORT])
-            # flow.pub_port = int(contact_data[CFF.PUBLISH_PORT])
             flow.api_version = int(contact_data[CFF.API])
         else:
             # wipe pre-existing contact-file data
@@ -425,7 +424,6 @@ class DataStoreMgr:
             flow.name = w_tokens['workflow']
             flow.host = ''
             flow.port = 0
-            # flow.pub_port = 0
             flow.api_version = 0
 
         if status is not None:

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -116,7 +116,9 @@ def make_entire_workflow():
 def one_workflow_aiter():
     """An async generator fixture that returns a single workflow.
     """
-    async def _create_aiter(*args, **kwargs):
+    async def _create_aiter(*args, none=False, **kwargs):
+        if none:
+            return
         yield kwargs
 
     return _create_aiter
@@ -334,7 +336,7 @@ def disable_workflow_connection(cylc_data_store_mgr, monkeypatch):
 
     monkeypatch.setattr(
         cylc_data_store_mgr,
-        'sync_workflow',
+        'connect_workflow',
         _null
     )
 

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -28,6 +28,7 @@ from tornado.web import HTTPError
 from traitlets.config import Config
 import zmq
 
+from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.id import Tokens
 from cylc.flow.data_messages_pb2 import (  # type: ignore
     PbEntireWorkflow,
@@ -394,3 +395,8 @@ def uis_caplog():
         caplog.set_level(level, uiserver.log.name)
 
     return _caplog
+
+
+@pytest.fixture(scope='session')
+def port_range():
+    return glbl_cfg().get(['scheduler', 'run hosts', 'ports'])

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -37,14 +37,14 @@ async def test_entire_workflow_update(
     async_client.will_return(entire_workflow.SerializeToString())
 
     # Set the client used by our test workflow.
-    data_store_mgr.workflows_mgr.active[w_id] = {
+    data_store_mgr.workflows_mgr.workflows[w_id] = {
         'req_client': async_client
     }
 
     # Call the entire_workflow_update function.
     # This should use the client defined above (``async_client``) when
     # calling ``workflow_request``.
-    await data_store_mgr.entire_workflow_update()
+    await data_store_mgr._entire_workflow_update()
 
     # The ``DataStoreMgr`` sets the workflow data retrieved in its
     # own ``.data`` dictionary, which will contain Protobuf message
@@ -70,14 +70,14 @@ async def test_entire_workflow_update_ignores_timeout_message(
     async_client.will_return(MSG_TIMEOUT)
 
     # Set the client used by our test workflow.
-    data_store_mgr.workflows_mgr.active[w_id] = {
+    data_store_mgr.workflows_mgr.workflows[w_id] = {
         'req_client': async_client
     }
 
     # Call the entire_workflow_update function.
     # This should use the client defined above (``async_client``) when
     # calling ``workflow_request``.
-    await data_store_mgr.entire_workflow_update()
+    await data_store_mgr._entire_workflow_update()
 
     # When a ``MSG_TIMEOUT`` happens, the ``DataStoreMgr`` object ignores
     # that message. So it means that its ``.data`` dictionary MUST NOT
@@ -89,7 +89,6 @@ async def test_entire_workflow_update_ignores_timeout_message(
 async def test_entire_workflow_update_gather_error(
     async_client: AsyncClientFixture,
     data_store_mgr: DataStoreMgr,
-    mocker,
     caplog,
 ):
     """
@@ -106,7 +105,7 @@ async def test_entire_workflow_update_gather_error(
     async_client.will_return(error_type)
 
     # Set the client used by our test workflow.
-    data_store_mgr.workflows_mgr.active['workflow_id'] = {
+    data_store_mgr.workflows_mgr.workflows['workflow_id'] = {
         'req_client': async_client
     }
 
@@ -114,7 +113,7 @@ async def test_entire_workflow_update_gather_error(
     # This should use the client defined above (``async_client``) when
     # calling ``workflow_request``.
     caplog.clear()
-    await data_store_mgr.entire_workflow_update()
+    await data_store_mgr._entire_workflow_update()
     assert caplog.record_tuples == [
         (
             'cylc',
@@ -147,7 +146,7 @@ async def test_update_contact_no_contact_data(
     w_id = Tokens(user='user', workflow='workflow_id').id
     api_version = 0
     await data_store_mgr.register_workflow(w_id=w_id, is_active=False)
-    data_store_mgr.update_contact(w_id=w_id, contact_data=None)
+    data_store_mgr._update_contact(w_id=w_id, contact_data=None)
     assert api_version == data_store_mgr.data[w_id]['workflow'].api_version
 
 
@@ -167,7 +166,7 @@ async def test_update_contact_with_contact_data(
         CFF.PORT: 40000,
         CFF.API: api_version
     }
-    data_store_mgr.update_contact(w_id=w_id, contact_data=contact_data)
+    data_store_mgr._update_contact(w_id=w_id, contact_data=contact_data)
     assert api_version == data_store_mgr.data[w_id]['workflow'].api_version
 
 
@@ -187,7 +186,7 @@ async def test_stop_workflow(
         CFF.PORT: 40000,
         CFF.API: api_version
     }
-    data_store_mgr.update_contact(w_id=w_id, contact_data=contact_data)
+    data_store_mgr._update_contact(w_id=w_id, contact_data=contact_data)
     assert api_version == data_store_mgr.data[w_id]['workflow'].api_version
 
     data_store_mgr.stop_workflow(w_id=w_id)

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -171,7 +171,7 @@ async def test_update_contact_with_contact_data(
 
 
 @pytest.mark.asyncio
-async def test_stop_workflow(
+async def test_disconnect_workflow(
     data_store_mgr: DataStoreMgr
 ):
     """Telling a data store to stop a workflow, is the same as updating
@@ -189,5 +189,5 @@ async def test_stop_workflow(
     data_store_mgr._update_contact(w_id=w_id, contact_data=contact_data)
     assert api_version == data_store_mgr.data[w_id]['workflow'].api_version
 
-    data_store_mgr.stop_workflow(w_id=w_id)
+    data_store_mgr.disconnect_workflow(w_id=w_id)
     assert data_store_mgr.data[w_id]['workflow'].api_version == 0

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -13,13 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from getpass import getuser
 from itertools import product
 import logging
 from random import random
 
 import pytest
-from pytest_mock import MockFixture
 
 from cylc.flow.id import Tokens
 from cylc.flow.exceptions import ClientError, ClientTimeout
@@ -93,14 +91,7 @@ async def test_workflow_request(
 # --- WorkflowsManager
 
 
-def test_workflows_manager_spawn_workflow(workflows_manager):
-    workflows_manager.spawn_workflow()
-    assert not workflows_manager.active
-
-# TODO: add tests for remaining methods in WorkflowsManager
-
-
-def mk_flow(path, reg, active=True):
+def mk_flow(path, reg, active=True, database=True):
     """Make a workflow appear on the filesystem for scan purposes.
 
     Args:
@@ -115,10 +106,13 @@ def mk_flow(path, reg, active=True):
     run_dir = path / reg
     srv_dir = run_dir / WorkflowFiles.Service.DIRNAME
     contact = srv_dir / WorkflowFiles.Service.CONTACT
+    database_path = srv_dir / WorkflowFiles.Service.DB
     fconfig = run_dir / WorkflowFiles.FLOW_FILE
     run_dir.mkdir()
     fconfig.touch()  # cylc uses this to identify a dir as a workflow
     srv_dir.mkdir()
+    if database:
+        database_path.touch()
     if active:
         with open(contact, 'w+') as contact_file:
             contact_file.write(
@@ -133,7 +127,7 @@ def mk_flow(path, reg, active=True):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    # generate all possible state changes
+    # generate all possible normal state changes
     'active_before,active_after',
     product(['active', 'inactive', None], repeat=2)
 )
@@ -145,13 +139,12 @@ async def test_workflow_state_changes(tmp_path, active_before, active_after):
     # mock the results of the previous scan
     wfm = WorkflowsManager(None, LOG, context=None, run_dir=tmp_path)
     wid = Tokens(user=wfm.owner, workflow='a').id
-    if active_before == 'active':
-        wfm.active[wid] = {
-            CFF.API: API,
-            CFF.UUID: '42'
-        }
-    elif active_before == 'inactive':
-        wfm.inactive.add(wid)
+
+    ret = (
+        {wid} if active_before == 'active' else set(),
+        {wid} if active_before == 'inactive' else set(),
+    )
+    wfm.get_workflows = lambda: ret
 
     # mock the filesystem in the new state
     if active_after == 'active':
@@ -172,19 +165,50 @@ async def test_workflow_state_changes(tmp_path, active_before, active_after):
         assert (wid, active_before, active_after) == changes[0][:3]
 
 
+@pytest.mark.parametrize(
+    'active_before,active_after',
+    product([True, False], repeat=2)
+)
 @pytest.mark.asyncio
-async def test_workflow_state_change_restart(tmp_path):
-    """It identifies workflows which have restarted between scans."""
+async def test_workflow_state_change_uuid(
+    tmp_path,
+    active_before,
+    active_after
+):
+    """It identifies discontinuities in workflow runs.
+
+    A workflow run is defined by its UUID. If this changes the workflow manager
+    must detect the change and re-register the workflow because any data known
+    about the workflow is now out of date.
+
+    This can happen because:
+
+    * A workflow was deleted and installed between scans.
+    * The user deleted the workflow database.
+
+    """
     # mock the result of the previous scan
     wfm = WorkflowsManager(None, LOG, context=None, run_dir=tmp_path)
     wid = Tokens(user=wfm.owner, workflow='a').id
-    wfm.active[wid] = {
-            CFF.API: API,
-            CFF.UUID: '41'
+
+    wfm.workflows[wid] = {
+        CFF.API: API,
+        CFF.UUID: '41'
     }
 
-    # create a new workflow with the same name but a different UUID
-    mk_flow(tmp_path, 'a', active=True)
+    if active_before:
+        wfm.get_workflows = lambda: ({wid}, set())
+    else:
+        wfm.get_workflows = lambda: (set(), {wid})
+
+    if active_after:
+        # create a workflow with the same name but a different UUID
+        # (simulates a new workflow run being started)
+        mk_flow(tmp_path, 'a', active=True)
+    else:
+        # create a workflow without a database
+        # (simulates the database being removed or workflow re-created)
+        mk_flow(tmp_path, 'a', active=False, database=False)
 
     # see what state changes the workflow manager detects
     changes = []
@@ -193,12 +217,16 @@ async def test_workflow_state_change_restart(tmp_path):
 
     # the flow should be marked as becoming inactive then active again
     assert [change[:3] for change in changes] == [
-        (wid, 'active', 'inactive'),
-        (wid, 'inactive', 'active')
+        (
+            wid,
+            ('/active' if active_before else '/inactive'),
+            ('active' if active_after else 'inactive'),
+        )
     ]
 
     # it should have picked up the new uuid too
-    assert changes[1][3][CFF.UUID] == '42'
+    if active_after:
+        assert changes[0][3][CFF.UUID] == '42'
 
 
 @pytest.mark.asyncio
@@ -221,7 +249,7 @@ async def test_multi_request(
         workflow_id: None
     }
 
-    workflows_manager.active[workflow_id] = {
+    workflows_manager.workflows[workflow_id] = {
         'req_client': async_client
     }
 
@@ -235,216 +263,22 @@ async def test_multi_request(
 async def test_multi_request_gather_errors(
     workflows_manager,
     async_client: AsyncClientFixture,
-    mocker: MockFixture,
     caplog
 ):
     workflow_id = 'gather-error-workflow'
     error_type = ValueError
     async_client.will_return(error_type)
 
-    workflows_manager.active[workflow_id] = {
+    workflows_manager.workflows[workflow_id] = {
         'req_client': async_client
     }
 
     caplog.clear()
     await workflows_manager.multi_request('', [workflow_id], None, None)
-    # assert caplog.record_tuples == []
     assert caplog.record_tuples == [
         ('cylc', 40, 'Failed to send requests to multiple workflows')
     ]
     assert caplog.records[0].exc_info[0] == error_type
-
-
-@pytest.mark.asyncio
-async def test_register(
-    mocker: MockFixture,
-    one_workflow_aiter,
-):
-    """Test the registration of a workflow.
-
-    It depends on the pipes returning a workflow with no
-    previous state, and the next state as 'active'."""
-    workflow_name = 'register-me'
-    workflow_id = Tokens(user=getuser(), workflow=workflow_name).id
-    uiserver = CylcUIServer()
-
-    assert workflow_id not in uiserver.data_store_mgr.data
-    assert workflow_id not in uiserver.workflows_mgr.active
-
-    uiserver.workflows_mgr._scan_pipe = one_workflow_aiter(
-        **{
-            'name': workflow_name,
-            'contact': True,
-            CFF.HOST: 'localhost',
-            CFF.PORT: 0,
-            CFF.PUBLISH_PORT: 0,
-            CFF.API: 1
-        }
-    )
-    # NOTE: here we will yield a workflow that is running, it has contact
-    #       data, is not active nor inactive (i.e. pending registration).
-    #       This is what forces the .update() to call register()!
-
-    # We don't have a real workflow, so we mock get_location.
-    mocker.patch(
-        'cylc.flow.network.client.get_location',
-        return_value=('localhost', 0, None)
-    )
-    # The following functions also depend on a running workflow
-    # with pyzmq socket, so we also mock them.
-    mocker.patch('cylc.flow.network.client.WorkflowRuntimeClient.start')
-    mocker.patch('cylc.flow.network.client.WorkflowRuntimeClient.get_header')
-    mocker.patch('cylc.uiserver.data_store_mgr.DataStoreMgr.'
-                 'start_subscription')
-
-    await uiserver.workflows_mgr.update()
-
-    # register must have created an entry in the workflow manager
-    assert workflow_id in uiserver.workflows_mgr.active
-
-
-@pytest.mark.asyncio
-async def test_unregister(
-    one_workflow_aiter,
-    empty_aiter
-):
-    """A workflow, once registered, can be unregistered in the
-    workflow manager.
-
-    It will delegate to the data store to properly remove the
-    workflow from the data store attributes, and call the necessary
-    functions."""
-    workflow_name = 'unregister-me'
-    workflow_id = Tokens(user=getuser(), workflow=workflow_name).id
-    uiserver = CylcUIServer()
-    await uiserver.workflows_mgr._register(workflow_id, None, is_active=False)
-
-    uiserver.workflows_mgr._scan_pipe = empty_aiter()
-    uiserver.workflows_mgr.inactive.add(workflow_id)
-    # NOTE: here we will yield a workflow that is not running, it does
-    #       not have the contact data and is inactive.
-    #       This is what forces the .update() to call unregister()!
-
-    await uiserver.workflows_mgr.update()
-
-    # now the workflow is not active, nor inactive, it is unregistered
-    assert workflow_id not in uiserver.workflows_mgr.inactive
-
-
-@pytest.mark.asyncio
-async def test_connect(
-    mocker: MockFixture,
-    one_workflow_aiter
-):
-    """Test connecting to a workflow.
-
-    If a workflow is running, but in the inactive state,
-    then the connect method will be called."""
-    workflow_name = 'connect'
-    workflow_id = Tokens(user=getuser(), workflow=workflow_name).id
-    uiserver = CylcUIServer()
-    uiserver.workflows_mgr.inactive.add(workflow_id)
-
-    assert workflow_id not in uiserver.workflows_mgr.active
-    assert workflow_id in uiserver.workflows_mgr.inactive
-
-    uiserver.workflows_mgr._scan_pipe = one_workflow_aiter(
-        **{
-            'name': workflow_name,
-            'contact': True,
-            CFF.HOST: 'localhost',
-            CFF.PORT: 0,
-            CFF.PUBLISH_PORT: 0,
-            CFF.API: 1
-        }
-    )
-    # NOTE: here we will yield a workflow that is running, it has contact
-    #       data, is not active nor inactive (i.e. pending registration).
-    #       This is what forces the .update() to call register()!
-
-    # We don't have a real workflow, so we mock get_location.
-    mocker.patch(
-        'cylc.flow.network.client.get_location',
-        return_value=('localhost', 0, None)
-    )
-    # The following functions also depend on a running workflow
-    # with pyzmq socket, so we also mock them.
-    mocker.patch('cylc.flow.network.client.WorkflowRuntimeClient.start')
-    mocker.patch('cylc.flow.network.client.WorkflowRuntimeClient.get_header')
-    mocker.patch('cylc.uiserver.data_store_mgr.DataStoreMgr.'
-                 'start_subscription')
-
-    async def my_sync_workflow(*args, **kwargs):
-        return True
-    mocker.patch(
-        'cylc.uiserver.data_store_mgr.DataStoreMgr.sync_workflow',
-        side_effect=my_sync_workflow
-    )
-
-    await uiserver.workflows_mgr.update()
-
-    # connect must have created an active entry for the workflow,
-    # and the update method must have taken care to remove from inactive
-    assert workflow_id in uiserver.workflows_mgr.active
-    assert not uiserver.workflows_mgr.inactive
-
-
-@pytest.mark.asyncio
-async def test_disconnect_and_stop(
-    mocker: MockFixture,
-    one_workflow_aiter,
-    async_client: AsyncClientFixture
-):
-    """Test disconnecting and stopping a workflow.
-
-    If a workflow is active, but the next state is inactive, the
-    workflow manager will take care to stop and disconnect the workflow."""
-    workflow_name = 'disconnect-stop'
-    workflow_id = Tokens(user=getuser(), workflow=workflow_name).id
-    uiserver = CylcUIServer()
-
-    flow = {
-            'name': workflow_name,
-            'contact': False,
-            CFF.HOST: 'localhost',
-            CFF.PORT: 0,
-            CFF.PUBLISH_PORT: 0,
-            CFF.API: 1,
-            'req_client': async_client
-        }
-    uiserver.workflows_mgr.active[workflow_id] = flow
-
-    assert workflow_id not in uiserver.workflows_mgr.inactive
-    assert workflow_id in uiserver.workflows_mgr.active
-
-    uiserver.workflows_mgr._scan_pipe = one_workflow_aiter(
-        **flow
-    )
-    # NOTE: here we will yield a workflow that is running, it has contact
-    #       data, is not active nor inactive (i.e. pending registration).
-    #       This is what forces the .update() to call register()!
-
-    # We don't have a real workflow, so we mock get_location.
-    mocker.patch(
-        'cylc.flow.network.client.get_location',
-        return_value=('localhost', 0, None)
-    )
-    # The following functions also depend on a running workflow
-    # with pyzmq socket, so we also mock them.
-    mocker.patch('cylc.flow.network.client.WorkflowRuntimeClient.start')
-    mocker.patch('cylc.flow.network.client.WorkflowRuntimeClient.get_header')
-    mocker.patch('cylc.uiserver.data_store_mgr.DataStoreMgr.'
-                 'start_subscription')
-    mocker.patch('cylc.uiserver.data_store_mgr.DataStoreMgr.update_contact')
-
-    await uiserver.workflows_mgr.update()
-
-    # connect must have created an active entry for the workflow,
-    # and the update method must have taken care to remove from inactive
-    assert workflow_id not in uiserver.workflows_mgr.active
-    assert workflow_id in uiserver.workflows_mgr.inactive
-
-# TODO: add tests for remaining methods in WorkflowsManager
 
 
 async def test_crashed_workflow(one_workflow_aiter, caplog, uis_caplog):
@@ -456,7 +290,7 @@ async def test_crashed_workflow(one_workflow_aiter, caplog, uis_caplog):
 
     # register a running workflow, the UIS will attempt to connect to it ...
     uiserver.workflows_mgr._scan_pipe = one_workflow_aiter(**{
-        'name': 'one',
+        'name': 'workflow-does-not-exist',
         'contact': True,
         CFF.HOST: 'localhost',
         CFF.PORT: 0,

--- a/cylc/uiserver/tests/test_workflows_mgr_data_store.py
+++ b/cylc/uiserver/tests/test_workflows_mgr_data_store.py
@@ -1,0 +1,158 @@
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from functools import partial
+from getpass import getuser
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from cylc.flow.id import Tokens
+from cylc.flow.workflow_files import ContactFileFields as CFF
+
+from cylc.uiserver.workflows_mgr import WorkflowsManager
+
+"""Test interaction between the workflows manager and data store."""
+
+
+def dummy_uis():
+    calls = []
+
+    async def async_capture(func, *_):
+        nonlocal calls
+        calls.append(func)
+
+    def sync_capture(func, *_):
+        nonlocal calls
+        calls.append(func)
+
+    data_store_mgr = SimpleNamespace(
+        register_workflow=partial(async_capture, 'register'),
+        unregister_workflow=partial(async_capture, 'unregister'),
+        connect_workflow=partial(async_capture, 'connect'),
+        disconnect_workflow=partial(sync_capture, 'disconnect'),
+        stop_workflow=partial(sync_capture, 'stop'),
+        calls=calls,
+    )
+
+    uis = SimpleNamespace(data_store_mgr=data_store_mgr)
+    wfm = WorkflowsManager(uis, logging.getLogger())
+    uis.workflows_mgr = wfm
+
+    return uis
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'before,after,actions',
+    [
+        (
+            None,
+            None,
+            [],
+        ),
+        (
+            None,
+            'inactive',
+            ['register'],
+        ),
+        (
+            None,
+            'active',
+            ['register', 'connect'],
+        ),
+        (
+            'inactive',
+            None,
+            ['unregister'],
+        ),
+        (
+            'inactive',
+            'inactive',
+            [],
+        ),
+        (
+            'inactive',
+            'active',
+            ['connect'],
+        ),
+        (
+            'active',
+            None,
+            ['disconnect', 'unregister'],  # TODO: should this stop?
+        ),
+        (
+            'active',
+            'inactive',
+            ['disconnect', 'stop'],
+        ),
+        (
+            'active',
+            'active',
+            [],
+        ),
+    ],
+)
+async def test_data_store_changes(
+    one_workflow_aiter,
+    monkeypatch,
+    before,
+    after,
+    actions,
+):
+    monkeypatch.setattr(
+        'cylc.uiserver.workflows_mgr.WorkflowRuntimeClient',
+        lambda *a, **k: True
+    )
+
+    workflow_name = 'register-me'
+    wid = Tokens(user=getuser(), workflow=workflow_name).id
+    uiserver = dummy_uis()
+
+    # mock the state of the data store
+    ret = [
+        {wid} if before == 'active' else set(),
+        {wid} if before == 'inactive' else set(),
+    ]
+    uiserver.data_store_mgr.get_workflows = lambda: ret
+
+    # mock the scan result
+    if after == 'active':
+        uiserver.workflows_mgr._scan_pipe = one_workflow_aiter(
+            **{
+                'name': workflow_name,
+                'contact': True,
+                CFF.HOST: 'localhost',
+                CFF.PORT: 0,
+                CFF.PUBLISH_PORT: 0,
+                CFF.API: 1
+            }
+        )
+    elif after == 'inactive':
+        uiserver.workflows_mgr._scan_pipe = one_workflow_aiter(
+            **{
+                'name': workflow_name,
+                'contact': False,
+            }
+        )
+    else:
+        uiserver.workflows_mgr._scan_pipe = one_workflow_aiter(none=True)
+
+    # run the update
+    await uiserver.workflows_mgr.update()
+
+    # see which data store methods got hit
+    assert uiserver.data_store_mgr.calls == actions

--- a/cylc/uiserver/tests/test_workflows_mgr_data_store.py
+++ b/cylc/uiserver/tests/test_workflows_mgr_data_store.py
@@ -44,7 +44,6 @@ def dummy_uis():
         unregister_workflow=partial(async_capture, 'unregister'),
         connect_workflow=partial(async_capture, 'connect'),
         disconnect_workflow=partial(sync_capture, 'disconnect'),
-        stop_workflow=partial(sync_capture, 'stop'),
         calls=calls,
     )
 
@@ -92,12 +91,12 @@ def dummy_uis():
         (
             'active',
             None,
-            ['disconnect', 'unregister'],  # TODO: should this stop?
+            ['disconnect', 'unregister'],
         ),
         (
             'active',
             'inactive',
-            ['disconnect', 'stop'],
+            ['disconnect'],
         ),
         (
             'active',

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -114,6 +114,7 @@ class WorkflowsManager:
             # only flows which are using the same api version
             | api_version(f'=={API}')
         )
+        self.queue = asyncio.Queue()
 
     def spawn_workflow(self):
         """Start/spawn a workflow."""
@@ -326,3 +327,16 @@ class WorkflowsManager:
                     and list(val.values())
                 ])
         return res
+
+    async def scan(self):
+        if self.queue.empty():
+            await self.queue.put(False)
+
+    async def run(self):
+        stop = False
+        while not stop:
+            await self.update()
+            stop = await self.queue.get()  # wait for a signal
+
+    async def stop(self):
+        await self.queue.put(True)

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -228,12 +228,12 @@ class WorkflowsManager:  # noqa: SIM119
 
     async def _connect(self, wid, flow):
         """Open a connection to a running workflow."""
-        self.workflows[wid] = flow
         try:
             flow['req_client'] = WorkflowRuntimeClient(flow['name'])
         except ClientError as exc:
             self.log.debug(f'Could not connect to {wid}: {exc}')
             return False
+        self.workflows[wid] = flow
         await self.uiserver.data_store_mgr.connect_workflow(
             wid,
             flow
@@ -259,6 +259,8 @@ class WorkflowsManager:  # noqa: SIM119
 
     async def update(self):
         """Scans for workflows, handles any state changes.
+
+        Don't call this method directly, call self.scan to queue an update.
 
         Possible workflow states:
             active:

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,6 @@ tests =
     mypy>=0.900
     pytest-asyncio>=0.14.0
     pytest-cov>=2.8.0
-    pytest-mock
     pytest-tornasync>=0.5.0
     pytest>=6
     types-pkg_resources>=0.1.2


### PR DESCRIPTION
Closes #223, #310, #311, #312 and most of #308

* Check the presence of the workflow database for workflows which have previously run.
   *  (closes #223).
  * When workflows stop we keep their data in the store.
  * In the UI you will still see the state of the task pool when the workflow shut down.
  * If the user deletes the workflow database the data store needs to be wiped because they have deleted the continuity of the workflow run, i.e. it is effectively a new workflow run now.
* Ensure that one scan finishes before the next begins.
  * (closes #312).
  * Scans are scheduled to an interval.
  * When changes in workflow state are detected the workflow manager calls the relevant methods in the data store manager to adapt to this change.
  * Because these operations are await'ed in the scan they hold up the scan.
  * This means it is possible two scans to overlap even if you set a sensible interval between them.
  * Especially likely on startup if you have loads of workflows.
* Ensure workflow disconnect happens before re-connect.
  * (closes #311).
  * Previously the workflow manager was correctly telling the data store to connect to running workflows.
  * However, if the disconnect hadn't been performed, the new connect would just return rather than doing anything.
  * Ensure disconnect is called when necessary.

Starting and stopping a batch of workflows, before some would occasionally get stuck in the stopped state:

<img src="https://user-images.githubusercontent.com/16705946/155750425-81e86a62-7bdb-4526-a0b8-f1759b824be2.gif" width="30%" />

Taking a single workflow through a full cycle:

![cycle](https://user-images.githubusercontent.com/16705946/155750430-c5785b90-a7f0-4c72-a9cc-e8467a38837d.gif)

Removing the workflow database now causes the workflow to be re-registered (data from the old run will disappear):

![db-remove](https://user-images.githubusercontent.com/16705946/155750434-fe13a82f-f806-4531-acd2-d3f50e783234.gif)


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes (one dep change but tests only)