### PR TITLE
Handle trying to play workflows which require upgrade

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,17 @@ updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
 -------------------------------------------------------------------------------
+
+## __cylc-uiserver-1.4.0 (<span actions:bind='release-date'>Upcoming</span>)__
+
+### Fixes
+
+[#455](https://github.com/cylc/cylc-uiserver/pull/455)- Added a specific
+warning for cases where workflow needs upgrade, and an upgrade toggle in
+cylc play dialog.
+
+-------------------------------------------------------------------------------
+
 ## __cylc-uiserver-1.3.0 (<span actions:bind='release-date'>Released 2023-07-21</span>)__
 
 [Updated cylc-ui to 2.0.0](https://github.com/cylc/cylc-ui/blob/master/CHANGES.md)
@@ -20,10 +31,6 @@ ones in. -->
 
 [#463](https://github.com/cylc/cylc-uiserver/pull/463) - Fixed failure to
 connect to workflows when they were restarted.
-
-[#455](https://github.com/cylc/cylc-uiserver/pull/455)- Added a specific
-warning for cases where workflow needs upgrade, and an upgrade toggle in
-cylc play dialog.
 
 -------------------------------------------------------------------------------
 ## __cylc-uiserver-1.2.2 (<span actions:bind='release-date'>Released 2023-04-28</span>)__

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ cylc play dialog.
 
 ### Enhancements
 
-[#434](https://github.com/cylc/cylc-uiserver/pull/434)- Added the server side
+[#434](https://github.com/cylc/cylc-uiserver/pull/434) - Added the server side
 code for the analysis view in the UI.
 
 ### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ ones in. -->
 
 -------------------------------------------------------------------------------
 
-## __cylc-uiserver-1.4.0 (<span actions:bind='release-date'>Upcoming</span>)__
+## __cylc-uiserver-1.3.1 (<span actions:bind='release-date'>Upcoming</span>)__
 
 ### Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@ ones in. -->
 [#463](https://github.com/cylc/cylc-uiserver/pull/463) - Fixed failure to
 connect to workflows when they were restarted.
 
+[#455](https://github.com/cylc/cylc-uiserver/pull/455)- Added a specific
+warning for cases where workflow needs upgrade, and an upgrade toggle in
+cylc play dialog.
+
 -------------------------------------------------------------------------------
 ## __cylc-uiserver-1.2.2 (<span actions:bind='release-date'>Released 2023-04-28</span>)__
 
@@ -28,8 +32,8 @@ connect to workflows when they were restarted.
 
 ### Enhancements
 
-[#434](https://github.com/cylc/cylc-uiserver/pull/434) - Added the server side
-code for the analysis view in the UI
+[#434](https://github.com/cylc/cylc-uiserver/pull/434)- Added the server side
+code for the analysis view in the UI.
 
 ### Fixes
 

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -332,9 +332,18 @@ class Services:
 
                 if ret:
                     # command failed
-                    _, err = proc.communicate()
+                    out, err = proc.communicate()
+                    if 'previously run with' in out:
+                        # Can't upgrade:
+                        msg = out + '\nEdit the play command to use "upgrade".'
+                    else:
+                        msg = (
+                            f'Could not start {tokens["workflow"]}'
+                            f' - {cmd_repr}'
+                        )
+
                     raise Exception(
-                        f'Could not start {tokens["workflow"]} - {cmd_repr}'
+                        msg
                         # suppress traceback unless in debug mode
                         + (f' - {err}' if DEBUG else '')
                     )

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -339,8 +339,6 @@ class Services:
                     )
                     raise Exception(
                         msg
-                        # include possible traceback in debug mode
-                        + (f' - {err}' if DEBUG else '')
                     )
 
             except Exception as exc:

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -332,8 +332,8 @@ class Services:
 
                 if ret:
                     # command failed
-                    _, err = proc.communicate()
-                    msg = err.strip() or (
+                    out, err = proc.communicate()
+                    msg = err.strip() or out.strip() or (
                         f'Could not start {tokens["workflow"]}'
                         f' - {cmd_repr}'
                     )

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -332,19 +332,14 @@ class Services:
 
                 if ret:
                     # command failed
-                    out, err = proc.communicate()
-                    if 'previously run with' in out:
-                        # Can't upgrade:
-                        msg = out + '\nEdit the play command to use "upgrade".'
-                    else:
-                        msg = (
-                            f'Could not start {tokens["workflow"]}'
-                            f' - {cmd_repr}'
-                        )
-
+                    _, err = proc.communicate()
+                    msg = err.strip() or (
+                        f'Could not start {tokens["workflow"]}'
+                        f' - {cmd_repr}'
+                    )
                     raise Exception(
                         msg
-                        # suppress traceback unless in debug mode
+                        # include possible traceback in debug mode
                         + (f' - {err}' if DEBUG else '')
                     )
 

--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -183,6 +183,7 @@ class Play(graphene.Mutation):
             ''')
         )
         upgrade = graphene.Boolean(
+            default_value=False,
             description=sstrip('''
                 Allow the workflow to be restarted with a newer
                 version of Cylc.

--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -185,8 +185,8 @@ class Play(graphene.Mutation):
         upgrade = graphene.Boolean(
             description=sstrip('''
                 Allow the workflow to be restarted with a newer
-                 version of Cylc.
-        ''')
+                version of Cylc.
+            ''')
         )
         abort_if_any_task_fails = graphene.Boolean(
             default_value=False,

--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -182,6 +182,12 @@ class Play(graphene.Mutation):
                 `[scheduler][main loop]plugins`. Can be used multiple times.
             ''')
         )
+        upgrade = graphene.Boolean(
+            description=sstrip('''
+                Allow the workflow to be restarted with a newer
+                 version of Cylc.
+        ''')
+        )
         abort_if_any_task_fails = graphene.Boolean(
             default_value=False,
             description=sstrip('''


### PR DESCRIPTION
Sibling: https://github.com/cylc/cylc-flow/pull/5535

Closes #429 

* Intercept error message about versions and upgrading and post
  it to a more helpful error message than stardard "This Cylc Play command failed"
* Add a toggle for the --upgrade option of Cylc Play

## Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included - manually tested, thoughts on automated testing welcomed.
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] ~[Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.~ N/A
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.

## Manual Testing

- Run a workflow with Cylc 8.1, then stop it. 
- Change to Cylc 8.2
- Load up the GUI (if you haven't already)
- Play workflow using the main button - watch for failure
- Play workflow using the burger bar, edit (pencil) and toggle upgrade (it's near the bottom). watch for success.