### PR TITLE
Fix sphinx autodoc warning

### DIFF
--- a/cylc/uiserver/authorise.py
+++ b/cylc/uiserver/authorise.py
@@ -77,6 +77,7 @@ class CylcAuthorizer(Authorizer):
     """
 
     # This is here just to fix sphinx autodoc warning from traitlets' __init__
+    # see https://github.com/cylc/cylc-uiserver/pull/560
     def __init__(*args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/cylc/uiserver/authorise.py
+++ b/cylc/uiserver/authorise.py
@@ -76,6 +76,10 @@ class CylcAuthorizer(Authorizer):
 
     """
 
+    # This is here just to fix sphinx autodoc warning from traitlets' __init__
+    def __init__(*args, **kwargs):
+        super().__init__(*args, **kwargs)
+
     def is_authorized(self, handler, user, action, resource) -> bool:
         """Allow a user to access their own server.
 


### PR DESCRIPTION
Workaround https://github.com/sphinx-doc/sphinx/issues/10151#issuecomment-1540802189

`CylcAuthorizer` inherits from `trailets.Configurable`. The problem is:

> In their code, they do `import typing as t` and they call `t.Any`, `t.Dict`, etc...
> 
> then when I compile my docs I see warnings as
> 
> `WARNING: py:class reference target not found: t.Any`

If there was some way of disabling the autodoc'ing of (just) `CylcAuthorizer`'s params in cylc-doc I would have gone for that, but I couldn't find any way. 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests are not needed
- [x] No `CHANGES.md` entry needed
- [x] https://github.com/cylc/cylc-doc/pull/686
