### PR TITLE
data store: remove threading

### DIFF
--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -32,11 +32,11 @@ Subscriptions are currently run in a different thread (via ThreadPoolExecutor).
 """
 
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
+from functools import wraps
 from pathlib import Path
 import time
-from typing import Dict, Optional, Set
+from typing import Dict, Optional, Set, NamedTuple
 
 from cylc.flow.exceptions import WorkflowStopped
 from cylc.flow.id import Tokens
@@ -72,6 +72,34 @@ def log_call(fcn):
     return _inner
 
 
+def call_to_tuple(fcn):
+    """Turns function calls into an (args, kwargs) tuple.
+
+    Examples:
+        >>> xargs(list)(1, 2, a=3, b=4)
+        [(1, 2), {'a': 3, 'b': 4}]
+
+    """
+    @wraps(fcn)
+    def _inner(*args, **kwargs):
+        nonlocal fcn
+        return fcn((args, kwargs))
+
+    return _inner
+
+
+class Subscriber(NamedTuple):
+    """Represents an active subscription.
+
+    Args:
+        subscriber: The subscriber client object.
+        task: The asyncio task running the client.
+
+    """
+    subscriber: WorkflowSubscriber
+    task: asyncio.Task
+
+
 class DataStoreMgr:
     """Manage the local data-store acquisition/updates for all workflows.
 
@@ -80,14 +108,6 @@ class DataStoreMgr:
             Service that scans for workflows.
         log:
             Application logger.
-        max_threads:
-            Max number of threads to use for subscriptions.
-
-            Note, this determines the maximum number of active workflows that
-            can be updated.
-
-            This should be overridden for real use in the UIS app. The
-            default is here for test purposes.
 
     """
 
@@ -96,15 +116,34 @@ class DataStoreMgr:
     RECONCILE_TIMEOUT = 5.  # seconds
     PENDING_DELTA_CHECK_INTERVAL = 0.5
 
-    def __init__(self, workflows_mgr, log, max_threads=10):
+    def __init__(self, workflows_mgr, log):
         self.workflows_mgr = workflows_mgr
         self.log = log
         self.data = {}
-        self.w_subs: Dict[str, WorkflowSubscriber] = {}
+        self.subscribers: Dict[str, Subscriber] = {}
         self.topics = {ALL_DELTAS.encode('utf-8'), b'shutdown'}
-        self.loop = None
-        self.executor = ThreadPoolExecutor(max_threads)
         self.delta_queues = {}
+        self.message_queue = asyncio.Queue()
+
+    def startup(self):
+        """Start the data store manager.
+
+        Note: Call this after the asyncio event loop has been opened.
+        """
+        self.message_processor_task = asyncio.create_task(
+            self._process_message_queues()
+        )
+
+    def shutdown(self):
+        """Stop the data store manager.
+
+        This will stop any active subscribers.
+
+        Note: It will not wait for pending messages to be processed.
+        """
+        for w_id in self.subscribers:
+            self._stop_subscription(w_id)
+            self.message_processor_task.cancel()
 
     @log_call
     async def register_workflow(self, w_id: str, is_active: bool) -> None:
@@ -152,23 +191,17 @@ class DataStoreMgr:
         blocking the main loop.
 
         """
-        if self.loop is None:
-            self.loop = asyncio.get_running_loop()
-
         # don't sync if subscription exists
-        if w_id in self.w_subs:
+        if w_id in self.subscribers:
             return
 
         self.delta_queues[w_id] = {}
 
-        # Might be options other than threads to achieve
-        # non-blocking subscriptions, but this works.
-        self.executor.submit(
-            self._start_subscription,
+        self._start_subscription(
             w_id,
             contact_data['name'],
             contact_data[CFF.HOST],
-            contact_data[CFF.PUBLISH_PORT]
+            contact_data[CFF.PUBLISH_PORT],
         )
         successful_updates = await self._entire_workflow_update(ids=[w_id])
 
@@ -204,9 +237,7 @@ class DataStoreMgr:
                 status=WorkflowStatus.STOPPED.value,
                 status_msg=disconnect_msg,
             )
