### PR TITLE
Allow setting user conf path through environment variables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ below.
  - David Matthews
  - Mel Hall
  - Christopher Bennett
+ - Scott Wales
  <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ The Cylc Hub will load the following files in order:
 
 3) User Config
 
-   This file
+   This file configures the Hub/UIS for the current user. The default path can
+   be changed by the ``CYLC_CONF_PATH`` environment variable.
 
    (`~/.cylc/uiserver/jupyter_config.py`)
 
@@ -174,7 +175,8 @@ are run use the `ServerApp.jpserver_extensions` configuration, see the
 [Jupyter Server configuration documentation](https://jupyter-server.readthedocs.io/en/latest/other/full-config.html#other-full-config).
 
 By default the Cylc part of the UI Server log is written to
-`~/.cylc/uiserver/uiserver.log`.
+`~/.cylc/uiserver/log/log`. This can be changed with the environment
+variable ``CYLC_UISERVER_LOG_PATH``.
 
 <!--
 TODO: Link to Jupyter Server logging_config docs when published

--- a/cylc/uiserver/config_util.py
+++ b/cylc/uiserver/config_util.py
@@ -38,7 +38,7 @@ SITE_CONF_ROOT: Path = Path(
     or GlobalConfig.DEFAULT_SITE_CONF_PATH,
     UISERVER_DIR
 )
-USER_CONF_ROOT = Path.home() / '.cylc' / UISERVER_DIR
+USER_CONF_ROOT = Path(os.getenv('CYLC_CONF_PATH') or Path.home() / '.cylc', UISERVER_DIR)
 
 
 def get_conf_dir_hierarchy(

--- a/cylc/uiserver/logging_util.py
+++ b/cylc/uiserver/logging_util.py
@@ -30,7 +30,7 @@ class RotatingUISFileHandler(logging.handlers.RotatingFileHandler):
     LOG_NAME_EXTENSION = "-uiserver.log"
 
     def __init__(self):
-        self.file_path = Path(USER_CONF_ROOT / "log").expanduser()
+        self.file_path = Path(os.getenv('CYLC_UISERVER_LOG_PATH') or USER_CONF_ROOT, "log").expanduser()
 
     def on_start(self):
         """Set up logging"""

--- a/cylc/uiserver/tests/test_config.py
+++ b/cylc/uiserver/tests/test_config.py
@@ -84,6 +84,20 @@ def test_cylc_site_conf_path(clear_env, capload, monkeypatch):
     ]
 
 
+def test_cylc_user_conf_path(clear_env, capload, monkeypatch):
+    """The user config should change to $CYLC_CONF_PATH if set."""
+    monkeypatch.setenv('CYLC_CONF_PATH', 'elephant')
+    monkeypatch.setattr(config_util, '__version__', '0')
+    load()
+    assert capload == [
+        SYS_CONF,
+        (SITE_CONF / 'jupyter_config.py'),
+        (SITE_CONF / '0/jupyter_config.py'),
+        Path('elephant/uiserver/jupyter_config.py'),
+        Path('elephant/uiserver/0/jupyter_config.py'),
+    ]
+
+
 def test_get_conf_dir_hierarchy(monkeypatch: pytest.MonkeyPatch):
     """Tests hierarchy of versioning for config"""
     config_paths = ['config_path/one', 'config_path/two']

--- a/cylc/uiserver/tests/test_logging_util.py
+++ b/cylc/uiserver/tests/test_logging_util.py
@@ -75,6 +75,13 @@ def test_first_init_log(tmp_path):
         LOG.file_path / '01-uiserver.log')
 
 
+def test_log_conf_path(tmp_path, monkeypatch):
+    """Check initial setup, no previous logs present"""
+    monkeypatch.setenv('CYLC_UISERVER_LOG_PATH', 'elephant')
+    LOG = RotatingUISFileHandler()
+    assert LOG.file_path == 'elephant/log'
+
+
 def test_init_log_with_established_setup(tmp_path):
     """Tests the entire logging init with a typically full logging dir"""
     LOG = RotatingUISFileHandler()


### PR DESCRIPTION
Teach the uiserver about two environment variables:

`$CYLC_CONF_PATH` (default `~/.cylc`) sets a path to read the uiserver configuration from, and also allows `USER_CONF_ROOT` in the server configuration to be updated by users. This variable matches the behaviour of `cylc-flow`.

`$CYLC_UISERVER_LOG_PATH` (default `~/.cylc/uiserver`) sets the output path for Cylc uiserver logs. These logs are created before the jupyter configuration is loaded so are unable to be configured there.

Closes #489 

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
