### PR TITLE
cat-log: support workflow files and log listing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Brew Install
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          # install system deps
+          brew update
+          brew install bash coreutils
+
+          # add GNU coreutils to the user PATH
+          # (see instructions in brew install output)
+          echo \
+            "$(brew --prefix)/opt/coreutils/libexec/gnubin" \
+            >> "${GITHUB_PATH}"
+
+          # add coreutils to the bashrc too (for jobs)
+          cat >> "${HOME}/.bashrc" <<__HERE__
+          PATH="$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH"
+          export PATH
+          __HERE__
+
       - name: Setup Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,14 +48,15 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      # NOTE: Install cylc-uiserver in editable mode for correct coverage results
-      - name: Install cylc-uiserver & dependencies
+      - name: install cylc-flow
         run: |
-          pip install git+https://github.com/cylc/cylc-flow@master
-          pip install -e .[all]
+        uses: cylc/release-actions/install-cylc-components@v1
+        with:
+          cylc_flow: true
+          cylc_flow_opts: ''
 
-      - name: (Debug - pip list)
-        run: pip list --format=freeze
+      - name: install cylc-uiserver
+        run: pip install -e .[all]
 
       - name: Style test
         run: flake8

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -20,9 +20,19 @@ from contextlib import suppress
 from getpass import getuser
 import os
 from copy import deepcopy
+import signal
 from subprocess import Popen, PIPE, DEVNULL
 from typing import (
-    TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Tuple, Union
+    Any,
+    AsyncGenerator,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    TYPE_CHECKING,
+    Tuple,
+    Union,
 )
 
 from graphql.language.base import print_ast
@@ -332,25 +342,21 @@ class Services:
             await queue.put(line.decode())
 
     @classmethod
-    async def cat_log(cls, workflow: Tokens, log, info, task=None, file=None):
+    async def cat_log(cls, id_: Tokens, log, info, file=None):
         """Calls `cat log`.
 
         Used for log subscriptions.
         """
-        full_workflow = workflow
-        if file and task:
-            full_workflow = Tokens(f"{workflow.workflow_id}//{task}")
-        cmd = ['cylc', 'cat-log', '-o']
-        cmd_workflow = full_workflow.id
-        if full_workflow['job']:
-            job = full_workflow['job']
-            # append the submit num
-            cmd += ['-s', job]
-            cmd_workflow = full_workflow.id.strip(job)
+        cmd: List[str] = [
+            'cylc',
+            'cat-log',
+            '--mode=tail',
+            '--force-remote',
+            '--prepend-path',
+            id_.id,
+        ]
         if file:
             cmd += ['-f', file]
-        cmd += ['-m', 't']
-        cmd.append(cmd_workflow)
         log.info(f'$ {" ".join(cmd)}')
 
         # For info, below subprocess is safe (uses shell=false by default)
@@ -371,45 +377,48 @@ class Services:
             while info.context['sub_statuses'].get(op_id) != 'stop':
                 if queue.empty():
                     if buffer:
-                        yield list(buffer)
+                        yield {'lines': list(buffer)}
                         buffer.clear()
                     if proc.returncode not in [None, 0]:
                         (_, stderr) = await proc.communicate()
                         # pass any error onto ui
-                        yield stderr.decode().splitlines()
+                        yield {'error': stderr.decode()}
                         break
                     # sleep set at 1, which matches the `tail` default interval
                     await asyncio.sleep(1)
                 else:
                     if line_count > MAX_LINES:
-                        yield buffer
-                        yield [
-                            '\n\n' + ('-' * 80) + '\n',
-                            (
+                        yield {'lines': buffer}
+                        yield {
+                            'error': (
                                 'This file has been truncated because'
-                                f' it is over {MAX_LINES} lines long.\n'
-                            ),
-                        ]
+                                f' it is over {MAX_LINES} lines long.'
+                            )
+                        }
                         break
+                    elif line_count == 0:
+                        line_count += 1
+                        yield {
+                            'connected': True,
+                            'path': (await queue.get())[2:].strip(),
+                        }
+                        continue
                     line = await queue.get()
                     line_count += 1
                     buffer.append(line)
                     if len(buffer) >= 75:
-                        yield list(buffer)
+                        yield {'lines': list(buffer)}
                         buffer.clear()
                         await asyncio.sleep(0)
         finally:
-            with suppress(psutil.Error):
-                cat_log_proc = psutil.Process(proc.pid)
-                # cat-log process will auto-terminate on tail termination
-                for tail_proc in cat_log_proc.children():
-                    tail_proc.terminate()
+            kill_process_tree(proc.pid)
             enqueue_task.cancel()
             with suppress(asyncio.CancelledError):
                 await enqueue_task
