### PR TITLE
update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,7 @@ This is a small change with no associated Issue.
 - [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
 - [ ] Contains logically grouped changes (else tidy your branch by rebase).
 - [ ] Does not contain off-topic changes (use other PRs for other changes).
+- [ ] Any dependency changes applied to `setup.cfg`.
 <!-- choose one: -->
 - [ ] Appropriate tests are included (unit and/or functional).
 - [ ] Already covered by existing tests.
@@ -23,6 +24,3 @@ This is a small change with no associated Issue.
 <!-- choose one: -->
 - [ ] I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
 - [ ] No documentation update required.
-<!-- choose one: -->
-- [ ] Created an issue at [cylc-uiserver conda-forge repository](https://github.com/conda-forge/cylc-uiserver-feedstock) with version changes (if you changed dependencies in `setup.py`, see `recipe/meta.yaml`).
-- [ ] No dependency changes.


### PR DESCRIPTION
Changed in line with cylc-flow.

Raising PRs like this didn't really work, the branch needed to be merged in with the release PR anyway and if it was merged ahead of schedule it could cause nasty problems.