### PR TITLE
data store mgr: Increase the max number of workflows to 100

### DIFF
--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -324,6 +324,16 @@ class CylcUIServer(ExtensionApp):
         ''',
         default_value=1
     )
+    max_threads = Int(
+        config=True,
+        help='''
+            Set the maximum number of threads the Cylc UI Server can use.
+
+            This determines the maximum number of active workflows that the
+            server can track.
+        ''',
+        default_value=100,
+    )
 
     @validate('ui_build_dir')
     def _check_ui_build_dir_exists(self, proposed):
@@ -384,7 +394,11 @@ class CylcUIServer(ExtensionApp):
         super().__init__(*args, **kwargs)
         self.executor = ProcessPoolExecutor(max_workers=self.max_workers)
         self.workflows_mgr = WorkflowsManager(self, log=self.log)
-        self.data_store_mgr = DataStoreMgr(self.workflows_mgr, self.log)
+        self.data_store_mgr = DataStoreMgr(
+            self.workflows_mgr,
+            self.log,
+            self.max_threads,
+        )
         # sub_status dictionary storing status of subscriptions
         self.sub_statuses = {}
         self.resolvers = Resolvers(

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -73,21 +73,37 @@ def log_call(fcn):
 
 
 class DataStoreMgr:
-    """Manage the local data-store acquisition/updates for all workflows."""
+    """Manage the local data-store acquisition/updates for all workflows.
+
+    Args:
+        workflows_mgr:
+            Service that scans for workflows.
+        log:
+            Application logger.
+        max_threads:
+            Max number of threads to use for subscriptions.
+
+            Note, this determines the maximum number of active workflows that
+            can be updated.
+
+            This should be overridden for real use in the UIS app. The
+            default is here for test purposes.
+
+    """
 
     INIT_DATA_WAIT_TIME = 5.  # seconds
     INIT_DATA_RETRY_DELAY = 0.5  # seconds
     RECONCILE_TIMEOUT = 5.  # seconds
     PENDING_DELTA_CHECK_INTERVAL = 0.5
 
-    def __init__(self, workflows_mgr, log):
+    def __init__(self, workflows_mgr, log, max_threads=10):
         self.workflows_mgr = workflows_mgr
         self.log = log
         self.data = {}
         self.w_subs: Dict[str, WorkflowSubscriber] = {}
         self.topics = {ALL_DELTAS.encode('utf-8'), b'shutdown'}
         self.loop = None
-        self.executor = ThreadPoolExecutor()
+        self.executor = ThreadPoolExecutor(max_threads)
         self.delta_queues = {}
 
     @log_call


### PR DESCRIPTION
* Workaround for #569

Easy way to test:
* Launch a bunch of workflows.
* Run `cylc pause '*'`.
* The workflows that are being updated will change state to paused, the ones which aren't will stay as running.

Try adjusting the max_threads value to a lower number.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.