### PR TITLE
config: configure default websocket ping interval

### DIFF
--- a/changes.d/586.feat.md
+++ b/changes.d/586.feat.md
@@ -1,0 +1,7 @@
+The UI Server is now configured to regularly ping active clients to ensure they
+are alive. This helps the server to detect closed connections sooner, it also
+ensures that open connections do not appear idle to proxy servers which are
+sometimes configured to kill websockets after a period of inactivity.
+You can override or modify this behaviour in your jupyter configuration using
+the `websocket_ping_interval` and `websocket_ping_timeout` configurations, see
+the Jupyter Server reference for more information.

--- a/cylc/uiserver/jupyter_config.py
+++ b/cylc/uiserver/jupyter_config.py
@@ -55,6 +55,10 @@ c.JupyterHub.template_paths = [
     )
 ]
 
+# configure websocket pings (helps to detect client-closed connections)
+c.ServerApp.websocket_ping_interval = 10
+c.ServerApp.websocket_ping_timeout = 10
+
 # store JupyterHub runtime files in the user config directory
 USER_CONF_ROOT.mkdir(parents=True, exist_ok=True)
 c.JupyterHub.cookie_secret_file = f'{USER_CONF_ROOT / "cookie_secret"}'

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     graphene
     graphene-tornado==2.6.*
     graphql-ws==0.4.4
-    jupyter_server>=2.7
+    jupyter_server>=2.13.0
     requests
     psutil
     tornado>=6.1.0  # matches jupyter_server value


### PR DESCRIPTION
* Closes #557
* Sends regular pings to websocket clients to ensure that the connection is still active and open at the other end.
* This allows for earlier detection of client-side connection closing.
* It should also circumnavigate web proxy killing of idle websockets.

To review, you might want to jam a debugger into this method:

https://github.com/tornadoweb/tornado/blob/f399f40fde0ae1b130646db783a6f79cc59231b2/tornado/websocket.py#L1540-L1557

Or mess around with the ping timeout.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included - tornado functionality vendored by jupyter_server, not something for us to test
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.