### PR TITLE
authorisation: allow jupyter lab to work in standalone mode

### DIFF
--- a/changes.d/558.fix.md
+++ b/changes.d/558.fix.md
@@ -1,0 +1,1 @@
+Permit Jupyter Lab to be run in the same Jupyter Server instance as the Cylc UI Server in standalone mode (i.e. via `cylc gui`), note it was already possible to do this in multi-user mode (i.e. via `cylc hub`).

--- a/changes.d/570.fix.md
+++ b/changes.d/570.fix.md
@@ -1,0 +1,1 @@
+Fix an issue that could impose a low limit on the number of active workflows the server is able to track.

--- a/cylc/uiserver/authorise.py
+++ b/cylc/uiserver/authorise.py
@@ -28,6 +28,7 @@ from tornado import web
 from traitlets.config.loader import LazyConfigValue
 
 from cylc.uiserver.schema import UISMutations
+from cylc.uiserver.utils import is_bearer_token_authenticated
 
 
 class CylcAuthorizer(Authorizer):
@@ -82,6 +83,11 @@ class CylcAuthorizer(Authorizer):
         Note that Cylc uses its own authorization system (which is locked-down
         by default) and is not affected by this policy.
         """
+        if is_bearer_token_authenticated(handler):
+            # this session is authenticated by a token or password NOT by
+            # Jupyter Hub -> the bearer of the token has full permissions
+            return True
+
         # the username of the user running this server
         # (used for authorzation purposes)
         me = getuser()

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -211,7 +211,7 @@ def mock_authentication_yossarian(monkeypatch):
         user,
     )
     monkeypatch.setattr(
-        'cylc.uiserver.handlers.is_token_authenticated',
+        'cylc.uiserver.handlers.is_bearer_token_authenticated',
         lambda x: True,
     )
 

--- a/cylc/uiserver/utils.py
+++ b/cylc/uiserver/utils.py
@@ -14,6 +14,35 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from typing import TYPE_CHECKING
+
+from jupyter_server.auth.identity import PasswordIdentityProvider
+
+if TYPE_CHECKING:
+    from cylc.uiserver.handlers import CylcAppHandler
+    from jupyter_server.auth.identity import (
+        IdentityProvider as JPSIdentityProvider,
+    )
+
+
+def is_bearer_token_authenticated(handler: 'CylcAppHandler') -> bool:
+    """Returns True if this request is bearer token authenticated.
+
+    Bearer tokens, e.g. tokens (?token=1234) and passwords, are short pieces of
+    text that are used for authentication. These can be used in single-user
+    mode (i.e. "cylc gui"). In these cases the bearer of the token is awarded
+    full privileges.
+
+    In multi-user mode, we have more advanced authentication based on an
+    external service which allows us to implement fine-grained authorisation.
+    """
+    identity_provider: 'JPSIdentityProvider' = (
+        handler.serverapp.identity_provider  # type: ignore[union-attr]
+    )
+    return identity_provider.__class__ == PasswordIdentityProvider
+    # NOTE: not using isinstance to narrow this down to just the one class
+
+
 def _repr(value):
     if isinstance(value, dict):
         return '<dict>'


### PR DESCRIPTION
Closes #556 

Jupyter Lab authorisation is open by default, a curious choice, safe for regular usage, but it becomes a security hole when deploying via Jupyter Hub and allowing users to see each other's servers.

Since this is key to Cylc Hub deployment, and we don't want our users accidentally opening security holes (Cylc must have safe, sane and secure defaults), we override the default security policy to only authorizing the server owner to access Jupyter Lab.

Unfortunately, I forgot to add a necessary backdoor to this policy for token authenticated sessions (i.e. sessions that are not run through Jupyter Hub) where the bearer of the token has full permission over the server.

This means that at present, Jupyter Lab is blocked by default when the Cylc UI Server is launched as a token authenticated (i.e. standalone) server. This PR reinstates access for this situation and this situation only.

* [x] Requires through security testing both in standalone mode and multi-user mode.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (manual security testing required).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.