### PR TITLE
Allow local logs for cat-log

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ below.
  - Mel Hall
  - Christopher Bennett
  - Mark Dawson
+ - Scott Wales
  <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -65,6 +65,7 @@ from pkg_resources import parse_version
 from tornado import ioloop
 from tornado.web import RedirectHandler
 from traitlets import (
+    Bool,
     Dict,
     Float,
     Int,
@@ -324,6 +325,13 @@ class CylcUIServer(ExtensionApp):
         ''',
         default_value=1
     )
+    force_remote_logs = Bool(
+        config=True,
+        help='''
+            Always use --force-remote with `cat-log`
+        ''',
+        default_value=True
+    )
 
     @validate('ui_build_dir')
     def _check_ui_build_dir_exists(self, proposed):
@@ -392,6 +400,7 @@ class CylcUIServer(ExtensionApp):
             log=self.log,
             executor=self.executor,
             workflows_mgr=self.workflows_mgr,
+            force_remote_logs=True,
         )
 
     def initialize_settings(self):

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -400,7 +400,7 @@ class CylcUIServer(ExtensionApp):
             log=self.log,
             executor=self.executor,
             workflows_mgr=self.workflows_mgr,
-            force_remote_logs=True,
+            force_remote_logs=self.config.CylcUIServer.force_remote_logs,
         )
 
     def initialize_settings(self):

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -369,7 +369,14 @@ class Services:
             await queue.put(line.decode())
 
     @classmethod
-    async def cat_log(cls, id_: Tokens, log, info, force_remote=True, file=None):
+    async def cat_log(
+            cls,
+            id_: Tokens,
+            log,
+            info,
+            force_remote=True,
+            file=None,
+            ):
         """Calls `cat log`.
 
         Used for log subscriptions.
@@ -593,7 +600,10 @@ class Resolvers(BaseResolvers):
         self,
         id_: Tokens,
     ):
-        return await Services.cat_log_files(id_, force_remote=self.force_remote_logs)
+        return await Services.cat_log_files(
+                id_,
+                force_remote=self.force_remote_logs
+                )
 
 
 def kill_process_tree(

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -374,9 +374,9 @@ class Services:
             id_: Tokens,
             log,
             info,
-            force_remote=True,
-            file=None,
-            ):
+            force_remote: bool = True,
+            file: Optional[str] = None,
+    ):
         """Calls `cat log`.
 
         Used for log subscriptions.
@@ -456,7 +456,7 @@ class Services:
             yield {'connected': False}
 
     @classmethod
-    async def cat_log_files(cls, id_: Tokens, force_remote):
+    async def cat_log_files(cls, id_: Tokens, force_remote: bool):
         """Calls cat log to get list of available log files.
 
         Note kept separate from the cat_log method above as this is a one off
@@ -505,6 +505,7 @@ class Resolvers(BaseResolvers):
         self.log = log
         self.workflows_mgr = workflows_mgr
         self.executor = executor
+        self.force_remote_logs = force_remote_logs
 
         # Set extra attributes
         for key, value in kwargs.items():
@@ -591,7 +592,7 @@ class Resolvers(BaseResolvers):
             ids[0],
             self.log,
             info,
-            file,
+            file=file,
             force_remote=self.force_remote_logs,
         ):
             yield ret
@@ -601,9 +602,9 @@ class Resolvers(BaseResolvers):
         id_: Tokens,
     ):
         return await Services.cat_log_files(
-                id_,
-                force_remote=self.force_remote_logs
-                )
+            id_,
+            force_remote=self.force_remote_logs
+        )
 
 
 def kill_process_tree(


### PR DESCRIPTION
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

Add a configuration item `c.CylcUIServer.force_remote_logs` defaulting to `True` (matching existing behaviour)

When `True`, `cat-log` will use the `--force-remote` option to always fetch from the remote Cylc server

When `False` logs will only be fetched if they are not present on the local server

Fixes #506 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
