### PR TITLE
Install coreutils

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Brew Install
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          # install system deps
+          brew update
+          brew install bash coreutils
+
+          # add GNU coreutils to the user PATH
+          # (see instructions in brew install output)
+          echo \
+            "$(brew --prefix)/opt/coreutils/libexec/gnubin" \
+            >> "${GITHUB_PATH}"
+
+          # add coreutils to the bashrc too (for jobs)
+          cat >> "${HOME}/.bashrc" <<__HERE__
+          PATH="$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH"
+          export PATH
+          __HERE__
+
       - name: Setup Python
         uses: actions/setup-python@v3
         with:

--- a/cylc/uiserver/__init__.py
+++ b/cylc/uiserver/__init__.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "1.2.2.dev"
+__version__ = "1.3.0.dev"
 
 import os
 from typing import Dict

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,8 +50,7 @@ install_requires =
     # bleeding-edge version.
     # NB: no graphene version specified; we only make light use of it in our
     # own code, so graphene-tornado's transitive version should do.
-    cylc-flow>=8.1.2, <8.2
-    # cylc-flow==8.2.*  (switch to this for 8.2.*)
+    cylc-flow==8.2.*
     ansimarkup>=1.0.0
     graphene
     graphene-tornado==2.6.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     graphene
     graphene-tornado==2.6.*
     graphql-ws==0.4.4
-    jupyter_server>=1.10.2
+    jupyter_server>=1.10.2,<2.0
     requests
     tornado>=6.1.0  # matches jupyter_server value
     traitlets>=5.2.1  # required for logging_config (5.2.0 had bugs)


### PR DESCRIPTION
> Built on: #436

We are using `tail --follow=name` which isn't posix. This is ok because we state GNU `coreutils` as a dependency of Cylc.

For Mac OS / BSD the GNU coreutils need to be installed alongside the BSD variants as documented here: https://cylc.github.io/cylc-doc/stable/html/installation.html#installing-on-mac-os

This PR uses a modified version of the `brew install` script used in the cylc-flow functional tests.