### PR TITLE
logging: redirect cylc-flow log to uis log file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@ ones in. -->
 
 ### Enhancements
 
+[#367](https://github.com/cylc/cylc-uiserver/pull/367) -
+the log file now captures messages from cylc-flow.
+
 [#370](https://github.com/cylc/cylc-uiserver/pull/370) -
 `cylc gui workflow_id` is now supported and will open the GUI at that workflow.
 

--- a/cylc/uiserver/jupyter_config.py
+++ b/cylc/uiserver/jupyter_config.py
@@ -82,6 +82,10 @@ c.CylcUIServer.logging_config = {
             'level': 'INFO',
             'handlers': ['console', 'file'],
         },
+        'cylc': {
+            'level': 'INFO',
+            'handlers': ['console', 'file'],
+        },
     },
     'formatters': {
         'file_fmt': {


### PR DESCRIPTION
Output of cleaning a workflow:

**Before**

```log
2023-02-16T13:12:17 INFO     Starting Cylc UI Server    
2023-02-16T13:12:17 INFO     Serving UI from: ~/cylc-uiserver/cylc/uiserver/ui/1.4.0    
2023-02-16T13:12:21 INFO     [data-store] register_workflow('~/generic/run1', False)    
2023-02-16T13:12:24 INFO     Cleaning ~/generic/run1    
2023-02-16T13:12:25 INFO     [data-store] unregister_workflow('~/generic/run1')    
2023-02-16T13:12:25 INFO     [data-store] _purge_workflow('~/generic/run1')    
2023-02-16T13:12:25 INFO     [data-store] disconnect_workflow('~/generic/run1', update_contact=False)  
```

**After**

```log
2023-02-16T13:10:50 INFO     Starting Cylc UI Server
2023-02-16T13:10:50 INFO     Serving UI from: /net/home/h06/osanders/cylc-uiserver/cylc/uiserver/ui/1.4.0
2023-02-16T13:11:25 INFO     [data-store] register_workflow('~osanders/generic/run1', False)
2023-02-16T13:11:31 INFO     Cleaning ~osanders/generic/run1
2023-02-16T13:11:31 INFO     No workflow database for generic/run1 - will only clean locally
2023-02-16T13:11:31 INFO     Removing symlink and its target directory: /home/h06/osanders/cylc-run/generic/run1/work -> /net/spice/scratch/osanders/cylc-run/generic/run1/work
2023-02-16T13:11:31 INFO     Removing symlink and its target directory: /home/h06/osanders/cylc-run/generic/run1/share -> /net/data/users/osanders/cylc-run/generic/run1/share
2023-02-16T13:11:31 INFO     Removing symlink and its target directory: /home/h06/osanders/cylc-run/generic/run1/log -> /net/data/users/osanders/cylc-run/generic/run1/log
2023-02-16T13:11:31 INFO     Removing directory: /home/h06/osanders/cylc-run/generic/run1
2023-02-16T13:11:31 INFO     Removing directory: /home/h06/osanders/cylc-run/generic/_cylc-install
2023-02-16T13:11:31 INFO     Removing directory: /home/h06/osanders/cylc-run/generic
2023-02-16T13:11:31 INFO     Removing directory: /net/spice/scratch/osanders/cylc-run/generic/run1
2023-02-16T13:11:31 INFO     Removing directory: /net/data/users/osanders/cylc-run/generic/run1
2023-02-16T13:11:31 INFO     [data-store] unregister_workflow('~osanders/generic/run1')
2023-02-16T13:11:31 INFO     [data-store] _purge_workflow('~osanders/generic/run1')
2023-02-16T13:11:31 INFO     [data-store] disconnect_workflow('~osanders/generic/run1', update_contact=False)
```

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Does not need tests 
- [x] Appropriate change log entry included.
- [x] No documentation update required.