+            yield {'connected': False}
 
     @classmethod
-    async def cat_log_files(cls, workflow: str, task=None):
+    async def cat_log_files(cls, id_: Tokens):
         """Calls cat log to get list of available log files.
 
         Note kept separate from the cat_log method above as this is a one off
@@ -417,11 +426,7 @@ class Services:
         This uses the Cylc cat-log interface, list dir mode, forcing remote
         file checking.
         """
-        cmd = ['cylc', 'cat-log', '-m', 'l', '-o']
-        full_workflow = (f"{workflow}//")
-        if task:
-            full_workflow = (f"{workflow}//{task}")
-        cmd.append(full_workflow)
+        cmd: List[str] = ['cylc', 'cat-log', '-m', 'l', '-o', id_.id]
         proc_job = await asyncio.subprocess.create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
@@ -429,12 +434,19 @@ class Services:
         )
         # wait for proc to finish
         await proc_job.wait()
+
         # MOTD returned in stderr, no use in returning
         out_job, _ = await proc_job.communicate()
         if out_job:
-            return out_job.decode().splitlines()
+            return sorted(
+                # return the log files in reverse sort order
+                # this means that the most recent log file rotations
+                # will be at the top of the list
+                out_job.decode().splitlines(),
+                reverse=True,
+            )
         else:
-            return ["No Logs Available"]
+            return []
 
 
 class Resolvers(BaseResolvers):
@@ -526,25 +538,85 @@ class Resolvers(BaseResolvers):
         self,
         info: 'ResolveInfo',
         _command: str,
-        workflows: List[Tokens],
-        task=None,
+        ids: List[Tokens],
         file=None
     ):
         async for ret in Services.cat_log(
-            workflows[0],
+            ids[0],
             self.log,
             info,
-            task,
             file
         ):
             yield ret
 
     async def query_service(
         self,
-        workflow: Tokens,
-        task=None
+        id_: Tokens,
     ):
-        return await Services.cat_log_files(
-            workflow=workflow,
-            task=task
-        )
+        return await Services.cat_log_files(id_)
+
+
+def kill_process_tree(
+    pid,
+    sig=signal.SIGTERM,
+    include_parent=True,
+):
+    """Kill an entire process tree.
+
+    Args:
+        pid: The parent process ID to kill.
+        sig: The signal to send to the processes in this tree.
+        include_parent: Also kill the parent process (pid).
+
+    """
+    try:
+        parent = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return
+    children = parent.children(recursive=True)
+    if include_parent:
+        children.append(parent)
+    for p in children:
+        with suppress(psutil.NoSuchProcess):
+            p.send_signal(sig)
+
+
+async def list_log_files(
+    root: Optional[Any],
+    info: 'ResolveInfo',
+    id: str,  # noqa: required to match schema arg name
+):
+    tokens = Tokens(id)
+    resolvers: 'Resolvers' = (
+        info.context.get('resolvers')  # type: ignore[union-attr]
+    )
+    files = await resolvers.query_service(tokens)
+    return {'files': files}
+
+
+async def stream_log(
+    root: Optional[Any],
+    info: 'ResolveInfo',
+    *,
+    command='cat_log',
+    id: str,  # noqa: required to match schema arg name
+    file=None,
+    **kwargs: Any,
+) -> AsyncGenerator[Any, None]:
+    """Cat Log Resolver
+    Expands workflow provided subscription query.
+    """
+    tokens = Tokens(id)
+    if kwargs.get('args', False):
+        kwargs.update(kwargs.get('args', {}))
+        kwargs.pop('args')
+    resolvers: 'Resolvers' = (
+        info.context.get('resolvers')  # type: ignore[union-attr]
+    )
+    async for item in resolvers.subscription_service(
+        info,
+        command,
+        [tokens],
+        file
+    ):
+        yield item

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     # bleeding-edge version.
     # NB: no graphene version specified; we only make light use of it in our
     # own code, so graphene-tornado's transitive version should do.
-    cylc-flow>=8.1.2, <8.2
+    cylc-flow>=8.1.3.dev, <8.2
     # cylc-flow==8.2.*  (switch to this for 8.2.*)
     ansimarkup>=1.0.0
     graphene


### PR DESCRIPTION
> **Built Atop:** https://github.com/cylc/cylc-uiserver/tree/update-log-work

> **Sibling:** https://github.com/cylc/cylc-flow/pull/5453

* Support subscribing to other workflow log files.
* Add interface for listing log files.
* Kill the full cat-log process tree recursively when stopping subscriptions (I seemed to hit some situation where that wasn't happening).
* Unify the `workflow` and `task` arguments in the log subscription interface into a single `id` argument.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.