### PR TITLE
graphql-ws: optimise the "resolve" routine

### DIFF
--- a/changes.d/548.feat.md
+++ b/changes.d/548.feat.md
@@ -1,0 +1,1 @@
+Improve the performance of the GraphQL server.

--- a/cylc/uiserver/websockets/resolve.py
+++ b/cylc/uiserver/websockets/resolve.py
@@ -27,7 +27,8 @@ found in the graphql-ws library with the above license.
 This is temporary code until the change makes its way upstream.
 """
 
-# NOTE: transient dependency from graphql-ws not
+# NOTE: transient dependency from graphql-ws purposefully not
+# reflected in cylc-uiserver dependencies 
 from promise import Promise
 
 from graphql_ws.base_async import is_awaitable
@@ -39,7 +40,7 @@ async def resolve(
     _key=None,
 ):
     """
-    Recursively wait on any awaitable children of a data element and resolve
+    Wait on any awaitable children of a data element and resolve
     any Promises.
     """
     stack = [(data, _container, _key)]

--- a/cylc/uiserver/websockets/resolve.py
+++ b/cylc/uiserver/websockets/resolve.py
@@ -28,7 +28,7 @@ This is temporary code until the change makes its way upstream.
 """
 
 # NOTE: transient dependency from graphql-ws purposefully not
-# reflected in cylc-uiserver dependencies 
+# reflected in cylc-uiserver dependencies
 from promise import Promise
 
 from graphql_ws.base_async import is_awaitable

--- a/cylc/uiserver/websockets/resolve.py
+++ b/cylc/uiserver/websockets/resolve.py
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2017, Syrus Akbary
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+This file contains an implementation of "resolve" derived from the one
+found in the graphql-ws library with the above license.
+
+This is temporary code until the change makes its way upstream.
+"""
+
+# NOTE: transient dependency from graphql-ws not
+from promise import Promise
+
+from graphql_ws.base_async import is_awaitable
+
+
+async def resolve(
+    data,
+    _container=None,
+    _key=None,
+):
+    """
+    Recursively wait on any awaitable children of a data element and resolve
+    any Promises.
+    """
+    stack = [(data, _container, _key)]
+
+    while stack:
+        _data, _container, _key = stack.pop()
+
+        if is_awaitable(_data):
+            _data = await _data
+            if isinstance(_data, Promise):
+                _data = _data.value
+            if _container is not None:
+                _container[_key] = _data
+        if isinstance(_data, dict):
+            items = _data.items()
+        elif isinstance(_data, list):
+            items = enumerate(_data)
+        else:
+            items = None
+        if items is not None:
+            stack.extend([
+                (child, _data, key)
+                for key, child in items
+            ])

--- a/cylc/uiserver/websockets/tornado.py
+++ b/cylc/uiserver/websockets/tornado.py
@@ -15,7 +15,6 @@ from tornado.websocket import WebSocketClosedError
 from graphql.execution.middleware import MiddlewareManager
 from graphql_ws.base import ConnectionClosedException
 from graphql_ws.base_async import (
-    resolve,
     BaseAsyncConnectionContext,
     BaseAsyncSubscriptionServer
 )
@@ -29,6 +28,9 @@ from graphql_ws.constants import (
 from typing import Union, Awaitable, Any, List, Tuple, Dict, Optional
 
 from cylc.uiserver.authorise import AuthorizationMiddleware
+from cylc.uiserver.websockets.resolve import resolve
+
+
 setup_observable_extension()
 
 NO_MSG_DELAY = 1.0


### PR DESCRIPTION
* Partially address
* The resolve routine is implmented recursively in the graphql-ws library.
* Because the function is async this results in a large number of async tasks being created when the library is used with large, deeply nested schema.
* Async tasks have an overhead, above that of regular function calls.
* For the example in https://github.com/cylc/cylc-uiserver/issues/547 this resulted in over 10 seconds of overheads.

Results **96% saving!**:
* Before (`base_async.resolve`):
  * cumtime: 11.24s
  * calls: 268'053
* After: (`resolve.resolve`):
  * cumtime - 0.3965s
  * calls: 24

Suggest adding this routine to the cylc-uiserver library for now as the graphql-ws library is not currently maintained (see #333).

The original implementation can be found here: https://github.com/graphql-python/graphql-ws/blob/7ef25ecfaf5390bf1a0cb4023272d8cb074368c2/graphql_ws/base_async.py#L37-L62

TODO:
* [x] Reviewers, please replicate profiling results.
* [x] Changelog entry.
* [x] License legal stuff.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
