### PR TITLE
check global config for hub url and

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,12 +12,6 @@ $ towncrier create <PR-number>.<break|feat|fix>.md --content "Short description"
 
 <!-- towncrier release notes start -->
 
-## cylc-uiserver-1.4.1
-### 🚀 Enhancements
-
-[#507](https://github.com/cylc/cylc-uiserver/pull/507) - Added functionality for routing to a multiuser deploymnet when running cylc gui command.
-
-
 ## cylc-uiserver-1.4.0 (Released 2023-09-12)
 
 ### 🚀 Enhancements

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,12 @@ $ towncrier create <PR-number>.<break|feat|fix>.md --content "Short description"
 
 <!-- towncrier release notes start -->
 
+## cylc-uiserver-1.4.1
+### 🚀 Enhancements
+
+[#507](https://github.com/cylc/cylc-uiserver/pull/507) - Added functionality for routing to a multiuser deploymnet when running cylc gui command.
+
+
 ## cylc-uiserver-1.4.0 (Released 2023-09-12)
 
 ### 🚀 Enhancements

--- a/changes.d/507.feat.md
+++ b/changes.d/507.feat.md
@@ -1,0 +1,1 @@
+Added functionality for routing to a multiuser deployment when running cylc gui command.

--- a/cylc/uiserver/scripts/gui.py
+++ b/cylc/uiserver/scripts/gui.py
@@ -74,7 +74,7 @@ def main(*argv):
                 and Jupyter Hub documentation for more details.
             '''))
         return
-    if '--help' not in sys.argv:
+    if not {'--help', '--help-all'} & set(sys.argv):
         if hub_url:
             print(f"Running on {hub_url } as specified in global config.")
             webbrowser.open(
@@ -218,7 +218,7 @@ def get_arg_parser():
 def update_url(url, workflow_id):
     """ Update the url to open at the correct workflow in the gui.
     """
-    GLOBAL_CONFIG = glbl_cfg().get(['hub', 'url'])
+    hub_url = glbl_cfg().get(['hub', 'url'])
     if not url:
         return
     split_url = url.split('/workspace/')
@@ -241,7 +241,7 @@ def update_url(url, workflow_id):
                 return url.replace(old_workflow, workflow_id)
         else:
             # current url points to dashboard, update to point to workflow
-            if GLOBAL_CONFIG:
+            if hub_url:
                 return (f"{url}/user/{getuser()}/{CylcUIServer.name}"
                         f"/#/workspace/{workflow_id}")
             else:

--- a/cylc/uiserver/scripts/gui.py
+++ b/cylc/uiserver/scripts/gui.py
@@ -55,9 +55,9 @@ CLI_OPT_NEW = "--new"
 
 def main(*argv):
     init_log()
-    GLOBAL_CONFIG = glbl_cfg().get(['hub', 'url'])
+    hub_url = glbl_cfg().get(['hub', 'url'])
     jp_server_opts, new_gui, workflow_id = parse_args_opts()
-    if '--help' in sys.argv and GLOBAL_CONFIG:
+    if '--help' in sys.argv and hub_url:
         print(
             dedent('''
                 cylc gui [WORKFLOW]
@@ -75,10 +75,10 @@ def main(*argv):
             '''))
         return
     if '--help' not in sys.argv:
-        if GLOBAL_CONFIG:
-            print(f"Running on {GLOBAL_CONFIG} as specified in global config.")
+        if hub_url:
+            print(f"Running on {hub_url } as specified in global config.")
             webbrowser.open(
-                update_url(GLOBAL_CONFIG, workflow_id), autoraise=True
+                update_url(hub_url, workflow_id), autoraise=True
             )
             return
         # get existing jpserver-<pid>-open.html files

--- a/cylc/uiserver/scripts/gui.py
+++ b/cylc/uiserver/scripts/gui.py
@@ -30,6 +30,7 @@ import re
 from requests.exceptions import RequestException
 import requests
 import sys
+from textwrap import dedent
 from typing import Optional
 import webbrowser
 from getpass import getuser
@@ -56,6 +57,23 @@ def main(*argv):
     init_log()
     GLOBAL_CONFIG = glbl_cfg().get(['hub', 'url'])
     jp_server_opts, new_gui, workflow_id = parse_args_opts()
+    if '--help' in sys.argv and GLOBAL_CONFIG:
+        print(
+            dedent('''
+                cylc gui [WORKFLOW]
+
+                Open the Cylc GUI in a new web browser tab.
+
+                If WORKFLOW is specified, the GUI will open on this workflow.
+
+                This command has been configured to use a centrally configured
+                Jupyter Hub instance rather than start a standalone server.
+                To see the configuration options for the server run
+                "cylc gui --help-all", these options can be configured in the
+                Jupyter configuration files using "c.Spawner.cmd", see the Cylc
+                and Jupyter Hub documentation for more details.
+            '''))
+        return
     if '--help' not in sys.argv:
         if GLOBAL_CONFIG:
             print(f"Running on {GLOBAL_CONFIG} as specified in global config.")

--- a/cylc/uiserver/tests/test_gui.py
+++ b/cylc/uiserver/tests/test_gui.py
@@ -28,10 +28,6 @@ from cylc.uiserver.scripts.gui import (
     update_url
 )
 
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
-GLOBAL_CONFIG = glbl_cfg().get(['hub', 'url'])
-
-
 @pytest.mark.parametrize(
     'existing_content,workflow_id,expected_updated_content,hub_url',
     [
@@ -92,8 +88,6 @@ def test_update_html_file_updates_gui_file(
         url = {hub_url}
         ''')
     updated_file_content = update_url(existing_content, workflow_id)
-    print('updated_file_content')
-    print(updated_file_content)
     assert updated_file_content == expected_updated_content
 
 

--- a/cylc/uiserver/tests/test_gui.py
+++ b/cylc/uiserver/tests/test_gui.py
@@ -20,7 +20,6 @@ from pathlib import Path
 import pytest
 from random import randint
 import requests
-from shutil import rmtree
 from time import sleep
 
 from cylc.uiserver.scripts.gui import (
@@ -29,48 +28,72 @@ from cylc.uiserver.scripts.gui import (
     update_url
 )
 
+from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+GLOBAL_CONFIG = glbl_cfg().get(['hub', 'url'])
+
+
 @pytest.mark.parametrize(
-    'existing_content,workflow_id,expected_updated_content',
+    'existing_content,workflow_id,expected_updated_content,hub_url',
     [
         pytest.param(
             'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#',
             None,
             'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#',
+            '',
             id='existing_no_workflow_new_no_workflow'
         ),
         pytest.param(
             'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#',
             'some/workflow',
             'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/workspace/some/workflow',
+            '',
             id='existing_no_workflow_new_workflow'
+        ),
+        pytest.param(
+            'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#',
+            'some/hub/workflow',
+            'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/user/mdawson/cylc/#/workspace/some/hub/workflow',
+            'localhost:8000',
+            id='existing_no_workflow_new_workflow_hub'
         ),
         pytest.param(
             'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/workspace/some/workflow',
             'another/flow',
             'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/workspace/another/flow',
+            '',
             id='existing_workflow_new_workflow'
         ),
         pytest.param(
             'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/workspace/some/workflow',
             None,
             'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#',
+            '',
             id='existing_workflow_no_new_workflow'
         ),
         pytest.param(
             '',
             'another/flow',
             None,
+            '',
             id='no_url_no_change'
         ),
     ]
 )
+
 def test_update_html_file_updates_gui_file(
     existing_content,
     workflow_id,
-        expected_updated_content):
+    expected_updated_content,
+    hub_url,
+    mock_glbl_cfg):
     """Tests url is updated correctly"""
-
+    mock_glbl_cfg('cylc.uiserver.scripts.gui.glbl_cfg', 
+        f'''[hub]
+        url = {hub_url}
+        ''')
     updated_file_content = update_url(existing_content, workflow_id)
+    print('updated_file_content')
+    print(updated_file_content)
     assert updated_file_content == expected_updated_content
 
 

--- a/cylc/uiserver/tests/test_gui.py
+++ b/cylc/uiserver/tests/test_gui.py
@@ -17,6 +17,7 @@ import builtins
 from glob import glob
 import os
 from pathlib import Path
+from getpass import getuser
 import pytest
 from random import randint
 import requests
@@ -48,7 +49,7 @@ from cylc.uiserver.scripts.gui import (
         pytest.param(
             'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#',
             'some/hub/workflow',
-            'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/user/mdawson/cylc/#/workspace/some/hub/workflow',
+            f'http://localhost:8892/cylc/?token=1234567890some_big_long_token1234567890#/user/{getuser()}/cylc/#/workspace/some/hub/workflow',
             'localhost:8000',
             id='existing_no_workflow_new_workflow_hub'
         ),


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-uiserver/issues/238

Uses hub url in global config (see https://github.com/cylc/cylc-flow/pull/5733) 
Existing testing needed to work with and without the global config parameter set - monkey patch used to change settings.
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present). **NA**
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch. **NA**
