### PR TITLE
Logs subscription: tidy error message for when a log file is deleted

### DIFF
--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -17,6 +17,7 @@
 
 import asyncio
 from contextlib import suppress
+import errno
 from getpass import getuser
 import os
 from copy import deepcopy
@@ -70,6 +71,8 @@ OPT_CONVERTERS: Dict['Options', Dict[
 
 # the maximum number of log lines to yield before truncating the file
 MAX_LINES = 5000
+
+ENOENT_MSG = os.strerror(errno.ENOENT)
 
 
 def snake_to_kebab(snake):
@@ -161,12 +164,15 @@ def _build_cmd(cmd: List, args: Dict) -> List:
 
 
 def process_cat_log_stderr(text: bytes) -> str:
-    """Tidy up cylc cat-log stderr."""
+    """Tidy up cylc cat-log stderr.
+
+    If ENOENT message is present in stderr, just return that, because
+    stderr may be full of other crud.
+    """
+    msg = text.decode()
     return (
-        text.decode()
-        .replace('tail: no files remaining', '')
-        .replace('tail: ', '')
-        .strip()
+        ENOENT_MSG if ENOENT_MSG in msg
+        else msg.strip()
     )
 
 

--- a/cylc/uiserver/tests/test_resolvers.py
+++ b/cylc/uiserver/tests/test_resolvers.py
@@ -8,6 +8,7 @@ from cylc.flow import CYLC_LOG
 from cylc.flow.id import Tokens
 from cylc.flow.scripts.clean import CleanOptions
 from cylc.uiserver.resolvers import (
+    ENOENT_MSG,
     _schema_opts_to_api_opts,
     Services,
     process_cat_log_stderr,
@@ -119,8 +120,8 @@ async def test_cat_log(workflow_run_dir):
     [
         (b"", ""),
         (b"dog \n", "dog"),
-        (b"tail: dog: No such file\ntail: no files remaining",
-         "dog: No such file"),
+        (f"tail: dog: {ENOENT_MSG}\ntail: no files remaining".encode(),
+         ENOENT_MSG),
     ]
 )
 def test_process_cat_log_stderr(text: bytes, expected: str):


### PR DESCRIPTION
This is a small change with no associated issue. Follow-up to #457.

### Abstract

When viewing a remote log file that got deleted, you might end up with a lot of crud in the error banner that appears (e.g. SSH login messages that are printed to stderr). Here we only yield the OS ENOENT message if it is present in the `cylc cat-log` stderr, otherwise we yield the whole stderr.

### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are updated.
- [x] No changelog entry needed.
- [x] No docs needed

