### PR TITLE
gui: fix browser open on macos

### DIFF
--- a/cylc/uiserver/scripts/gui.py
+++ b/cylc/uiserver/scripts/gui.py
@@ -65,7 +65,7 @@ def main(*argv):
             )
             update_html_file(gui_file, workflow_id)
             if '--no-browser' not in sys.argv:
-                webbrowser.open(gui_file, autoraise=True)
+                webbrowser.open(f'file://{gui_file}', autoraise=True)
             return
     return CylcUIServer.launch_instance(
         jp_server_opts or None, workflow_id=workflow_id


### PR DESCRIPTION
Fixes a minor bug discovered on macos but likely impacting other systems.

Add the `file://` prefix in front of the file path to ensure the browser opens it as a file rather than a URL.

Note the behaviour of a file path without the file prefix is going to be OS/browser specific.

This is fine providing that `gui_file` is guaranteed to be an absolute path which will require a quick check.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Any dependency changes applied to `setup.cfg`.
- [x] Does not need tests (why?).
- [x] No changelog (un released bug)
- [x] No documentation update required.