### PR TITLE
Bump cylc-flow version

### DIFF
--- a/cylc/uiserver/__init__.py
+++ b/cylc/uiserver/__init__.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "1.1.1.dev"
+__version__ = "1.2.0.dev"
 
 import os
 from typing import Dict

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     # bleeding-edge version.
     # NB: no graphene version specified; we only make light use of it in our
     # own code, so graphene-tornado's transitive version should do.
-    cylc-flow==8.0.*
+    cylc-flow==8.1.*
     graphene
     graphene-tornado==2.6.*
     graphql-ws==0.4.4


### PR DESCRIPTION
If the next uiserver release is a minor rather than maintenance one, then doesn't it need to have a dependency on the next cylc-flow minor release?

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Any dependency changes applied to `setup.cfg`.
- [x] Does not need tests 
- [x] No change log entry required
- [x] No documentation update required.
