### PR TITLE
Fix URL for `cylc gui <workflow-id>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,9 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 -------------------------------------------------------------------------------
-## __cylc-uiserver-1.3.0 (<span actions:bind='release-date'>Pending</span>)__
+## __cylc-uiserver-1.2.1 (<span actions:bind='release-date'>Pending</span>)__
 
-<!-- [Updated cylc-ui to x.y.z](https://github.com/cylc/cylc-ui/blob/master/CHANGES.md) -->
+[Updated cylc-ui to 1.5.0](https://github.com/cylc/cylc-ui/blob/master/CHANGES.md)
 
 ### Enhancements
 

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -518,7 +518,7 @@ class CylcUIServer(ExtensionApp):
     @classmethod
     def launch_instance(cls, argv=None, workflow_id=None, **kwargs):
         if workflow_id:
-            cls.default_url = f"/cylc/#/workflows/{workflow_id}"
+            cls.default_url = f"/cylc/#/workspace/{workflow_id}"
         else:
             cls.default_url = "/cylc"
         if argv is None:

--- a/cylc/uiserver/scripts/gui.py
+++ b/cylc/uiserver/scripts/gui.py
@@ -145,7 +145,7 @@ def update_html_file(gui_file, workflow_id):
     if not url_string:
         return
     url = url_string.group(1)
-    split_url = url.split('/workflows/')
+    split_url = url.split('/workspace/')
     if not workflow_id:
         # new url should point to dashboard
         if len(split_url) == 1:
@@ -165,7 +165,7 @@ def update_html_file(gui_file, workflow_id):
                 replacement_url_string = url.replace(old_workflow, workflow_id)
         else:
             # current url points to dashboard, update to point to workflow
-            replacement_url_string = f"{url}/workflows/{workflow_id}"
+            replacement_url_string = f"{url}/workspace/{workflow_id}"
     update_url_string(gui_file, url, replacement_url_string)
 
 

--- a/cylc/uiserver/tests/test_gui.py
+++ b/cylc/uiserver/tests/test_gui.py
@@ -32,17 +32,17 @@ from cylc.uiserver.scripts.gui import update_html_file
         pytest.param(
             'content="1;url=http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#" /> ',
             'some/workflow',
-            'content="1;url=http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/workflows/some/workflow" /> ',
+            'content="1;url=http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/workspace/some/workflow" /> ',
             id='existing_no_workflow_new_workflow'
         ),
         pytest.param(
-            'content="1;url=http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/workflows/some/workflow" /> ',
+            'content="1;url=http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/workspace/some/workflow" /> ',
             'another/flow',
-            'content="1;url=http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/workflows/another/flow" /> ',
+            'content="1;url=http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/workspace/another/flow" /> ',
             id='existing_workflow_new_workflow'
         ),
         pytest.param(
-            'content="1;url=http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/workflows/some/workflow" /> ',
+            'content="1;url=http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/workspace/some/workflow" /> ',
             None,
             'content="1;url=http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#" /> ',
             id='existing_workflow_no_new_workflow'


### PR DESCRIPTION
Follow-up to #370

`cylc gui <workflow-id>` currently ends up at 404 page due to https://github.com/cylc/cylc-ui/pull/1183

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] No tests
- [x] No change log entry required (unreleased bug)
- [x] No documentation update required.
