### PR TITLE
data_store: suppress traceback from _update_contact

### DIFF
--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -407,6 +407,24 @@ class DataStoreMgr:
         status_msg=None,
         pruned=False,
     ):
+        """Update the data store with information from the contact file.
+
+        Args:
+            w_id: Workflow ID.
+            contact_data: Contact file data dictionary.
+            status: Workflow status (e.g. "running").
+            status_msg: Workflow status message (e.g. "will stop at 2000").
+            pruned: ?
+
+        Returns:
+            True if the contact data is successfully updated or False if
+            the workflow is no longer in the store (e.g. has been removed).
+
+        """
+        if w_id not in self.data:
+            # workflow has been removed - do nothing
+            return False
+
         delta = DELTAS_MAP[ALL_DELTAS]()
         delta.workflow.time = time.time()
         flow = delta.workflow.updated
@@ -442,6 +460,8 @@ class DataStoreMgr:
         self._apply_all_delta(w_id, delta)
         # Queue delta for subscription push
         self._delta_store_to_queues(w_id, ALL_DELTAS, delta)
+
+        return True
 
     def _get_status_msg(self, w_id: str, is_active: bool) -> str:
         """Derive a status message for the workflow.

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -150,8 +150,19 @@ async def test_update_contact_no_contact_data(
     w_id = Tokens(user='user', workflow='workflow_id').id
     api_version = 0
     await data_store_mgr.register_workflow(w_id=w_id, is_active=False)
-    data_store_mgr._update_contact(w_id=w_id, contact_data=None)
+    assert data_store_mgr._update_contact(w_id=w_id, contact_data=None)
     assert api_version == data_store_mgr.data[w_id]['workflow'].api_version
+
+
+@pytest.mark.asyncio
+async def test_update_contact_no_workflow(
+    data_store_mgr: DataStoreMgr
+):
+    """Ensure _update_contact doesn't error if the workflow is missing.
+
+    This can happen if the workflow is removed.
+    """
+    assert not data_store_mgr._update_contact(w_id='elephant')
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Spotted reviewing #323

The `_update_contact` thing can fall over if the workflow has been removed since the action was kicked off (note scan is async).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.