### PR TITLE
`cylc play` service: don't unset `$CYLC_ENV_NAME` if no version specified

### DIFF
--- a/changes.d/533.fix.md
+++ b/changes.d/533.fix.md
@@ -1,0 +1,1 @@
+Fixed bug introduced in 1.4.2 where playing a workflow would fail if using a Cylc environment whose name does not match `cylc-8.X.Y` exactly.

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -300,8 +300,8 @@ class Services:
                 log.info(f'$ {cmd_repr}')
 
                 env = os.environ.copy()
-                env.pop('CYLC_ENV_NAME', None)
                 if cylc_version:
+                    env.pop('CYLC_ENV_NAME', None)
                     env['CYLC_VERSION'] = cylc_version
 
                 # run cylc play

--- a/cylc/uiserver/tests/test_resolvers.py
+++ b/cylc/uiserver/tests/test_resolvers.py
@@ -78,6 +78,14 @@ def test_Services_anciliary_methods(func, message, expect):
             {'CYLC_VERSION': 'top'},
             id="cylc version overrides env"
         ),
+        pytest.param(
+            [Tokens('wflow1')],
+            {},
+            {'CYLC_VERSION': 'charm', 'CYLC_ENV_NAME': 'quark'},
+            [True, "Workflow(s) started"],
+            {'CYLC_VERSION': 'charm', 'CYLC_ENV_NAME': 'quark'},
+            id="cylc env not overriden if no version specified"
+        ),
     ]
 )
 async def test_play(
@@ -97,6 +105,9 @@ async def test_play(
         expected_ret: expected return value
         expected_env: any expected environment variables
     """
+    monkeypatch.delenv('CYLC_ENV_NAME', raising=False)
+    expected_env = {**os.environ, **expected_env}
+
     for k, v in env.items():
         monkeypatch.setenv(k, v)
     monkeypatch.setattr('cylc.uiserver.resolvers.getuser', lambda: 'murray')
@@ -117,9 +128,6 @@ async def test_play(
     )
 
     assert ret == expected_ret
-
-    expected_env = {**os.environ, **expected_env}
-    expected_env.pop('CYLC_ENV_NAME', None)
 
     for i, call_args in enumerate(mock_popen.call_args_list):
         cmd_str = ' '.join(call_args.args[0])


### PR DESCRIPTION
Follow-up to #525

Unfortunately it broke ~job submission~ `cylc play` if you were using a ~non-standard Cylc environment name (i.e. not `cylc-8.X.Y`)~ Cylc environment name that didn't match `cylc-8.X.Y` exactly, and didn't specify a version in the `cylc play`-edit form

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included 
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
