### PR TITLE
GH Actions: fix sync PRs not happening on push?

### DIFF
--- a/.github/workflows/branch_sync.yml
+++ b/.github/workflows/branch_sync.yml
@@ -3,7 +3,7 @@ name: Sync PR
 on:
   push:
     branches:
-      - '*.*.x'
+      - '[0-9]+.[0-9]+.x'
   schedule:
     - cron: '49 03 * * 1-5' # 03:49 UTC Mon-Fri
   workflow_dispatch:


### PR DESCRIPTION
Maybe there is a bug in using multiple `*`? There are no occurrences of the sync workflow being triggered by push in the history: https://github.com/cylc/cylc-uiserver/actions/workflows/branch_sync.yml

