### PR TITLE
Don't protect static assets from XSRF

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ below.
  - Mel Hall
  - Christopher Bennett
  - Mark Dawson
+ - Min RK
  <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/changes.d/592.fix
+++ b/changes.d/592.fix
@@ -1,0 +1,1 @@
+Compatibility with JupyterHub 4.1 XSRF changes for static requests

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -184,6 +184,10 @@ class CylcStaticHandler(CylcAppHandler, web.StaticFileHandler):
     def initialize(self, *args, **kwargs):
         return web.StaticFileHandler.initialize(self, *args, **kwargs)
 
+    def check_xsrf_cookie(self):
+        # don't need XSRF protections on static assets
+        return
+
     @web.authenticated
     def get(self, path):
         # authenticate the static handler

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -192,10 +192,15 @@ class CylcStaticHandler(CylcAppHandler, web.StaticFileHandler):
     def get(self, path):
         # authenticate the static handler
         # this provides us with login redirection and token caching
-        # accessing xsrf_token ensures xsrf cookie is set if it needs to be,
-        # e.g. setting it during request for /index.html
-        # to be available for next request to /userprofile
-        self.xsrf_token  # noqa
+        if not path:
+            # Request for /index.html
+            # Accessing xsrf_token ensures xsrf cookie is set
+            # to be available for next request to /userprofile
+            self.xsrf_token
+            # Ensure request goes through this method even when cached so
+            # that the xsrf cookie is set on new browser sessions
+            # (doesn't prevent browser storing the response):
+            self.set_header('Cache-Control', 'no-cache')
         return web.StaticFileHandler.get(self, path)
 
 

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -193,7 +193,8 @@ class CylcStaticHandler(CylcAppHandler, web.StaticFileHandler):
         # authenticate the static handler
         # this provides us with login redirection and token caching
         # accessing xsrf_token ensures xsrf cookie is set if it needs to be,
-        # e.g. setting it during request for /index.html to be available for next request to /userprofile
+        # e.g. setting it during request for /index.html
+        # to be available for next request to /userprofile
         self.xsrf_token  # noqa
         return web.StaticFileHandler.get(self, path)
 

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -192,6 +192,9 @@ class CylcStaticHandler(CylcAppHandler, web.StaticFileHandler):
     def get(self, path):
         # authenticate the static handler
         # this provides us with login redirection and token caching
+        # accessing xsrf_token ensures xsrf cookie is set if it needs to be,
+        # e.g. setting it during request for /index.html to be available for next request to /userprofile
+        self.xsrf_token  # noqa
         return web.StaticFileHandler.get(self, path)
 
 


### PR DESCRIPTION
JupyterHub 4.1 applies XSRF checks to authenticated GET requests, which is not necessary for static assets. It would be a valid alternative to not authenticate these requests.

This solves the static asset request, described in https://github.com/jupyterhub/jupyterhub/issues/4800

The userprofile request must be addressed in https://github.com/cylc/cylc-ui

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are not needed for this
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] cylc-doc PR not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
