### PR TITLE
DataStoreMgr - use single thread pool

### DIFF
--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -508,7 +508,6 @@ class CylcUIServer(ExtensionApp):
         for sub in self.data_store_mgr.w_subs.values():
             sub.stop()
         # Shutdown the thread pool executor
-        for executor in self.data_store_mgr.executors.values():
-            executor.shutdown(wait=False)
+        self.data_store_mgr.executor.shutdown(wait=False)
         # Destroy ZeroMQ context of all sockets
         self.workflows_mgr.context.destroy()


### PR DESCRIPTION
These changes close #327

Use a single thread pool for all subscriptions instead of one for each.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Any dependency changes applied to `setup.cfg`.
- [x] Does not need tests 
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
