### PR TITLE
GH Actions: fix release workflow

### DIFF
--- a/.github/workflows/1_create_release_pr.yml
+++ b/.github/workflows/1_create_release_pr.yml
@@ -43,13 +43,13 @@ jobs:
           init-file: 'cylc/uiserver/__init__.py'
           pypi-package-name: 'cylc-uiserver'
 
-      - name: Generate changelog
-        run: |
-          python3 -m pip install -q towncrier
-          towncrier build --yes
-
       - name: Test build
         uses: cylc/release-actions/build-python-package@v1
+
+      - name: Generate changelog
+        run: |
+          python3 -m pip install -q -e .[tests]
+          towncrier build --yes
 
       - name: Create pull request
         uses: cylc/release-actions/stage-1/create-release-pr@v1


### PR DESCRIPTION
For some reason it failed complaining about missing tornado dependency; didn't see this sort of thing on cylc-flow