### PR TITLE
Remove deprecated asyncio loop arg

### DIFF
--- a/cylc/uiserver/websockets/tornado.py
+++ b/cylc/uiserver/websockets/tornado.py
@@ -121,7 +121,7 @@ class TornadoSubscriptionServer(BaseAsyncSubscriptionServer):
         await self.on_close(connection_context)
 
     async def handle(self, ws, request_context=None):
-        await shield(self._handle(ws, request_context), loop=self.loop)
+        await shield(self._handle(ws, request_context))
 
     async def on_start(self, connection_context, op_id, params):
         # Attempt to unsubscribe first in case we already have a subscription


### PR DESCRIPTION
These changes partially address:
- #388 

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes applied to `setup.cfg`.
- [x] Does not need tests 
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
