### PR TITLE
Ignore flake8-simplify experimental 9xx rules.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,8 @@
 [flake8]
+ignore=
+    ; "experimental" SIM9xx rules (flake8-simplify)
+    SIM9
+
 exclude=
     build,
     dist,


### PR DESCRIPTION

This is a small change with no associated Issue.

Sibling of https://github.com/cylc/cylc-flow/pull/4785
