### PR TITLE
Avoid requiring `jupyter_config.py` in to be in `uiserver` subdirectory

### DIFF
--- a/changes.d/594.fix
+++ b/changes.d/594.fix
@@ -1,0 +1,1 @@
+Avoid requiring jupyter_config.py in to be in uiserver subdirectory when using CYLC_SITE_CONF_PATH

--- a/cylc/uiserver/config_util.py
+++ b/cylc/uiserver/config_util.py
@@ -30,7 +30,8 @@ from cylc.uiserver import (
 )
 
 # base configuration - always used
-DEFAULT_CONF_PATH: Path = Path(uis_pkg).parent / 'jupyter_config.py'
+CONF_FILE_NAME = 'jupyter_config.py'
+DEFAULT_CONF_PATH: Path = Path(uis_pkg).parent / CONF_FILE_NAME
 UISERVER_DIR = 'uiserver'
 # UIS configuration dirs
 SITE_CONF_ROOT: Path = Path(

--- a/cylc/uiserver/tests/test_config.py
+++ b/cylc/uiserver/tests/test_config.py
@@ -77,8 +77,8 @@ def test_cylc_site_conf_path(clear_env, capload, monkeypatch):
     load()
     assert capload == [
         SYS_CONF,
-        Path('elephant/uiserver/jupyter_config.py'),
-        Path('elephant/uiserver/0/jupyter_config.py'),
+        Path('elephant/jupyter_config.py'),
+        Path('elephant/0/jupyter_config.py'),
         Path(USER_CONF / 'jupyter_config.py'),
         Path(USER_CONF / '0/jupyter_config.py')
     ]

--- a/cylc/uiserver/tests/test_jupyterhub_config.py
+++ b/cylc/uiserver/tests/test_jupyterhub_config.py
@@ -1,0 +1,39 @@
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for jupyterhub_config module."""
+
+from cylc.uiserver.jupyterhub_config import check_cylc_site_conf_path
+from cylc.uiserver.config_util import CONF_FILE_NAME, SITE_CONF_ROOT
+
+
+def test_cylc_site_conf_path_ok(tmp_path, caplog):
+    """Method passes valid file without comment"""
+    (tmp_path / CONF_FILE_NAME).touch()
+    assert check_cylc_site_conf_path(tmp_path) == tmp_path
+    assert caplog.messages == []
+
+
+def test_cylc_site_conf_path_unreadable(tmp_path, caplog):
+    """Method logs error because file exists but is unreadable."""
+    (tmp_path / CONF_FILE_NAME).touch()
+    (tmp_path / CONF_FILE_NAME).chmod(0)
+    assert check_cylc_site_conf_path(tmp_path) == SITE_CONF_ROOT
+    assert caplog.messages[0].startswith('Unable to read config file at')
+
+
+def test_cylc_site_conf_path_empty(tmp_path, caplog):
+    """Method logs error because file does not exist."""
+    assert check_cylc_site_conf_path(tmp_path) == tmp_path
+    assert 'does not exist' in caplog.messages[0]


### PR DESCRIPTION
Closes #565 

Previously it was assumed to be in `CYLC_SITE_CONF_PATH/uiserver`.

Ensure that user is warned if file at `CYLC_SITE_CONF_PATH` is
* Unreadable
* Non-existent

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
