### PR TITLE
Add logging_util and rotating log archive for uiserver logs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,16 @@ creating a new release entry be sure to copy & paste the span tag with the
 `actions:bind` attribute, which is used by a regex to find the text to be
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
+
+-------------------------------------------------------------------------------
+## __cylc-uiserver-1.2.0 (<span actions:bind='release-date'>Upcoming</span>)__
+
+### Enhancements
+
+[#376](https://github.com/cylc/cylc-uiserver/pull/376) -
+UIServer logs are now archived. The five most recent logs are retained (located
+in `~/.cylc/uiserver/log/`). A new log is created with each UIServer instance.
+
 -------------------------------------------------------------------------------
 ## __cylc-uiserver-1.1.0 (<span actions:bind='release-date'>Released 2022-07-28</span>)__
 

--- a/cylc/uiserver/__init__.py
+++ b/cylc/uiserver/__init__.py
@@ -22,9 +22,10 @@ from cylc.uiserver.app import CylcUIServer
 from cylc.uiserver.logging_util import RotatingUISFileHandler
 
 
-LOG = RotatingUISFileHandler()
-# set up uiserver log
-LOG.on_start()
+def init_log():
+    LOG = RotatingUISFileHandler()
+    # set up uiserver log
+    LOG.on_start()
 
 
 def _jupyter_server_extension_points():

--- a/cylc/uiserver/__init__.py
+++ b/cylc/uiserver/__init__.py
@@ -17,8 +17,14 @@ __version__ = "1.1.1.dev"
 
 import os
 from typing import Dict
-
 from cylc.uiserver.app import CylcUIServer
+
+from cylc.uiserver.logging_util import RotatingUISFileHandler
+
+
+LOG = RotatingUISFileHandler()
+# set up uiserver log
+LOG.on_start()
 
 
 def _jupyter_server_extension_points():

--- a/cylc/uiserver/jupyter_config.py
+++ b/cylc/uiserver/jupyter_config.py
@@ -21,8 +21,7 @@ import pkg_resources
 
 from cylc.uiserver import (
     __file__ as uis_pkg,
-    getenv,
-)
+    getenv)
 from cylc.uiserver.app import USER_CONF_ROOT
 
 
@@ -72,7 +71,7 @@ c.CylcUIServer.logging_config = {
         'file': {
             'class': 'logging.handlers.RotatingFileHandler',
             'level': 'INFO',
-            'filename': str(USER_CONF_ROOT / 'uiserver.log'),
+            'filename': str(USER_CONF_ROOT / 'log' / 'log'),
             'mode': 'a',
             'backupCount': 5,
             'maxBytes': 10485760,

--- a/cylc/uiserver/logging_util.py
+++ b/cylc/uiserver/logging_util.py
@@ -19,6 +19,8 @@ import logging
 import os
 from pathlib import Path
 
+from typing import List
+
 from cylc.uiserver.app import USER_CONF_ROOT
 
 
@@ -34,25 +36,21 @@ class RotatingUISFileHandler(logging.handlers.RotatingFileHandler):
         """Set up logging"""
         self.file_path.mkdir(parents=True, exist_ok=True)
         self.delete_symlink()
-        self.rename_logs()
-        self.setup_new_log()
         self.update_log_archive()
+        self.setup_new_log()
 
     def update_log_archive(self):
         """Ensure log archive retains only 5 logs"""
-        log_files = sorted(
-            glob(os.path.join(
-                self.file_path, f"*{self.LOG_NAME_EXTENSION}")
-            ), reverse=True)
-        while len(log_files) > 5:
+        log_files = sorted(glob(os.path.join(
+            self.file_path, f"[0-9]*{self.LOG_NAME_EXTENSION}")), reverse=True)
+        while len(log_files) > 4:
             os.unlink(log_files.pop(0))
+        self.rename_logs(log_files)
 
-    def rename_logs(self):
+    def rename_logs(self, log_files: List[str]):
         """Increment the log number by one for each log"""
         # increments each log number, done in descending order to avoid
         # filename conflicts
-        log_files = sorted(glob(os.path.join(
-            self.file_path, f"*{self.LOG_NAME_EXTENSION}")), reverse=True)
         for file in log_files:
             log_num = int(Path(file).name.partition('-')[0]) + 1
             new_file_name = Path(

--- a/cylc/uiserver/logging_util.py
+++ b/cylc/uiserver/logging_util.py
@@ -45,12 +45,11 @@ class RotatingUISFileHandler(logging.handlers.RotatingFileHandler):
             self.file_path, f"[0-9]*{self.LOG_NAME_EXTENSION}")), reverse=True)
         while len(log_files) > 4:
             os.unlink(log_files.pop(0))
