### PR TITLE
used log_message in HttpError

### DIFF
--- a/cylc/uiserver/authorise.py
+++ b/cylc/uiserver/authorise.py
@@ -523,7 +523,7 @@ class AuthorizationMiddleware:
                        f":requested to {op_name}.")
         if message:
             log_message = log_message + " " + message
-        raise web.HTTPError(http_code, reason=message)
+        raise web.HTTPError(http_code, reason=log_message)
 
     def get_op_name(self, field_name: str, operation: str) -> Optional[str]:
         """


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-uiserver/issues/469

Previous error message
`tornado.web.HTTPError: HTTP 403: Forbidden`
New error message
`tornado.web.HTTPError: HTTP 403: Authorization failed for mdawson:requested to read.`

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
