### PR TITLE
fix upper version compat jupyter_server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,13 @@ creating a new release entry be sure to copy & paste the span tag with the
 `actions:bind` attribute, which is used by a regex to find the text to be
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
+
+-------------------------------------------------------------------------------
+## __cylc-uiserver-1.2.3 (<span actions:bind='release-date'>UPCOMING</span>)__
+
+[#456](https://github.com/cylc/cylc-uiserver/pull/456)- (packaging) pinned
+upper version of jupyter_server to prevent `pip` from installing version 2.
+
 -------------------------------------------------------------------------------
 ## __cylc-uiserver-1.2.2 (<span actions:bind='release-date'>Released 2023-04-28</span>)__
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     graphene
     graphene-tornado==2.6.*
     graphql-ws==0.4.4
-    jupyter_server>=1.10.2
+    jupyter_server>=1.10.2, <2.0
     requests
     tornado>=6.1.0  # matches jupyter_server value
     traitlets>=5.2.1  # required for logging_config (5.2.0 had bugs)


### PR DESCRIPTION
We're not yet compatible with Jupyter Server 2, so ensure `pip` won't choose it.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
