### PR TITLE
Revert "Upper pin pytest"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,7 @@ tests =
     mypy>=0.900
     pytest-cov>=2.8.0
     pytest-tornasync>=0.5.0
-    pytest>=6,!=8.2.1
+    pytest>=6
     towncrier>=23
     types-pkg_resources>=0.1.2
     types-requests>2

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,7 @@ tests =
     mypy>=0.900
     pytest-cov>=2.8.0
     pytest-tornasync>=0.5.0
-    pytest>=6
+    pytest>=6,!=8.2.1
     towncrier>=23
     types-pkg_resources>=0.1.2
     types-requests>2

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,8 +100,7 @@ tests =
     mypy>=0.900
     pytest-cov>=2.8.0
     pytest-tornasync>=0.5.0
-    # https://github.com/pytest-dev/pytest/issues/12263
-    pytest>=6,<8.2
+    pytest>=6
     towncrier>=23
     types-pkg_resources>=0.1.2
     types-requests>2


### PR DESCRIPTION
Reverts cylc/cylc-uiserver#588 which is no longer required: https://github.com/pytest-dev/pytest-asyncio/issues/706#issuecomment-2082788963