### PR TITLE
Pin cylc-flow back to `8.2.*`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     # bleeding-edge version.
     # NB: no graphene version specified; we only make light use of it in our
     # own code, so graphene-tornado's transitive version should do.
-    cylc-flow==8.3.*
+    cylc-flow==8.2.*
     ansimarkup>=1.0.0
     graphene
     graphene-tornado==2.6.*


### PR DESCRIPTION
Needed as we are releasing UIS 1.4.0 but not cylc-flow 8.3.0.

I've confirmed the tests pass locally with each of cylc-flow 8.2.0 and 8.2.1 checked out