### PR TITLE
GH Actions: use branch sync workflow

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,27 @@
+# Codecov settings
+# After modifying this file, you can validate it, see https://api.codecov.io/validate
+
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  # define the colour bar limits here (red...green)
+  range: "75...100"
+
+  # diff type
+  status:
+    project:
+      default:
+        # fail if coverage below this:
+        target: '85%'
+        # fail if coverage drops by this much:
+        threshold: '2%'
+    patch:
+      default:
+        target: '85%'
+
+# turn off comments to pull requests
+comment: false

--- a/.github/workflows/branch_sync.yml
+++ b/.github/workflows/branch_sync.yml
@@ -1,0 +1,20 @@
+name: Sync PR
+
+on:
+  push:
+    branches:
+      - '*.*.x'
+  schedule:
+    - cron: '49 03 * * 1-5' # 03:49 UTC Mon-Fri
+  workflow_dispatch:
+    inputs:
+      head_branch:
+        description: Branch to merge into master
+        required: true
+
+jobs:
+  sync:
+    uses: cylc/release-actions/.github/workflows/branch-sync.yml@v1
+    with:
+      head_branch: ${{ inputs.head_branch }}
+    secrets: inherit


### PR DESCRIPTION
Also turn off codecov comments. I've requested the Codecov app be added to this repo so we get it as CI checks instead, but it might need @hjoliver to approve that