+        # rename logs, logs sent in descending order to prevent conflicts
         self.rename_logs(log_files)
 
     def rename_logs(self, log_files: List[str]):
         """Increment the log number by one for each log"""
-        # increments each log number, done in descending order to avoid
-        # filename conflicts
         for file in log_files:
             log_num = int(Path(file).name.partition('-')[0]) + 1
             new_file_name = Path(

--- a/cylc/uiserver/logging_util.py
+++ b/cylc/uiserver/logging_util.py
@@ -1,0 +1,75 @@
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from contextlib import suppress
+from glob import glob
+import logging
+import os
+from pathlib import Path
+
+from cylc.uiserver.app import USER_CONF_ROOT
+
+
+class RotatingUISFileHandler(logging.handlers.RotatingFileHandler):
+    """Rotate logs on ui-server restart"""
+
+    LOG_NAME_EXTENSION = "-uiserver.log"
+
+    def __init__(self):
+        self.file_path = Path(USER_CONF_ROOT / "log").expanduser()
+
+    def on_start(self):
+        """Set up logging"""
+        self.file_path.mkdir(parents=True, exist_ok=True)
+        self.delete_symlink()
+        self.rename_logs()
+        self.setup_new_log()
+        self.update_log_archive()
+
+    def update_log_archive(self):
+        """Ensure log archive retains only 5 logs"""
+        log_files = sorted(
+            glob(os.path.join(
+                self.file_path, f"*{self.LOG_NAME_EXTENSION}")
+            ), reverse=True)
+        while len(log_files) > 5:
+            os.unlink(log_files.pop(0))
+
+    def rename_logs(self):
+        """Increment the log number by one for each log"""
+        # increments each log number, done in descending order to avoid
+        # filename conflicts
+        log_files = sorted(glob(os.path.join(
+            self.file_path, f"*{self.LOG_NAME_EXTENSION}")), reverse=True)
+        for file in log_files:
+            log_num = int(Path(file).name.partition('-')[0]) + 1
+            new_file_name = Path(
+                f"{self.file_path}/{log_num:02d}{self.LOG_NAME_EXTENSION}"
+            )
+            Path(file).rename(new_file_name)
+
+    def delete_symlink(self):
+        """Deletes an existing log symlink."""
+        symlink_path = Path(self.file_path / 'log')
+        if symlink_path.exists() and symlink_path.is_symlink():
+            symlink_path.unlink()
+
+    def setup_new_log(self):
+        """Create log"""
+        log = Path(self.file_path / f'01{self.LOG_NAME_EXTENSION}')
+        log.touch()
+        symlink_path = Path(self.file_path / 'log')
+        with suppress(OSError):
+            symlink_path.symlink_to(log)

--- a/cylc/uiserver/scripts/gui.py
+++ b/cylc/uiserver/scripts/gui.py
@@ -20,8 +20,10 @@ Launch the Cylc GUI as a standalone web app for local use.
 For a multi-user system see `cylc hub`.
 """
 
+from cylc.uiserver import init_log
 from cylc.uiserver.app import CylcUIServer
 
 
 def main(*argv):
+    init_log()
     return CylcUIServer.launch_instance(argv or None)

--- a/cylc/uiserver/scripts/hub.py
+++ b/cylc/uiserver/scripts/hub.py
@@ -24,11 +24,13 @@ from jupyterhub.app import main as hub_main
 
 from cylc.uiserver import (
     __version__,
-    __file__ as uis_pkg
+    __file__ as uis_pkg,
+    init_log
 )
 
 
 def main(*args):
+    init_log()
     for arg in args:
         if arg.startswith('-f') or arg.startswith('--config'):
             break

--- a/cylc/uiserver/scripts/hub.py
+++ b/cylc/uiserver/scripts/hub.py
@@ -25,12 +25,10 @@ from jupyterhub.app import main as hub_main
 from cylc.uiserver import (
     __version__,
     __file__ as uis_pkg,
-    init_log
 )
 
 
 def main(*args):
-    init_log()
     for arg in args:
         if arg.startswith('-f') or arg.startswith('--config'):
             break

--- a/cylc/uiserver/scripts/hub.py
+++ b/cylc/uiserver/scripts/hub.py
@@ -24,7 +24,7 @@ from jupyterhub.app import main as hub_main
 
 from cylc.uiserver import (
     __version__,
-    __file__ as uis_pkg,
+    __file__ as uis_pkg
 )
 
 

--- a/cylc/uiserver/scripts/hubapp.py
+++ b/cylc/uiserver/scripts/hubapp.py
@@ -18,10 +18,12 @@ This should be the command JupyterHub is configured to spawn e.g:
   c.Spawner.cmd = ['cylc', 'hubapp']
 """
 
+from cylc.uiserver import init_log
 from cylc.uiserver.hubapp import CylcHubApp
 
 INTERNAL = True
 
 
 def main(*argv):
+    init_log()
     return CylcHubApp.launch_instance(argv or None)

--- a/cylc/uiserver/tests/test_logging_util.py
+++ b/cylc/uiserver/tests/test_logging_util.py
@@ -1,0 +1,90 @@
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from glob import glob
+import os
+import pytest
+
+from pathlib import Path
+
+from cylc.uiserver.logging_util import RotatingUISFileHandler
+
+
+def test_update_log_archive(tmp_path):
+    """Test update log archive retains log count at 5"""
+    LOG = RotatingUISFileHandler()
+    LOG.file_path = Path(tmp_path/'.cylc'/'uiserver'/'log')
+    LOG.file_path.mkdir(parents=True, exist_ok=True)
+    for file in [
+        '03-uiserver.log',
+        '01-uiserver.log',
+        '04-uiserver.log',
+        '02-uiserver.log',
+        '05-uiserver.log',
+        '07-uiserver.log',
+        '06-uiserver.log'
+    ]:
+        log_file = LOG.file_path.joinpath(file)
+        log_file.touch()
+        # now log files are set up to test.
+
+    LOG.update_log_archive()
+    log_files = glob(os.path.join(LOG.file_path, f"*.log"))
+    expected_files = [
+        f'{LOG.file_path}/05-uiserver.log',
+        f'{LOG.file_path}/04-uiserver.log',
+        f'{LOG.file_path}/03-uiserver.log',
+        f'{LOG.file_path}/02-uiserver.log',
+        f'{LOG.file_path}/01-uiserver.log']
+    assert len(log_files) == 5
+    assert sorted(log_files) == sorted(expected_files)
+
+
+def test_rename_files(tmp_path):
+    """Test logs are renamed correctly"""
+    LOG = RotatingUISFileHandler()
+    LOG.file_path = Path(tmp_path/'.cylc'/'uiserver'/'log')
+    LOG.file_path.mkdir(parents=True, exist_ok=True)
+    for file in [
+        '01-uiserver.log',
+        '02-uiserver.log',
+        ]:
+        log_file = LOG.file_path.joinpath(file)
+        log_file.touch()
+        log_file.write_text(f"File: {file}")
+        # now log files are set up to test.
+
+    LOG.rename_logs()
+    log_files = glob(os.path.join(LOG.file_path, f"*.log"))
+    expected_files = [
+        f'{LOG.file_path}/03-uiserver.log',
+        f'{LOG.file_path}/02-uiserver.log']
+    assert sorted(log_files) == sorted(expected_files)
+    actual_output = Path(LOG.file_path/'03-uiserver.log').read_text() # LOG.file_path/{03-uiserver.log}
+    assert actual_output == f"File: 02-uiserver.log"
+
+
+def test_setup_new_log(tmp_path):
+    """Checks new log is set up correctly."""
+    LOG = RotatingUISFileHandler()
+    LOG.file_path = Path(tmp_path/'.cylc'/'uiserver'/'log')
+    LOG.file_path.mkdir(parents=True, exist_ok=True)
+    LOG.setup_new_log()
+    new_log = Path(LOG.file_path / '01-uiserver.log')
+    symlink_log =  Path(LOG.file_path / 'log' )
+    assert new_log.exists()
+    assert symlink_log.is_symlink()
+    assert symlink_log.resolve() == new_log
+


### PR DESCRIPTION
Logs for the uiserver can now be found in `~/.cylc/uiserver/log`

These changes close [#352](https://github.com/cylc/cylc-uiserver/issues/352)

When a new instance is started, the previous log is archived. The archive will retain the last 5 logs. 
For convenience, and to keep functionality similar to cylc flow, a log symlink, linking to the latest log has been added.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Any dependency changes applied to `setup.cfg`.
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [ ] I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [x] No documentation update required.
