### PR TITLE
setup: migrate to jupyter server 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.8', '3.9']
         include:
           - os: 'macos-latest'
-            python: '3.7'
+            python: '3.8'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.8', '3.9']
         include:
           - os: 'macos-latest'
-            python: '3.7'
+            python: '3.8'
     env:
       PYTEST_ADDOPTS: --cov --color=yes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,16 @@ updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
 -------------------------------------------------------------------------------
+## __cylc-uiserver-1.4.0 (<span actions:bind='release-date'>Awaiting Release</span>)__
+
+### Enhancements
+
+[#450](https://github.com/cylc/cylc-uiserver/pull/450) -
+Upgraded to Jupyter Server 2.7+ and Jupyter Hub 4.0+. Note cylc-uiserver
+1.3 remains supported and compatible with cylc-flow 8.2 for those not ready
+to make the jump just yet.
+
+-------------------------------------------------------------------------------
 ## __cylc-uiserver-1.3.0 (<span actions:bind='release-date'>Released 2023-07-21</span>)__
 
 [Updated cylc-ui to 2.0.0](https://github.com/cylc/cylc-ui/blob/master/CHANGES.md)

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -152,6 +152,7 @@ class CylcUIServer(ExtensionApp):
     config_file_paths.insert(0, str(Path(uis_pkg).parent))  # packaged config
     config_file_paths.reverse()
     # TODO: Add a link to the access group table mappings in cylc documentation
+    # https://github.com/cylc/cylc-uiserver/issues/466
     AUTH_DESCRIPTION = '''
             Authorization can be granted at operation (mutation) level, i.e.
             specifically grant user access to execute Cylc commands, e.g.
@@ -172,7 +173,7 @@ class CylcUIServer(ExtensionApp):
                applied to all workflows.
 
             For more information, including the access group mappings, see
-            :ref:`Authorization`.
+            :ref:`cylc.uiserver.multi-user`.
     '''
 
     site_authorization = Dict(

--- a/cylc/uiserver/jupyter_config.py
+++ b/cylc/uiserver/jupyter_config.py
@@ -15,7 +15,6 @@
 
 # Configuration file for jupyterhub.
 
-import os
 from pathlib import Path
 import pkg_resources
 
@@ -23,6 +22,7 @@ from cylc.uiserver import (
     __file__ as uis_pkg,
     getenv)
 from cylc.uiserver.app import USER_CONF_ROOT
+from cylc.uiserver.authorise import CylcAuthorizer
 
 
 # the command the hub should spawn (i.e. the cylc uiserver itself)
@@ -94,3 +94,10 @@ c.CylcUIServer.logging_config = {
         }
     },
 }
+
+
+# Define the authorization-policy for Jupyter Server.
+# This prevents users being granted full access to extensions such as Jupyter
+# Lab as a result of being granted the ``access:servers`` permission in Jupyter
+# Hub.
+c.ServerApp.authorizer_class = CylcAuthorizer

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -29,6 +29,8 @@ from tornado.web import HTTPError
 from traitlets.config import Config
 import zmq
 
+from jupyter_server.auth.identity import User
+
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.id import Tokens
 from cylc.flow.data_messages_pb2 import (  # type: ignore
@@ -200,60 +202,16 @@ def authorisation_false(monkeypatch):
 
 
 @pytest.fixture
-def mock_authentication(monkeypatch: pytest.MonkeyPatch):
-
-    def _mock_authentication(user=None, server=None, none=False):
-        ret = {
-            'name': user or getuser(),
-            'server': server or gethostname()
-        }
-        if none:
-            ret = None
-            monkeypatch.setattr(
-                'cylc.uiserver.handlers.parse_current_user',
-                lambda x: {
-                    'kind': 'user',
-                    'name': None,
-                    'server': 'some_server'
-                }
-            )
-
-            def mock_redirect(*args):
-                # normally tornado would attempt to redirect us to the login
-                # page - for testing purposes we will skip this and raise
-                # a 403 with an explanatory reason
-                raise HTTPError(
-                    403,
-                    reason='login redirect replaced by 403 for test purposes'
-                )
-
-            monkeypatch.setattr(
-                'cylc.uiserver.handlers.CylcAppHandler.redirect',
-                mock_redirect
-            )
-
-        monkeypatch.setattr(
-            'cylc.uiserver.handlers.CylcAppHandler.get_current_user',
-            lambda x: ret
-        )
-        monkeypatch.setattr(
-            'cylc.uiserver.handlers.CylcAppHandler.get_login_url',
-            lambda x: "http://cylc"
-        )
-
-    _mock_authentication()
-
-    return _mock_authentication
-
-
-@pytest.fixture
-def mock_authentication_yossarian(mock_authentication):
-    mock_authentication(user='yossarian')
-
-
-@pytest.fixture
-def mock_authentication_none(mock_authentication):
-    mock_authentication(none=True)
+def mock_authentication_yossarian(monkeypatch):
+    user = User('yossarian')
+    monkeypatch.setattr(
+        'cylc.uiserver.handlers.CylcAppHandler.current_user',
+        user,
+    )
+    monkeypatch.setattr(
+        'cylc.uiserver.handlers.is_token_authenticated',
+        lambda x: True,
+    )
 
 
 @pytest.fixture

--- a/cylc/uiserver/tests/test_auth.py
+++ b/cylc/uiserver/tests/test_auth.py
@@ -22,7 +22,7 @@ from tornado.httpclient import HTTPClientError
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures("mock_authentication")
+@pytest.mark.usefixtures("mock_authentication_yossarian")
 async def test_cylc_handler(patch_conf_files, jp_fetch):
     """The Cylc endpoints have been added and work."""
     resp = await jp_fetch(
@@ -32,7 +32,7 @@ async def test_cylc_handler(patch_conf_files, jp_fetch):
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures("mock_authentication")
+@pytest.mark.usefixtures("mock_authentication_yossarian")
 @pytest.mark.parametrize(
     'endpoint,code,message,body',
     [
@@ -71,45 +71,6 @@ async def test_authorised_and_authenticated(
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures("mock_authentication_none")
-@pytest.mark.parametrize(
-    'endpoint,code,message,body',
-    [
-        pytest.param(
-            ('cylc', 'graphql'),
-            403,
-            'login redirect replaced by 403 for test purposes',
-            None,
-            id='cylc/graphql',
-        ),
-        pytest.param(
-            ('cylc', 'subscriptions'),
-            403,
-            'Forbidden',
-            None,
-            id='cylc/subscriptions',
-        ),
-        pytest.param(
-            ('cylc', 'userprofile'),
-            403,
-            'login redirect replaced by 403 for test purposes',
-            None,
-            id='cylc/userprofile',
-        )
-    ]
-)
-async def test_unauthenticated(
-    patch_conf_files,
-    jp_fetch,
-    endpoint,
-    code,
-    message,
-    body
-):
-    await _test(jp_fetch, endpoint, code, message, body)
-
-
-@pytest.mark.integration
 @pytest.mark.usefixtures("mock_authentication_yossarian")
 @pytest.mark.parametrize(
     'endpoint,code,message,body',
@@ -124,19 +85,13 @@ async def test_unauthenticated(
         ),
         pytest.param(
             # should pass through authentication but fail as there is no query
+            # (authorisation is performed in the grahpql layer)
             ('cylc', 'subscriptions'),
             400,
             'Bad Request',
             None,
             id='cylc/subscriptions',
         ),
-        pytest.param(
-            ('cylc', 'userprofile'),
-            403,
-            'authorization insufficient',
-            None,
-            id='cylc/userprofile',
-        )
     ]
 )
 async def test_unauthorised(

--- a/cylc/uiserver/tests/test_handlers.py
+++ b/cylc/uiserver/tests/test_handlers.py
@@ -56,15 +56,15 @@ class SubscriptionHandlerTest(AsyncHTTPTestCase):
             handler.get
             _current_user = lambda: {'name': getuser()}
         else:
-            handler.get_current_user = lambda: None
+            handler.current_user = None
         return handler
 
-    @pytest.mark.usefixtures("mock_authentication")
+    @pytest.mark.usefixtures("mock_authentication_yossarian")
     def test_websockets_subprotocol(self):
         handler = self._create_handler()
         assert handler.select_subprotocol(subprotocols=[]) == GRAPHQL_WS
 
-    @pytest.mark.usefixtures("mock_authentication")
+    @pytest.mark.usefixtures("mock_authentication_yossarian")
     def test_websockets_check_origin_accepts_same_origin(self):
         """A request that includes the Host header must use the same
         value as the server host, or an error is raised.
@@ -79,7 +79,7 @@ class SubscriptionHandlerTest(AsyncHTTPTestCase):
         handler.request.headers['Host'] = host_header
         assert handler.check_origin(f'http://{host_header}')
 
-    @pytest.mark.usefixtures("mock_authentication")
+    @pytest.mark.usefixtures("mock_authentication_yossarian")
     def test_websockets_check_origin_rejects_different_origin(self):
         """A request from a different Host MUST be blocked to prevent
         CORS attacks.
@@ -93,13 +93,13 @@ class SubscriptionHandlerTest(AsyncHTTPTestCase):
         handler.request.headers['Origin'] = 'ui.notcylc'
         assert not handler.check_origin('http://ui.notcylc')
 
-    @pytest.mark.usefixtures("mock_authentication")
+    @pytest.mark.usefixtures("mock_authentication_yossarian")
     def test_websockets_context(self):
         handler = self._create_handler()
         assert handler.request == handler.context['request']
         assert 'resolvers' in handler.context
 
-    @pytest.mark.usefixtures("mock_authentication")
+    @pytest.mark.usefixtures("mock_authentication_yossarian")
     def test_websockets_queue(self):
         handler = self._create_handler()
         message = '{"message":"a message"}'
@@ -111,7 +111,7 @@ class SubscriptionHandlerTest(AsyncHTTPTestCase):
                                                 get_async_test_timeout())
         assert handler.queue.empty()
 
-    @pytest.mark.usefixtures("mock_authentication")
+    @pytest.mark.usefixtures("mock_authentication_yossarian")
     def test_assert_callback_handler_gets_called(self):
         handler = self._create_handler()
         handler.subscription_server = MagicMock()

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ classifiers =
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Operating System :: POSIX
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only
@@ -41,7 +40,7 @@ classifiers =
 
 [options]
 packages = find_namespace:
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 install_requires =
     # NB: We have cylc-flow at the top to force it to install its transitive
@@ -55,7 +54,7 @@ install_requires =
     graphene
     graphene-tornado==2.6.*
     graphql-ws==0.4.4
-    jupyter_server>=1.10.2, <2.0
+    jupyter_server>=2.7
     requests
     tornado>=6.1.0  # matches jupyter_server value
     traitlets>=5.2.1  # required for logging_config (5.2.0 had bugs)
@@ -84,7 +83,7 @@ cylc.command =
 
 [options.extras_require]
 hub =
-    jupyterhub>=1.4.0
+    jupyterhub>=4
 tests =
     coverage>=5.0.0
     flake8-broken-line>=0.3.0
@@ -95,6 +94,7 @@ tests =
     flake8-mutable>=1.2.0
     flake8-simplify>=0.14.0
     flake8>=3.0.0
+    jupyter_server[test]
     mypy>=0.900
     pytest-cov>=2.8.0
     pytest-tornasync>=0.5.0


### PR DESCRIPTION
Closes #411

Migrate from Jupyter Server 1-2.

There has been a rejig of the `get_current_user` logic so this should be accompanied by a security check of authorisation/authentication.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/625.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
- [x] Security penetration test.