### PR TITLE
GH Actions: add branch sync workflow from master

### DIFF
--- a/.github/workflows/branch_sync.yml
+++ b/.github/workflows/branch_sync.yml
@@ -1,0 +1,20 @@
+name: Sync PR
+
+on:
+  push:
+    branches:
+      - '*.*.x'
+  schedule:
+    - cron: '49 03 * * 1-5' # 03:49 UTC Mon-Fri
+  workflow_dispatch:
+    inputs:
+      head_branch:
+        description: Branch to merge into master
+        required: true
+
+jobs:
+  sync:
+    uses: cylc/release-actions/.github/workflows/branch-sync.yml@v1
+    with:
+      head_branch: ${{ inputs.head_branch }}
+    secrets: inherit


### PR DESCRIPTION
There are no occurrences of the sync workflow being triggered by push in the history: https://github.com/cylc/cylc-uiserver/actions/workflows/branch_sync.yml

I think this is because the workflow did not exist on the 1.4.x branch
