### PR TITLE
Extend userprofile endpoint with all data on the current user from Jupyter Server

### DIFF
--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -39,6 +39,7 @@ from cylc.flow.scripts.cylc import (
 
 from cylc.uiserver.authorise import Authorization, AuthorizationMiddleware
 from cylc.uiserver.websockets import authenticated as websockets_authenticated
+
 if TYPE_CHECKING:
     from cylc.uiserver.resolvers import Resolvers
     from cylc.uiserver.websockets.tornado import TornadoSubscriptionServer

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -131,14 +131,16 @@ def get_usernames(handler: 'CylcAppHandler'):
     if is_token_authenticated(handler):
         # the bearer of the token has full privileges
         if ('.' in ME):
-            initials = ME.split('.')[0].upper() + ME.split('.')[1][0].upper()
+            first_inital = ME.split('.')[0][0].upper()
+            last_initial = ME.split('.')[1][0].upper()
+            initials = first_inital + last_initial
         else:
             initials = ME[0].upper()
         return {'name': ME, 'initials': initials, 'username': ME}
     else:
         return {
             'name': handler.current_user.username,
-            'initials': handler.current_user.initials,
+            'initials': '',
             'username': handler.current_user.username
         }
 

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -125,9 +125,8 @@ def _authorise(
 
 def get_initials(username: str):
     if ('.' in username):
-        first_inital = username.split('.')[0][0].upper()
-        last_initial = username.split('.')[1][0].upper()
-        return first_inital + last_initial
+        first, last = username.split('.', maxsplit=1)
+        return f"{first[0]}{last[0]}".upper()
     elif (username != ''):
         return username[0].upper()
     else:
@@ -144,10 +143,9 @@ def get_user_info(handler: 'CylcAppHandler'):
         # the bearer of the token has full privileges
         return {'name': ME, 'initials': get_initials(ME), 'username': ME}
     else:
-        if (handler.current_user.initials):
-            initials = handler.current_user.initials
-        else:
-            initials = get_initials(handler.current_user.username)
+        initials = handler.current_user.initials or get_initials(
+            handler.current_user.username
+        )
         return {
             'name': handler.current_user.name,
             'initials': initials,

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -131,12 +131,16 @@ def get_usernames(handler: 'CylcAppHandler'):
     if is_token_authenticated(handler):
         # the bearer of the token has full privileges
         if ('.' in ME):
-            initials = ME.split('.')[0].upper()+ME.split('.')[1][0].upper()
+            initials = ME.split('.')[0].upper() + ME.split('.')[1][0].upper()
         else:
             initials = ME[0].upper()
         return {'name': ME, 'initials': initials, 'username': ME}
     else:
-        return {'name': handler.current_user.username, 'initials': handler.current_user.initials, 'username': handler.current_user.username}
+        return {
+            'name': handler.current_user.username,
+            'initials': handler.current_user.initials,
+            'username': handler.current_user.username
+        }
 
 
 class CylcAppHandler(JupyterHandler):

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -256,13 +256,10 @@ class UserProfileHandler(CylcAppHandler):
     @web.authenticated
     # @authorised  TODO: I can't think why we would want to authorise this
     def get(self):
-        user_info = dict(self.current_user.__dict__)
-
-        user_details = get_usernames(self)
-
-        user_info['name'] = user_details['name']
-        user_info['initials'] = user_details['initials']
-        user_info['username'] = user_details['username']
+        user_info = {
+            **self.current_user.__dict__,
+            **get_usernames(self)
+        }
 
         # add an entry for the workflow owner
         # NOTE: when running behind a hub this may be different from the

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -246,9 +246,9 @@ class UserProfileHandler(CylcAppHandler):
     @web.authenticated
     # @authorised  TODO: I can't think why we would want to authorise this
     def get(self):
-        user_info = {
-            'name': get_username(self)
-        }
+        user_info = dict(self.current_user.__dict__)
+
+        user_info['name'] = get_username(self)
 
         # add an entry for the workflow owner
         # NOTE: when running behind a hub this may be different from the


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-ui/issues/1504

Extends the userprofile endpoint to provide all the fields on current_user. 
This is required for https://github.com/cylc/cylc-ui/pull/1505

## Available data

### Available data Single user mode
In single user mode the user is authenticated with a bearer token. Inside the UserProfileHandler a function ```is_token_authenticated``` will return True.
In this case jupyter server knows no info about the user, so handler.current_user is populated with values that are not helpful:

```
display_name = "Anonoymous Herse"
username = "ae5071....."
name = Anonoymous Herse"
initials = "AH"
````
### Available data Multi user / hub mode
In multiuser (hub) mode the user provides a username and password to the server for auth. Inside the UserProfileHandler a function```is_token_authenticated``` will return False. In this case the jupyter server knows the users username so uses that for populating handler.current_user.

```
display_name = "mdawson"
username = "mdawson"
name = "mdawson"
initials = none
````
Note: initials set to none

This is what we have to work with to try and send some useful data back to the ```/user-profile/``` endpoint.

## The approach

The username used for hub login depends on how jupyterhub is configured and can potentially accept more than one value. For example ```jsmith``` and ```john.smith@uni.ac.uk``` may both be valid.

An alternative method for attaining a name for the user is to get it from the operating system using getpass (```ME = getpass.getuser()```) .

### Approach for Multi user / hub mode
Use the username that can be accessed through jupyter on ```handler.current_user```. 
Calculate a value for the initials field.

###  Approach for Single user
Get a username from the OS
Calculate a value for the initials field.

## Example responses

<!--- If not authenticated

```
username	"ae507119171a4306bb631b4b01d5ed82"
name	"ae507119171a4306bb631b4b01d5ed82"
display_name	"Anonymous Herse"
initials	""
```
-->

If authenticated and have a ```.``` in username
```
username	"m.dawson"
name	"m.dawson"
display_name	"Anonymous Herse"
initials	"MD"
```

If authenticated and **dont** have a ```.``` in username
```
username	"mdawson"
name	"mdawson"
display_name	"Anonymous Herse"
initials	"M"
```
https://jupyter-server.readthedocs.io/en/latest/operators/security.html#jupyter_server.auth.User
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed). - **See comment**
- [x] `CHANGES.md` entry included if this is a change that can affect users - **Not added but can do if required?**
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
