### PR TITLE
Fix lack of upper pin for `rx` in `graphql-core<2.3.0`

### DIFF
--- a/cylc/uiserver/authorise.py
+++ b/cylc/uiserver/authorise.py
@@ -420,15 +420,17 @@ class AuthorizationMiddleware:
         op_name = self.get_op_name(info.field_name, info.operation.operation)
         # It shouldn't get here but worth checking for zero trust
         if not op_name:
-            self.auth_failed(current_user, op_name, 400,
-                             "Operation not in schema.")
+            self.auth_failed(
+                current_user, op_name, http_code=400,
+                msg="Operation not in schema."
+            )
         try:
             authorised = self.auth.is_permitted(current_user, op_name)
         except Exception:
             # Fail secure
             authorised = False
         if not authorised:
-            self.auth_failed(current_user, op_name, 403)
+            self.auth_failed(current_user, op_name, http_code=403)
         if (info.operation.operation in Authorization.ASYNC_OPS
                 or iscoroutinefunction(next_)):
             return self.async_resolve(next_, root, info, **args)
@@ -453,7 +455,7 @@ class AuthorizationMiddleware:
             log_message = log_message + " " + message
         raise web.HTTPError(http_code, reason=message)
 
-    def get_op_name(self, field_name: str, operation: str) -> Union[None, str]:
+    def get_op_name(self, field_name: str, operation: str) -> Optional[str]:
         """
         Returns operation name required for authorization.
         Converts queries and subscriptions to read operations.

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -134,7 +134,7 @@ class WorkflowsManager:  # noqa: SIM119
             # all flows on the filesystem
             scan(run_dir)
             # stop here is the flow is stopped, else...
-            | is_active(True, filter_stop=False)
+            | is_active(is_active=True, filter_stop=False)
             # extract info from the contact file
             | contact_info
             # only flows which are using the same api version

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,10 @@ install_requires =
     tornado>=6.1.0  # matches jupyter_server value
     traitlets>=5
 
+    # Fix lack of upper pin for rx in graphql-core<2.3.0 (remove when
+    # upgrading graphene to 3.0):
+    rx<2
+
 [options.packages.find]
 include = cylc*
 


### PR DESCRIPTION
This is a small change with no associated Issue.

I tried (in fresh conda env)
```
$ conda install 'cylc-flow==8.0rc2'
$ pip install cylc-uiserver
```
And when I ran `cylc gui` I got
```
ImportError: cannot import name 'extensionmethod' from 'rx.internal'
```
(`rx` is a dependency of [`graphql-core`](https://github.com/graphql-python/graphql-core-legacy) which is a dependency of `graphene`)

Turns out with the conda installation of `cylc-flow` I ended up with `rx 3.2.0`, because I ended up with `graphql-core 2.2` and that version does not have an upper pin on `rx` (just a lower pin `rx>=1.6`). (The latest `graphene 2.1.9` has a pin `graphql-core>=2.1,<3`) It was not until `graphql-core 2.3.0` that the pin `rx>=1.6,<2` was introduced.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests
- [x] No change log entry required (users don't need to know the pain I've been through).
- [x] No documentation update required.
- [x] This dependency is already included in [cylc-uiserver conda-forge repository](https://github.com/conda-forge/cylc-uiserver-feedstock)