-        if w_id in self.w_subs:
-            self.w_subs[w_id].stop()
-            del self.w_subs[w_id]
+        self._stop_subscription(w_id)
 
     def get_workflows(self):
         """Return all workflows the data store is currently tracking.
@@ -237,36 +268,61 @@ class DataStoreMgr:
         if w_id in self.delta_queues:
             del self.delta_queues[w_id]
 
-    def _start_subscription(self, w_id, reg, host, port):
+    def _start_subscription(self, w_id: str, reg: str, host: str, port: int):
         """Instantiate and run subscriber data-store sync.
 
         Args:
-            w_id (str): Workflow external ID.
-            reg (str): Registered workflow name.
-            host (str): Hostname of target workflow.
-            port (int): Port of target workflow.
+            w_id: Workflow external ID.
+            reg: Registered workflow name.
+            host: Hostname of target workflow.
+            port: Port of target workflow.
 
         """
-        self.w_subs[w_id] = WorkflowSubscriber(
+        subscriber = WorkflowSubscriber(
             reg,
             host=host,
             port=port,
             context=self.workflows_mgr.context,
-            topics=self.topics
+            topics=self.topics,
         )
-        self.w_subs[w_id].loop.run_until_complete(
-            self.w_subs[w_id].subscribe(
+        subscriber_task = asyncio.create_task(
+            subscriber.subscribe(
                 process_delta_msg,
-                func=self._update_workflow_data,
-                w_id=w_id))
+                func=call_to_tuple(self.message_queue.put_nowait),
+                w_id=w_id,
+            )
+        )
+        self.subscribers[w_id] = Subscriber(subscriber, subscriber_task)
 
-    def _update_workflow_data(self, topic, delta, w_id):
+    def _stop_subscription(self, w_id: str) -> None:
+        """Stop an active subscription.
+
+        Args:
+            w_id: Workflow external ID.
+
+        """
+        if w_id in self.subscribers:
+            self.subscribers[w_id].subscriber.stop()
+            del self.subscribers[w_id]
+
+    async def _process_message_queues(self):
+        """Wait for new messages, call the update method then they arrive."""
+        while True:
+            args, kwargs = await self.message_queue.get()
+            await self._update_workflow_data(*args, **kwargs)
+
+    async def _update_workflow_data(
+        self,
+        topic: str,
+        delta,
+        w_id: str,
+    ) -> None:
         """Manage and apply incoming data-store deltas.
 
         Args:
-            topic (str): topic of published data.
-            delta (object): Published protobuf message data container.
-            w_id (str): Workflow external ID.
+            topic: topic of published data.
+            delta: Published protobuf message data container.
+            w_id: Workflow external ID.
 
         """
         # wait until data-store is populated for this workflow
@@ -275,7 +331,7 @@ class DataStoreMgr:
             while loop_cnt < self.INIT_DATA_WAIT_TIME:
                 if w_id in self.data:
                     break
-                time.sleep(self.INIT_DATA_RETRY_DELAY)
+                await asyncio.sleep(self.INIT_DATA_RETRY_DELAY)
                 loop_cnt += 1
                 continue
         if topic == 'shutdown':
@@ -351,7 +407,6 @@ class DataStoreMgr:
                         'pb_data_elements',
                         args={'element_type': topic}
                     ),
-                    self.loop
                 )
                 new_delta_msg = future.result(self.RECONCILE_TIMEOUT)
                 new_delta = DELTAS_MAP[topic]()


### PR DESCRIPTION
Closes #194

Run subscribers via asyncio rather than the ThreadPoolExecutor.

I think the only non-blocking operations in the code being called were:
- time.sleep  (has an async variant)
- asyncio.sleep (async)
- self.socket.recv_multipart (async)

If so, I don't think we need to use threading here so I've refactored the code so that the underlying async functions could be called via asyncio.

If so, this cuts out the need for the `ThreadPoolExecutor` removing the workflow limit.

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
