### PR TITLE
Fix .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,8 +1,10 @@
-Bruno Kinoshita <bruno.kinoshita@niwa.co.nz>
-Bruno Kinoshita <kinow@users.noreply.github.com>
-David Matthews <david.matthews@metoffice.gov.uk>
-Hilary Oliver <hilary.j.oliver@gmail.com>
-Sadie Bartholomew <30274190+sadielbartholomew@users.noreply.github.com>
-Mel Hall <37735232+datamel@users.noreply.github.com> Melanie Hall
-Tim Pillinger <26465611+wxtim@users.noreply.github.com>
-Tim Pillinger <tim.pillinger@metoffice.gov.uk>
+Bruno Kinoshita        <kinow@apache.org>                                             <bruno.kinoshita@niwa.co.nz>
+Bruno Kinoshita        <kinow@apache.org>                                             <kinow@users.noreply.github.com>
+David Matthews         <david.matthews@metoffice.gov.uk>
+Hilary Oliver          <hilary.j.oliver@gmail.com>
+Sadie Bartholomew      <sadie.bartholomew@metoffice.gov.uk>   Sadie L. Bartholomew    <30274190+sadielbartholomew@users.noreply.github.com>
+Ronnie Dutta           <ronnie.dutta@metoffice.gov.uk>                                <61982285+MetRonnie@users.noreply.github.com>
+Mel Hall               <mel.hall@metoffice.gov.uk>                                    <37735232+datamel@users.noreply.github.com>
+Tim Pillinger           <tim.pillinger@metoffice.gov.uk>                              <26465611+wxtim@users.noreply.github.com>
+Stephen McVeigh        <smcveigh941@gmail.com>                                        <stephenmcveigh@users-MacBook-Pro.local>                  
+github-actions[bot]    <github-actions@noreply.github.com>                            <41898282+github-actions[bot]@users.noreply.github.com> 


### PR DESCRIPTION
Another small .mailmap fix.

This is a small change with no associated Issue.

Result:
```console
$ git shortlog -se
   207  Bruno Kinoshita <kinow@apache.org>
     1  David Matthews <david.matthews@metoffice.gov.uk>
    42  David Sutherland <davidwollow@gmail.com>
    58  Hilary Oliver <hilary.j.oliver@gmail.com>
     5  Matt Shin <matthew.shin@metoffice.gov.uk>
    32  Mel Hall <mel.hall@metoffice.gov.uk>
   138  Oliver Sanders <oliver.sanders@metoffice.gov.uk>
    28  Ronnie Dutta <ronnie.dutta@metoffice.gov.uk>
     1  Sadie Bartholomew <sadie.bartholomew@metoffice.gov.uk>
     1  Stephen McVeigh <smcveigh941@gmail.com>
    16  Tim Pillinger <tim.pillinger@metoffice.gov.uk>
    21  github-actions[bot] <github-actions@noreply.github.com>
```