### PR TITLE
Sync minimal flow data

### DIFF
--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -530,6 +530,12 @@ class CylcUIServer(ExtensionApp):
             self.scan_interval * 1000
         ).start()
 
+        # configure the sync level expiry check
+        ioloop.PeriodicCallback(
+            self.data_store_mgr.check_query_sync_level_expiries,
+            self.data_store_mgr.SYNC_LEVEL_TIMER_INTERVAL * 1000
+        ).start()
+
     def initialize_handlers(self):
         self.authobj = self.set_auth()
         self.set_sub_server()

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -103,7 +103,22 @@ class DataStoreMgr:
         self.log = log
         self.data = {}
         self.w_subs: Dict[str, WorkflowSubscriber] = {}
-        self.topics = {ALL_DELTAS.encode('utf-8'), b'shutdown'}
+        self.topics = {
+            ALL_DELTAS.encode('utf-8'),
+            WORKFLOW.encode('utf-8'),
+            b'shutdown'
+        }
+        # If fragments in graphql sub for minimal sync
+        self.min_sync_fragments = {
+            'AddedDelta',
+            'WorkflowData',
+            'UpdatedDelta'
+        }
+        # set of workflows to sync all data
+        self.full_sync_workflows = set()
+        self.full_sync_gql_subs = set()
+        # dict of workflow full sync subscriber IDs
+        self.full_sync_workflow_gql_subs = {}
         self.loop = None
         self.executor = ThreadPoolExecutor(max_threads)
         self.delta_queues = {}
@@ -163,6 +178,9 @@ class DataStoreMgr:
 
         self.delta_queues[w_id] = {}
 
+        # setup sync subscriber set
+        self.full_sync_workflow_gql_subs[w_id] = set()
+
         # Might be options other than threads to achieve
         # non-blocking subscriptions, but this works.
         self.executor.submit(
@@ -172,7 +190,25 @@ class DataStoreMgr:
             contact_data[CFF.HOST],
             contact_data[CFF.PUBLISH_PORT]
         )
-        successful_updates = await self._entire_workflow_update(ids=[w_id])
+
+        result = await self.workflow_data_update(w_id, minimal=True)
+
+        if result:
+            # don't update the contact data until we have successfully updated
+            self._update_contact(w_id, contact_data)
+
+    @log_call
+    async def workflow_data_update(
+        self,
+        w_id: str,
+        minimal: Optional[bool] = None
+    ):
+        if minimal is None:
+            minimal = w_id in self.full_sync_workflows
+        successful_updates = await self._entire_workflow_update(
+            ids=[w_id],
+            minimal=minimal
+        )
 
         if w_id not in successful_updates:
             # something went wrong, undo any changes to allow for subsequent
@@ -180,6 +216,7 @@ class DataStoreMgr:
             self.log.info(f'failed to connect to {w_id}')
             self.disconnect_workflow(w_id)
             return False
+        return True
 
     @log_call
     def disconnect_workflow(self, w_id, update_contact=True):
@@ -206,6 +243,9 @@ class DataStoreMgr:
         if w_id in self.w_subs:
             self.w_subs[w_id].stop()
             del self.w_subs[w_id]
+        if w_id in self.full_sync_workflow_gql_subs:
+            del self.full_sync_workflow_gql_subs[w_id]
+            self.full_sync_workflows.discard(w_id)
 
     def get_workflows(self):
         """Return all workflows the data store is currently tracking.
@@ -283,8 +323,18 @@ class DataStoreMgr:
             # close connections
             self.disconnect_workflow(w_id)
             return
-        self._apply_all_delta(w_id, delta)
-        self._delta_store_to_queues(w_id, topic, delta)
+        elif topic == WORKFLOW:
+            if w_id in self.full_sync_workflows:
+                return
+            self._apply_delta(w_id, WORKFLOW, delta)
+            # might seem clunky, but as with contact update, making it look
+            # like an ALL_DELTA avoids changing the resolver in cylc-flow
+            all_deltas = DELTAS_MAP[ALL_DELTAS]()
+            all_deltas.workflow.CopyFrom(delta)
+            self._delta_store_to_queues(w_id, ALL_DELTAS, all_deltas)
+        elif w_id in self.full_sync_workflows:
+            self._apply_all_delta(w_id, delta)
+            self._delta_store_to_queues(w_id, topic, delta)
 
     def _clear_data_field(self, w_id, field_name):
         if field_name == WORKFLOW:
@@ -294,24 +344,28 @@ class DataStoreMgr:
 
     def _apply_all_delta(self, w_id, delta):
         """Apply the AllDeltas delta."""
-        delta_times = self.data[w_id]['delta_times']
         for field, sub_delta in delta.ListFields():
-            delta_time = getattr(sub_delta, 'time', 0.0)
-            # If the workflow has reloaded clear the data before
-            # delta application.
-            if sub_delta.reloaded:
-                self._clear_data_field(w_id, field.name)
-                delta_times[field.name] = 0.0
-            # hard to catch errors in a threaded async app, so use try-except.
-            try:
-                # Apply the delta if newer than the previously applied.
-                if delta_time >= delta_times.get(field.name, 0.0):
-                    apply_delta(field.name, sub_delta, self.data[w_id])
-                    delta_times[field.name] = delta_time
-                    if not sub_delta.reloaded:
-                        self._reconcile_update(field.name, sub_delta, w_id)
-            except Exception as exc:
-                self.log.exception(exc)
+            self._apply_delta(w_id, field.name, sub_delta)
+
+    def _apply_delta(self, w_id, name, delta):
+        """Apply delta."""
+        delta_times = self.data[w_id]['delta_times']
+        delta_time = getattr(delta, 'time', 0.0)
+        # If the workflow has reloaded clear the data before
+        # delta application.
+        if delta.reloaded:
+            self._clear_data_field(w_id, name)
+            delta_times[name] = 0.0
+        # hard to catch errors in a threaded async app, so use try-except.
+        try:
+            # Apply the delta if newer than the previously applied.
+            if delta_time >= delta_times.get(name, 0.0):
+                apply_delta(name, delta, self.data[w_id])
+                delta_times[name] = delta_time
+                if not delta.reloaded:
+                    self._reconcile_update(name, delta, w_id)
+        except Exception as exc:
+            self.log.exception(exc)
 
     def _delta_store_to_queues(self, w_id, topic, delta):
         # Queue delta for graphql subscription resolving
@@ -370,7 +424,9 @@ class DataStoreMgr:
                 self.log.exception(exc)
 
     async def _entire_workflow_update(
-        self, ids: Optional[list] = None
+        self,
+        ids: Optional[list] = None,
+        minimal: Optional[bool] = False
     ) -> Set[str]:
         """Update entire local data-store of workflow(s).
 
@@ -418,6 +474,8 @@ class DataStoreMgr:
                         key: value.last_updated
                         for key in DATA_TEMPLATE
                     }
+                    continue
+                elif minimal:
                     continue
                 new_data[field.name] = {n.id: n for n in value}
             self.data[w_id] = new_data
@@ -507,3 +565,33 @@ class DataStoreMgr:
         else:
             # the workflow has not yet run
             return 'not yet run'
+
+    def graphql_sub_interrogate(self, sub_id, info):
+        """Scope data requirements."""
+        fragments = set(info.fragments.keys())
+        minimal = (
+            fragments <= self.min_sync_fragments
+            and bool(fragments)
+        )
+        if not minimal:
+            self.full_sync_gql_subs.add(sub_id)
+        return minimal
+
+    async def graphql_sub_data_match(self, w_id, sub_id):
+        """Match store data level to requested graphql subscription."""
+        if (
+            sub_id in self.full_sync_gql_subs
+            and sub_id not in self.full_sync_workflow_gql_subs[w_id]
+        ):
+            self.full_sync_workflow_gql_subs[w_id].add(sub_id)
+            await self.workflow_data_update(w_id, minimal=False)
+
+            self.full_sync_workflows.add(w_id)
+
+    def graphql_sub_discard(self, sub_id):
+        """Discard graphql subscription references."""
+        self.full_sync_gql_subs.discard(sub_id)
+        for w_id in self.full_sync_workflow_gql_subs:
+            self.full_sync_workflow_gql_subs[w_id].discard(w_id)
+            if not self.full_sync_workflow_gql_subs[w_id]:
+                self.full_sync_workflows.discard(w_id)

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -129,12 +129,16 @@ SUBSCRIPTION_CATALOGUE = {
         'request': 'pb_data_elements',
     },
     ALL_DELTAS: {
+        # Tie proxies together, otherwise they can arrive out of order
+        # at the UI, causing pruning issue at the UI (because UI
+        # regenerates/keeps family after it's pruned to anchor).
+        # Otherwise, we could include all fields...
         'criteria': {
-            EDGES,
-            FAMILIES,
+            # EDGES,
+            # FAMILIES,
             FAMILY_PROXIES,
-            JOBS,
-            TASKS,
+            # JOBS,
+            # TASKS,
             TASK_PROXIES,
             WORKFLOW,
         },
@@ -148,9 +152,8 @@ QUERY_SYNC_EXPIRY = 60
 def generate_level_topics(level) -> set:
     """Produce the subscription topics from the workflow sync level."""
     selection = set()
-    all_criteria = SUBSCRIPTION_CATALOGUE[ALL_DELTAS]['criteria']
-    if all_criteria.issubset(level):
-        selection.update(level.difference(all_criteria))
+    if SUBSCRIPTION_CATALOGUE[ALL_DELTAS]['criteria'].issubset(level):
+        selection.update(level.difference(DATA_TEMPLATE))
         selection.add(ALL_DELTAS)
     else:
         selection = level
@@ -391,7 +394,7 @@ class DataStoreMgr:
             del self.data[w_id]
         if w_id in self.delta_queues:
             del self.delta_queues[w_id]
-        if w_id in self.workflow_sync_level_graphql_subs:
+        if w_id in self.workflow_sync_graphql_subs:
             del self.workflow_sync_graphql_subs[w_id]
         if w_id in self.workflow_query_sync_timers:
             del self.workflow_query_sync_timers[w_id]
@@ -465,8 +468,10 @@ class DataStoreMgr:
 
     def _apply_all_delta(self, w_id, delta):
         """Apply the AllDeltas delta."""
+        level = self.workflow_sync_level.get(w_id, None)
         for field, sub_delta in delta.ListFields():
-            self._apply_delta(w_id, field.name, sub_delta)
+            if not level or field.name in level:
+                self._apply_delta(w_id, field.name, sub_delta)
 
     def _apply_delta(self, w_id, name, delta):
         """Apply delta."""

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -38,14 +38,16 @@ from pathlib import Path
 import time
 from typing import Dict, Iterable, List, Optional, Set, cast, TYPE_CHECKING
 
-from cylc.flow.exceptions import WorkflowStopped
-from cylc.flow.id import Tokens
-from cylc.flow.network.server import PB_METHOD_MAP
-from cylc.flow.network.subscriber import WorkflowSubscriber, process_delta_msg
 from cylc.flow.data_store_mgr import (
+    FAMILIES, FAMILY_PROXIES, JOBS, TASKS, TASK_PROXIES,
     EDGES, DATA_TEMPLATE, ALL_DELTAS, DELTAS_MAP, WORKFLOW,
     apply_delta, generate_checksum, create_delta_store
 )
+from cylc.flow.exceptions import WorkflowStopped
+from cylc.flow.id import Tokens
+from cylc.flow.network.graphql import extract_ast_fields
+from cylc.flow.network.server import PB_METHOD_MAP
+from cylc.flow.network.subscriber import WorkflowSubscriber, process_delta_msg
 from cylc.flow.workflow_files import (
     ContactFileFields as CFF,
     WorkflowFiles,
@@ -61,28 +63,98 @@ if TYPE_CHECKING:
     from cylc.flow.data_messages_pb2 import PbWorkflow
 
 
-MIN_LEVEL = 'min'
-MAX_LEVEL = 'max'
-SUBSCRIPTION_LEVELS = {
-    MIN_LEVEL: {
-        'topics': {WORKFLOW.encode('utf-8'), b'shutdown'},
+SUBSCRIPTION_CATALOGUE = {
+    EDGES: {
         'criteria': {
-            'fragments': {
-                'AddedDelta',
-                'WorkflowData',
-                'UpdatedDelta'
-            },
+            'edges',
+            'nodesEdges',
         },
-        'request': 'pb_workflow_only',
+        'request': 'pb_data_elements',
     },
-    MAX_LEVEL: {
-        'topics': {ALL_DELTAS.encode('utf-8'), b'shutdown'},
-        'criteria': {'fragments': set()},
+    FAMILIES: {
+        'criteria': {
+            'ancestors',
+            'childFamilies',
+            'family',
+            'families',
+            'firstParent',
+            'parents',
+        },
+        'request': 'pb_data_elements',
+    },
+    FAMILY_PROXIES: {
+        'criteria': {
+            'ancestors',
+            'childFamilies',
+            'familyProxy',
+            'familyProxies',
+            'firstParent',
+            'nodes',
+            'parents',
+        },
+        'request': 'pb_data_elements',
+    },
+    JOBS: {
+        'criteria': {
+            'job',
+            'jobs',
+        },
+        'request': 'pb_data_elements',
+    },
+    TASKS: {
+        'criteria': {
+            'childTasks',
+            'task',
+            'tasks',
+        },
+        'request': 'pb_data_elements',
+    },
+    TASK_PROXIES: {
+        'criteria': {
+            'childTasks',
+            'nodes',
+            'sourceNode',
+            'targetNode',
+            'taskProxy',
+            'taskProxies',
+        },
+        'request': 'pb_data_elements',
+    },
+    WORKFLOW: {
+        'criteria': {
+            'workflow',
+            'workflows',
+            'deltas',
+        },
+        'request': 'pb_data_elements',
+    },
+    ALL_DELTAS: {
+        'criteria': {
+            EDGES,
+            FAMILIES,
+            FAMILY_PROXIES,
+            JOBS,
+            TASKS,
+            TASK_PROXIES,
+            WORKFLOW,
+        },
         'request': 'pb_entire_workflow',
     },
 }
 # expiry interval post query
 QUERY_SYNC_EXPIRY = 60
+
+
+def generate_level_topics(level) -> set:
+    """Produce the subscription topics from the workflow sync level."""
+    selection = set()
+    all_criteria = SUBSCRIPTION_CATALOGUE[ALL_DELTAS]['criteria']
+    if all_criteria.issubset(level):
+        selection.update(level.difference(all_criteria))
+        selection.add(ALL_DELTAS)
+    else:
+        selection = level
+    return {item.encode('utf-8') for item in selection}
 
 
 def log_call(fcn):
@@ -131,11 +203,10 @@ class DataStoreMgr:
         self.w_subs: Dict[str, WorkflowSubscriber] = {}
         # graphql subscription level
         self.sync_level_graphql_subs = {
-            MIN_LEVEL: set(),
-            MAX_LEVEL: set()
+            'minimal': {WORKFLOW, 'shutdown'},
         }
-        # workflow graphql subscription by level
-        self.workflow_sync_level_graphql_subs = {}
+        # workflow graphql subscriptions
+        self.workflow_sync_graphql_subs = {}
         # workflow graphql query timers
         self.workflow_query_sync_timers = {}
         # resultant workflow sync level
@@ -165,16 +236,16 @@ class DataStoreMgr:
         )
 
         # setup sync subscriber level sets
-        self.workflow_sync_level_graphql_subs[w_id] = {
-            MIN_LEVEL: set(),
-            MAX_LEVEL: set()
-        }
+        self.workflow_sync_graphql_subs[w_id] = {'minimal'}
 
         # set query sync timer
-        self.workflow_query_sync_timers[w_id] = 0.0
+        self.workflow_query_sync_timers[w_id] = {
+            'expiry': 0.0,
+            'level': set(),
+        }
 
         # set workflow sync level
-        self.workflow_sync_level[w_id] = MIN_LEVEL
+        self.workflow_sync_level[w_id] = self._get_sync_level(w_id)
 
     @log_call
     async def unregister_workflow(self, w_id):
@@ -211,9 +282,7 @@ class DataStoreMgr:
 
         self.delta_queues[w_id] = {}
 
-        level = MIN_LEVEL
-        if self.workflow_sync_level_graphql_subs[w_id][MAX_LEVEL]:
-            level = MAX_LEVEL
+        level = self.workflow_sync_level[w_id]
 
         # Might be options other than threads to achieve
         # non-blocking subscriptions, but this works.
@@ -223,7 +292,7 @@ class DataStoreMgr:
             contact_data['name'],
             contact_data[CFF.HOST],
             contact_data[CFF.PUBLISH_PORT],
-            SUBSCRIPTION_LEVELS[level]['topics']
+            generate_level_topics(level)
         )
 
         result = await self.workflow_data_update(w_id, level)
@@ -236,13 +305,29 @@ class DataStoreMgr:
     async def workflow_data_update(
         self,
         w_id: str,
-        level: str,
+        level: Set[str],
     ):
-        # for some reason mypy doesn't like non-fstring...
-        successful_updates = await self._workflow_update(
-            [w_id],
-            f'{SUBSCRIPTION_LEVELS[level]["request"]}'
-        )
+        requests = set()
+        if ALL_DELTAS in level:
+            requests.add(SUBSCRIPTION_CATALOGUE[ALL_DELTAS]["request"])
+        else:
+            requests.update(
+                {
+                    SUBSCRIPTION_CATALOGUE[topic]["request"]
+                    for topic in level
+                    if topic in SUBSCRIPTION_CATALOGUE
+                }
+            )
+        for request in requests:
+            successful_updates = await self._workflow_update(
+                [w_id],
+                request,
+                elements=[
+                    element
+                    for element in level
+                    if element in DATA_TEMPLATE
+                ]
+            )
 
         if w_id not in successful_updates:
             # something went wrong, undo any changes to allow for subsequent
@@ -307,7 +392,7 @@ class DataStoreMgr:
         if w_id in self.delta_queues:
             del self.delta_queues[w_id]
         if w_id in self.workflow_sync_level_graphql_subs:
-            del self.workflow_sync_level_graphql_subs[w_id]
+            del self.workflow_sync_graphql_subs[w_id]
         if w_id in self.workflow_query_sync_timers:
             del self.workflow_query_sync_timers[w_id]
         if w_id in self.workflow_sync_level:
@@ -361,18 +446,16 @@ class DataStoreMgr:
             # close connections
             self.disconnect_workflow(w_id)
             return
-        elif topic == WORKFLOW:
-            if self.workflow_sync_level_graphql_subs[w_id][MAX_LEVEL]:
-                return
-            self._apply_delta(w_id, WORKFLOW, delta)
+        elif topic == ALL_DELTAS:
+            self._apply_all_delta(w_id, delta)
+            self._delta_store_to_queues(w_id, topic, delta)
+        else:
+            self._apply_delta(w_id, topic, delta)
             # might seem clunky, but as with contact update, making it look
             # like an ALL_DELTA avoids changing the resolver in cylc-flow
             all_deltas = DELTAS_MAP[ALL_DELTAS]()
-            all_deltas.workflow.CopyFrom(delta)
+            getattr(all_deltas, topic).CopyFrom(delta)
             self._delta_store_to_queues(w_id, ALL_DELTAS, all_deltas)
-        else:
-            self._apply_all_delta(w_id, delta)
-            self._delta_store_to_queues(w_id, topic, delta)
 
     def _clear_data_field(self, w_id, field_name):
         if field_name == WORKFLOW:
@@ -441,7 +524,7 @@ class DataStoreMgr:
                 future = asyncio.run_coroutine_threadsafe(
                     workflow_request(
                         self.workflows_mgr.workflows[w_id]['req_client'],
-                        'pb_data_elements',
+                        'pb_delta_elements',
                         args={'element_type': topic}
                     ),
                     self.loop
@@ -462,7 +545,7 @@ class DataStoreMgr:
                 self.log.exception(exc)
 
     async def _workflow_update(
-        self, ids: List[str], req_method: str,
+        self, ids: List[str], req_method: str, **kwargs
     ) -> Set[str]:
         """Update entire local data-store of workflow(s).
 
@@ -472,11 +555,13 @@ class DataStoreMgr:
         """
         # Request new data
         req_time = time.time()
-        req_method = 'pb_entire_workflow'
 
         requests = {
             w_id: workflow_request(
-                client=info['req_client'], command=req_method, log=self.log
+                client=info['req_client'],
+                command=req_method,
+                log=self.log,
+                args=kwargs
             )
             for w_id, info in self.workflows_mgr.workflows.items()
             if info.get('req_client')  # skip stopped workflows
@@ -597,96 +682,93 @@ class DataStoreMgr:
             # the workflow has not yet run
             return 'not yet run'
 
-    async def _update_subscription_level(self, w_id, level):
+    def _get_sync_level(self, w_id) -> set:
+        """Return the sync level in the form of a set of catalogue items."""
+        level = set()
+        if (
+            w_id in self.workflow_query_sync_timers
+            and self.workflow_query_sync_timers[w_id]['expiry'] > 0
+        ):
+            level.update(self.workflow_query_sync_timers[w_id]['level'])
+        for sub_id in self.workflow_sync_graphql_subs[w_id]:
+            level.update(self.sync_level_graphql_subs.get(sub_id, ()))
+        return level
+
+    async def _update_subscription_level(self, w_id):
         """Update level of data subscribed to."""
+        new_level = self._get_sync_level(w_id)
+        if new_level == self.workflow_sync_level[w_id]:
+            return
+        self.workflow_sync_level[w_id] = new_level
         sub = self.w_subs.get(w_id)
         if sub:
-            stop_topics = sub.topics.difference(
-                SUBSCRIPTION_LEVELS[level]['topics']
-            )
-            start_topics = SUBSCRIPTION_LEVELS[level]['topics'].difference(
-                sub.topics
-            )
+            new_topics = generate_level_topics(new_level)
+            stop_topics = sub.topics.difference(new_topics)
+            start_topics = new_topics.difference(sub.topics)
             for stop_topic in stop_topics:
                 sub.unsubscribe_topic(stop_topic)
             # Doing this after unsubscribe and before subscribe
             # to make sure old topics stop and new data is in place.
-            await self.workflow_data_update(w_id, level)
+            await self.workflow_data_update(w_id, new_level)
             for start_topic in start_topics:
                 sub.subscribe_topic(start_topic)
-            self.workflow_sync_level[w_id] = level
 
     def graphql_sub_interrogate(self, sub_id, info):
         """Scope data requirements."""
-        fragments = set(info.fragments.keys())
-        minimal = (
-            (
-                fragments
-                <= SUBSCRIPTION_LEVELS[MIN_LEVEL]['criteria']['fragments']
-            )
-            and bool(fragments)
-        )
-        if minimal:
-            self.sync_level_graphql_subs[MIN_LEVEL].add(sub_id)
-            return
-        self.sync_level_graphql_subs[MAX_LEVEL].add(sub_id)
+        fields = set()
+        extract_ast_fields(info.operation, fields)
+        for frag in getattr(info, 'fragments', {}).values():
+            extract_ast_fields(frag, fields)
+        self.sync_level_graphql_subs[sub_id] = {'shutdown'}
+        sync_level_subs = self.sync_level_graphql_subs[sub_id]
+        for category in DATA_TEMPLATE:
+            if fields.intersection(
+                SUBSCRIPTION_CATALOGUE[category]['criteria']
+            ):
+                sync_level_subs.add(category)
 
     async def graphql_sub_data_match(self, w_id, sub_id):
         """Match store data level to requested graphql subscription."""
-        sync_level_wsubs = self.workflow_sync_level_graphql_subs[w_id]
-        if sub_id in self.sync_level_graphql_subs[MAX_LEVEL]:
-            no_max = not sync_level_wsubs[MAX_LEVEL]
-            sync_level_wsubs[MAX_LEVEL].add(sub_id)
-            if no_max:
-                await self._update_subscription_level(w_id, MAX_LEVEL)
-        else:
-            sync_level_wsubs[MIN_LEVEL].add(sub_id)
+        sync_level_wsubs = self.workflow_sync_graphql_subs[w_id]
+        sync_level_wsubs.add(sub_id)
+
+        # set new sync level
+        await self._update_subscription_level(w_id)
 
     async def graphql_sub_discard(self, sub_id):
         """Discard graphql subscription references."""
-        level = MIN_LEVEL
-        if sub_id in self.sync_level_graphql_subs[MAX_LEVEL]:
-            level = MAX_LEVEL
-        self.sync_level_graphql_subs[level].discard(sub_id)
-        for w_id in self.workflow_sync_level_graphql_subs:
-            self.workflow_sync_level_graphql_subs[w_id][level].discard(
-                sub_id
-            )
-            # if there are no more max level subscriptions after removal
-            # of a max level sub, downgrade to min.
-            if (
-                not self.workflow_sync_level_graphql_subs[w_id][level]
-                and level is MAX_LEVEL
-                and self.workflow_query_sync_timers[w_id] < time.time()
-            ):
-                await self._update_subscription_level(w_id, MIN_LEVEL)
+        if sub_id in self.sync_level_graphql_subs:
+            del self.sync_level_graphql_subs[sub_id]
+        for w_id in self.workflow_sync_graphql_subs:
+            if sub_id not in self.workflow_sync_graphql_subs[w_id]:
+                continue
+            self.workflow_sync_graphql_subs[w_id].discard(sub_id)
+            await self._update_subscription_level(w_id)
 
     async def set_query_sync_levels(
         self,
         w_ids: Iterable[str],
-        level: Optional[str] = None,
+        level: Optional[Iterable[str]] = None,
         expire_delay: Optional[float] = None,
     ):
         """Set a workflow sync level."""
         if level is None:
-            level = MAX_LEVEL
+            level = set(DATA_TEMPLATE.keys())
         if expire_delay is None:
             expire_delay = QUERY_SYNC_EXPIRY
         expire_time = time.time() + expire_delay
         for w_id in w_ids:
-            self.workflow_query_sync_timers[w_id] = expire_time
-            if self.workflow_sync_level[w_id] is level:
+            if self.workflow_sync_level[w_id] == level:
                 # Already required level
                 continue
-            await self._update_subscription_level(w_id, level)
+            self.workflow_query_sync_timers[w_id]['expiry'] = expire_time
+            self.workflow_query_sync_timers[w_id]['level'].update(level)
+            await self._update_subscription_level(w_id)
 
     async def check_query_sync_level_expiries(self):
         """Check for and downgrade expired sub levels."""
-        for w_id, expiry in self.workflow_query_sync_timers.items():
-            if (
-                w_id in self.w_subs
-                and self.workflow_sync_level[w_id] is not MIN_LEVEL
-                and not self.workflow_sync_level_graphql_subs[w_id][MAX_LEVEL]
-                and expiry < time.time()
-            ):
-                await self._update_subscription_level(w_id, MIN_LEVEL)
+        for w_id, items in self.workflow_query_sync_timers.items():
+            if items['expiry'] < time.time():
+                items['expiry'] = 0.0
+                items['level'].clear()
+                await self._update_subscription_level(w_id)

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -36,7 +36,7 @@ from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from pathlib import Path
 import time
-from typing import TYPE_CHECKING, Dict, List, Set, cast
+from typing import Dict, Iterable, List, Optional, Set, cast, TYPE_CHECKING
 
 from cylc.flow.exceptions import WorkflowStopped
 from cylc.flow.id import Tokens
@@ -81,6 +81,8 @@ SUBSCRIPTION_LEVELS = {
         'request': 'pb_entire_workflow',
     },
 }
+# expiry interval post query
+QUERY_SYNC_EXPIRY = 60
 
 
 def log_call(fcn):
@@ -120,6 +122,7 @@ class DataStoreMgr:
     INIT_DATA_RETRY_DELAY = 0.5  # seconds
     RECONCILE_TIMEOUT = 5.  # seconds
     PENDING_DELTA_CHECK_INTERVAL = 0.5
+    SYNC_LEVEL_TIMER_INTERVAL = 30
 
     def __init__(self, workflows_mgr, log, max_threads=10):
         self.workflows_mgr = workflows_mgr
@@ -132,7 +135,11 @@ class DataStoreMgr:
             MAX_LEVEL: set()
         }
         # workflow graphql subscription by level
-        self.sync_level_workflow_graphql_subs = {}
+        self.workflow_sync_level_graphql_subs = {}
+        # workflow graphql query timers
+        self.workflow_query_sync_timers = {}
+        # resultant workflow sync level
+        self.workflow_sync_level = {}
         self.loop = None
         self.executor = ThreadPoolExecutor(max_threads)
         self.delta_queues = {}
@@ -157,11 +164,17 @@ class DataStoreMgr:
             status_msg=self._get_status_msg(w_id, is_active),
         )
 
-        # setup sync subscriber set
-        self.sync_level_workflow_graphql_subs[w_id] = {
+        # setup sync subscriber level sets
+        self.workflow_sync_level_graphql_subs[w_id] = {
             MIN_LEVEL: set(),
             MAX_LEVEL: set()
         }
+
+        # set query sync timer
+        self.workflow_query_sync_timers[w_id] = 0.0
+
+        # set workflow sync level
+        self.workflow_sync_level[w_id] = MIN_LEVEL
 
     @log_call
     async def unregister_workflow(self, w_id):
@@ -199,7 +212,7 @@ class DataStoreMgr:
         self.delta_queues[w_id] = {}
 
         level = MIN_LEVEL
-        if self.sync_level_workflow_graphql_subs[w_id][MAX_LEVEL]:
+        if self.workflow_sync_level_graphql_subs[w_id][MAX_LEVEL]:
             level = MAX_LEVEL
 
         # Might be options other than threads to achieve
@@ -293,8 +306,12 @@ class DataStoreMgr:
             del self.data[w_id]
         if w_id in self.delta_queues:
             del self.delta_queues[w_id]
-        if w_id in self.sync_level_workflow_graphql_subs:
-            del self.sync_level_workflow_graphql_subs[w_id]
+        if w_id in self.workflow_sync_level_graphql_subs:
+            del self.workflow_sync_level_graphql_subs[w_id]
+        if w_id in self.workflow_query_sync_timers:
+            del self.workflow_query_sync_timers[w_id]
+        if w_id in self.workflow_sync_level:
+            del self.workflow_sync_level[w_id]
 
     def _start_subscription(self, w_id, reg, host, port, topics):
         """Instantiate and run subscriber data-store sync.
@@ -345,7 +362,7 @@ class DataStoreMgr:
             self.disconnect_workflow(w_id)
             return
         elif topic == WORKFLOW:
-            if self.sync_level_workflow_graphql_subs[w_id][MAX_LEVEL]:
+            if self.workflow_sync_level_graphql_subs[w_id][MAX_LEVEL]:
                 return
             self._apply_delta(w_id, WORKFLOW, delta)
             # might seem clunky, but as with contact update, making it look
@@ -597,6 +614,7 @@ class DataStoreMgr:
             await self.workflow_data_update(w_id, level)
             for start_topic in start_topics:
                 sub.subscribe_topic(start_topic)
+            self.workflow_sync_level[w_id] = level
 
     def graphql_sub_interrogate(self, sub_id, info):
         """Scope data requirements."""
@@ -615,10 +633,11 @@ class DataStoreMgr:
 
     async def graphql_sub_data_match(self, w_id, sub_id):
         """Match store data level to requested graphql subscription."""
-        sync_level_wsubs = self.sync_level_workflow_graphql_subs[w_id]
+        sync_level_wsubs = self.workflow_sync_level_graphql_subs[w_id]
         if sub_id in self.sync_level_graphql_subs[MAX_LEVEL]:
-            if not sync_level_wsubs[MAX_LEVEL]:
-                sync_level_wsubs[MAX_LEVEL].add(sub_id)
+            no_max = not sync_level_wsubs[MAX_LEVEL]
+            sync_level_wsubs[MAX_LEVEL].add(sub_id)
+            if no_max:
                 await self._update_subscription_level(w_id, MAX_LEVEL)
         else:
             sync_level_wsubs[MIN_LEVEL].add(sub_id)
@@ -629,14 +648,45 @@ class DataStoreMgr:
         if sub_id in self.sync_level_graphql_subs[MAX_LEVEL]:
             level = MAX_LEVEL
         self.sync_level_graphql_subs[level].discard(sub_id)
-        for w_id in self.sync_level_workflow_graphql_subs:
-            self.sync_level_workflow_graphql_subs[w_id][level].discard(
+        for w_id in self.workflow_sync_level_graphql_subs:
+            self.workflow_sync_level_graphql_subs[w_id][level].discard(
                 sub_id
             )
             # if there are no more max level subscriptions after removal
             # of a max level sub, downgrade to min.
             if (
-                not self.sync_level_workflow_graphql_subs[w_id][level]
+                not self.workflow_sync_level_graphql_subs[w_id][level]
                 and level is MAX_LEVEL
+                and self.workflow_query_sync_timers[w_id] < time.time()
+            ):
+                await self._update_subscription_level(w_id, MIN_LEVEL)
+
+    async def set_query_sync_levels(
+        self,
+        w_ids: Iterable[str],
+        level: Optional[str] = None,
+        expire_delay: Optional[float] = None,
+    ):
+        """Set a workflow sync level."""
+        if level is None:
+            level = MAX_LEVEL
+        if expire_delay is None:
+            expire_delay = QUERY_SYNC_EXPIRY
+        expire_time = time.time() + expire_delay
+        for w_id in w_ids:
+            self.workflow_query_sync_timers[w_id] = expire_time
+            if self.workflow_sync_level[w_id] is level:
+                # Already required level
+                continue
+            await self._update_subscription_level(w_id, level)
+
+    async def check_query_sync_level_expiries(self):
+        """Check for and downgrade expired sub levels."""
+        for w_id, expiry in self.workflow_query_sync_timers.items():
+            if (
+                w_id in self.w_subs
+                and self.workflow_sync_level[w_id] is not MIN_LEVEL
+                and not self.workflow_sync_level_graphql_subs[w_id][MAX_LEVEL]
+                and expiry < time.time()
             ):
                 await self._update_subscription_level(w_id, MIN_LEVEL)

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -36,7 +36,7 @@ from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from pathlib import Path
 import time
-from typing import TYPE_CHECKING, Dict, Optional, Set, cast
+from typing import TYPE_CHECKING, Dict, List, Set, cast
 
 from cylc.flow.exceptions import WorkflowStopped
 from cylc.flow.id import Tokens
@@ -56,8 +56,31 @@ from cylc.flow.workflow_status import WorkflowStatus
 from .utils import fmt_call
 from .workflows_mgr import workflow_request
 
+
 if TYPE_CHECKING:
     from cylc.flow.data_messages_pb2 import PbWorkflow
+
+
+MIN_LEVEL = 'min'
+MAX_LEVEL = 'max'
+SUBSCRIPTION_LEVELS = {
+    MIN_LEVEL: {
+        'topics': {WORKFLOW.encode('utf-8'), b'shutdown'},
+        'criteria': {
+            'fragments': {
+                'AddedDelta',
+                'WorkflowData',
+                'UpdatedDelta'
+            },
+        },
+        'request': 'pb_workflow_only',
+    },
+    MAX_LEVEL: {
+        'topics': {ALL_DELTAS.encode('utf-8'), b'shutdown'},
+        'criteria': {'fragments': set()},
+        'request': 'pb_entire_workflow',
+    },
+}
 
 
 def log_call(fcn):
@@ -103,22 +126,13 @@ class DataStoreMgr:
         self.log = log
         self.data = {}
         self.w_subs: Dict[str, WorkflowSubscriber] = {}
-        self.topics = {
-            ALL_DELTAS.encode('utf-8'),
-            WORKFLOW.encode('utf-8'),
-            b'shutdown'
+        # graphql subscription level
+        self.sync_level_graphql_subs = {
+            MIN_LEVEL: set(),
+            MAX_LEVEL: set()
         }
-        # If fragments in graphql sub for minimal sync
-        self.min_sync_fragments = {
-            'AddedDelta',
-            'WorkflowData',
-            'UpdatedDelta'
-        }
-        # set of workflows to sync all data
-        self.full_sync_workflows = set()
-        self.full_sync_gql_subs = set()
-        # dict of workflow full sync subscriber IDs
-        self.full_sync_workflow_gql_subs = {}
+        # workflow graphql subscription by level
+        self.sync_level_workflow_graphql_subs = {}
         self.loop = None
         self.executor = ThreadPoolExecutor(max_threads)
         self.delta_queues = {}
@@ -142,6 +156,12 @@ class DataStoreMgr:
             status=WorkflowStatus.STOPPED.value,
             status_msg=self._get_status_msg(w_id, is_active),
         )
+
+        # setup sync subscriber set
+        self.sync_level_workflow_graphql_subs[w_id] = {
+            MIN_LEVEL: set(),
+            MAX_LEVEL: set()
+        }
 
     @log_call
     async def unregister_workflow(self, w_id):
@@ -178,8 +198,9 @@ class DataStoreMgr:
 
         self.delta_queues[w_id] = {}
 
-        # setup sync subscriber set
-        self.full_sync_workflow_gql_subs[w_id] = set()
+        level = MIN_LEVEL
+        if self.sync_level_workflow_graphql_subs[w_id][MAX_LEVEL]:
+            level = MAX_LEVEL
 
         # Might be options other than threads to achieve
         # non-blocking subscriptions, but this works.
@@ -188,10 +209,11 @@ class DataStoreMgr:
             w_id,
             contact_data['name'],
             contact_data[CFF.HOST],
-            contact_data[CFF.PUBLISH_PORT]
+            contact_data[CFF.PUBLISH_PORT],
+            SUBSCRIPTION_LEVELS[level]['topics']
         )
 
-        result = await self.workflow_data_update(w_id, minimal=True)
+        result = await self.workflow_data_update(w_id, level)
 
         if result:
             # don't update the contact data until we have successfully updated
@@ -201,13 +223,12 @@ class DataStoreMgr:
     async def workflow_data_update(
         self,
         w_id: str,
-        minimal: Optional[bool] = None
+        level: str,
     ):
-        if minimal is None:
-            minimal = w_id in self.full_sync_workflows
-        successful_updates = await self._entire_workflow_update(
-            ids=[w_id],
-            minimal=minimal
+        # for some reason mypy doesn't like non-fstring...
+        successful_updates = await self._workflow_update(
+            [w_id],
+            f'{SUBSCRIPTION_LEVELS[level]["request"]}'
         )
 
         if w_id not in successful_updates:
@@ -243,9 +264,6 @@ class DataStoreMgr:
         if w_id in self.w_subs:
             self.w_subs[w_id].stop()
             del self.w_subs[w_id]
-        if w_id in self.full_sync_workflow_gql_subs:
-            del self.full_sync_workflow_gql_subs[w_id]
-            self.full_sync_workflows.discard(w_id)
 
     def get_workflows(self):
         """Return all workflows the data store is currently tracking.
@@ -275,8 +293,10 @@ class DataStoreMgr:
             del self.data[w_id]
         if w_id in self.delta_queues:
             del self.delta_queues[w_id]
+        if w_id in self.sync_level_workflow_graphql_subs:
+            del self.sync_level_workflow_graphql_subs[w_id]
 
-    def _start_subscription(self, w_id, reg, host, port):
+    def _start_subscription(self, w_id, reg, host, port, topics):
         """Instantiate and run subscriber data-store sync.
 
         Args:
@@ -284,6 +304,7 @@ class DataStoreMgr:
             reg (str): Registered workflow name.
             host (str): Hostname of target workflow.
             port (int): Port of target workflow.
+            topics set(str): set of topics to subscribe to.
 
         """
         self.w_subs[w_id] = WorkflowSubscriber(
@@ -291,7 +312,7 @@ class DataStoreMgr:
             host=host,
             port=port,
             context=self.workflows_mgr.context,
-            topics=self.topics
+            topics=topics
         )
         self.w_subs[w_id].loop.run_until_complete(
             self.w_subs[w_id].subscribe(
@@ -324,7 +345,7 @@ class DataStoreMgr:
             self.disconnect_workflow(w_id)
             return
         elif topic == WORKFLOW:
-            if w_id in self.full_sync_workflows:
+            if self.sync_level_workflow_graphql_subs[w_id][MAX_LEVEL]:
                 return
             self._apply_delta(w_id, WORKFLOW, delta)
             # might seem clunky, but as with contact update, making it look
@@ -332,7 +353,7 @@ class DataStoreMgr:
             all_deltas = DELTAS_MAP[ALL_DELTAS]()
             all_deltas.workflow.CopyFrom(delta)
             self._delta_store_to_queues(w_id, ALL_DELTAS, all_deltas)
-        elif w_id in self.full_sync_workflows:
+        else:
             self._apply_all_delta(w_id, delta)
             self._delta_store_to_queues(w_id, topic, delta)
 
@@ -423,10 +444,8 @@ class DataStoreMgr:
             except Exception as exc:
                 self.log.exception(exc)
 
-    async def _entire_workflow_update(
-        self,
-        ids: Optional[list] = None,
-        minimal: Optional[bool] = False
+    async def _workflow_update(
+        self, ids: List[str], req_method: str,
     ) -> Set[str]:
         """Update entire local data-store of workflow(s).
 
@@ -434,9 +453,6 @@ class DataStoreMgr:
             ids: List of workflow external IDs.
 
         """
-        if ids is None:
-            ids = []
-
         # Request new data
         req_time = time.time()
         req_method = 'pb_entire_workflow'
@@ -474,8 +490,6 @@ class DataStoreMgr:
                         key: value.last_updated
                         for key in DATA_TEMPLATE
                     }
-                    continue
-                elif minimal:
                     continue
                 new_data[field.name] = {n.id: n for n in value}
             self.data[w_id] = new_data
@@ -566,32 +580,63 @@ class DataStoreMgr:
             # the workflow has not yet run
             return 'not yet run'
 
+    async def _update_subscription_level(self, w_id, level):
+        """Update level of data subscribed to."""
+        sub = self.w_subs.get(w_id)
+        if sub:
+            stop_topics = sub.topics.difference(
+                SUBSCRIPTION_LEVELS[level]['topics']
+            )
+            start_topics = SUBSCRIPTION_LEVELS[level]['topics'].difference(
+                sub.topics
+            )
+            for stop_topic in stop_topics:
+                sub.unsubscribe_topic(stop_topic)
+            # Doing this after unsubscribe and before subscribe
+            # to make sure old topics stop and new data is in place.
+            await self.workflow_data_update(w_id, level)
+            for start_topic in start_topics:
+                sub.subscribe_topic(start_topic)
+
     def graphql_sub_interrogate(self, sub_id, info):
         """Scope data requirements."""
         fragments = set(info.fragments.keys())
         minimal = (
-            fragments <= self.min_sync_fragments
+            (
+                fragments
+                <= SUBSCRIPTION_LEVELS[MIN_LEVEL]['criteria']['fragments']
+            )
             and bool(fragments)
         )
-        if not minimal:
-            self.full_sync_gql_subs.add(sub_id)
-        return minimal
+        if minimal:
+            self.sync_level_graphql_subs[MIN_LEVEL].add(sub_id)
+            return
+        self.sync_level_graphql_subs[MAX_LEVEL].add(sub_id)
 
     async def graphql_sub_data_match(self, w_id, sub_id):
         """Match store data level to requested graphql subscription."""
-        if (
-            sub_id in self.full_sync_gql_subs
-            and sub_id not in self.full_sync_workflow_gql_subs[w_id]
-        ):
-            self.full_sync_workflow_gql_subs[w_id].add(sub_id)
-            await self.workflow_data_update(w_id, minimal=False)
+        sync_level_wsubs = self.sync_level_workflow_graphql_subs[w_id]
+        if sub_id in self.sync_level_graphql_subs[MAX_LEVEL]:
+            if not sync_level_wsubs[MAX_LEVEL]:
+                sync_level_wsubs[MAX_LEVEL].add(sub_id)
+                await self._update_subscription_level(w_id, MAX_LEVEL)
+        else:
+            sync_level_wsubs[MIN_LEVEL].add(sub_id)
 
-            self.full_sync_workflows.add(w_id)
-
-    def graphql_sub_discard(self, sub_id):
+    async def graphql_sub_discard(self, sub_id):
         """Discard graphql subscription references."""
-        self.full_sync_gql_subs.discard(sub_id)
-        for w_id in self.full_sync_workflow_gql_subs:
-            self.full_sync_workflow_gql_subs[w_id].discard(w_id)
-            if not self.full_sync_workflow_gql_subs[w_id]:
-                self.full_sync_workflows.discard(w_id)
+        level = MIN_LEVEL
+        if sub_id in self.sync_level_graphql_subs[MAX_LEVEL]:
+            level = MAX_LEVEL
+        self.sync_level_graphql_subs[level].discard(sub_id)
+        for w_id in self.sync_level_workflow_graphql_subs:
+            self.sync_level_workflow_graphql_subs[w_id][level].discard(
+                sub_id
+            )
+            # if there are no more max level subscriptions after removal
+            # of a max level sub, downgrade to min.
+            if (
+                not self.sync_level_workflow_graphql_subs[w_id][level]
+                and level is MAX_LEVEL
+            ):
+                await self._update_subscription_level(w_id, MIN_LEVEL)

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -311,7 +311,10 @@ class DataStoreMgr:
         level: Set[str],
     ):
         requests = set()
-        if ALL_DELTAS in level:
+        # If level has all fields, just use one request.
+        # As BACK COMPAT workflows automatically contain all fields they will
+        # use this request.
+        if DATA_TEMPLATE.keys() <= level:
             requests.add(SUBSCRIPTION_CATALOGUE[ALL_DELTAS]["request"])
         else:
             requests.update(
@@ -522,14 +525,19 @@ class DataStoreMgr:
             [getattr(e, s_att)
              for e in self.data[w_id][topic].values()])
         if local_checksum != delta.checksum:
-            self.log.debug(
+            self.log.warn(
                 f'Out of sync with {topic} of {w_id}... Reconciling.')
             try:
+                # BACK COMPAT: see cylc/cylc-flow/pull/6113 for API changes.
+                if self.data[w_id]['workflow'].cylc_version < '8.7':
+                    end_point = 'pb_data_elements'
+                else:
+                    end_point = 'pb_delta_elements'
                 # use threadsafe as client socket is in main loop thread.
                 future = asyncio.run_coroutine_threadsafe(
                     workflow_request(
                         self.workflows_mgr.workflows[w_id]['req_client'],
-                        'pb_delta_elements',
+                        end_point,
                         args={'element_type': topic}
                     ),
                     self.loop
@@ -641,6 +649,7 @@ class DataStoreMgr:
             flow.host = contact_data[CFF.HOST]
             flow.port = int(contact_data[CFF.PORT])
             flow.api_version = int(contact_data[CFF.API])
+            flow.cylc_version = contact_data[CFF.VERSION]
         else:
             # wipe pre-existing contact-file data
             w_tokens = Tokens(w_id)
@@ -649,6 +658,7 @@ class DataStoreMgr:
             flow.host = ''
             flow.port = 0
             flow.api_version = 0
+            flow.cylc_version = '0'
 
         if status is not None:
             flow.status = status
@@ -690,6 +700,9 @@ class DataStoreMgr:
     def _get_sync_level(self, w_id) -> set:
         """Return the sync level in the form of a set of catalogue items."""
         level = set()
+        # BACK COMPAT: see cylc/cylc-flow/pull/6113 for API changes.
+        if self.data[w_id]['workflow'].cylc_version < '8.7':
+            level.update(DATA_TEMPLATE)
         if (
             w_id in self.workflow_query_sync_timers
             and self.workflow_query_sync_timers[w_id]['expiry'] > 0

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -50,11 +50,12 @@ import psutil
 from cylc.flow.data_store_mgr import WORKFLOW
 from cylc.flow.exceptions import CylcError
 from cylc.flow.id import Tokens
-from cylc.flow.network.resolvers import BaseResolvers
+from cylc.flow.network.resolvers import BaseResolvers, workflow_filter
 from cylc.flow.scripts.clean import CleanOptions, run
 from cylc.flow.util import natural_sort_key
 
 from cylc.uiserver.utils import cast_non_null
+
 
 if TYPE_CHECKING:
     from concurrent.futures import Executor
@@ -573,11 +574,12 @@ class Resolvers(BaseResolvers):
             )
         }
         w_ids = [
-            flow[WORKFLOW].id
-            for flow in await self.get_workflows_data(w_args)]
+            workflow[WORKFLOW].id
+            for workflow in self.data_store_mgr.data.values()
+            if workflow_filter(workflow, w_args)
+        ]
         if not w_ids:
-            return [{
-                'response': (False, 'No matching workflows')}]
+            return [{'response': (False, 'No matching workflows')}]
         # Pass the request to the workflow GraphQL endpoints
         _, variables, _, _ = info.context.get(  # type: ignore[union-attr]
             'graphql_params'

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -29,8 +29,8 @@ from cylc.flow.workflow_files import ContactFileFields as CFF
 from cylc.uiserver.data_store_mgr import (
     DataStoreMgr,
     ALL_DELTAS,
-    MAX_LEVEL,
-    SUBSCRIPTION_LEVELS
+    WORKFLOW,
+    SUBSCRIPTION_CATALOGUE
 )
 
 from typing import TYPE_CHECKING
@@ -59,7 +59,8 @@ async def test_workflow_update(
     # calling ``workflow_request``.
     await data_store_mgr._workflow_update(
         [w_id],
-        SUBSCRIPTION_LEVELS[MAX_LEVEL]["request"]
+        SUBSCRIPTION_CATALOGUE[WORKFLOW]["request"],
+        elements=[WORKFLOW]
     )
 
     # The ``DataStoreMgr`` sets the workflow data retrieved in its
@@ -94,7 +95,8 @@ async def test_workflow_update_ignores_timeout_message(
     # calling ``workflow_request``.
     await data_store_mgr._workflow_update(
         [w_id],
-        SUBSCRIPTION_LEVELS[MAX_LEVEL]["request"]
+        SUBSCRIPTION_CATALOGUE[WORKFLOW]["request"],
+        elements=[WORKFLOW]
     )
 
     # When a ClientTimeout happens, the ``DataStoreMgr`` object ignores
@@ -130,7 +132,8 @@ async def test_workflow_update_gather_error(
     # calling ``workflow_request``.
     await data_store_mgr._workflow_update(
         ['workflow_id'],
-        SUBSCRIPTION_LEVELS[MAX_LEVEL]["request"]
+        SUBSCRIPTION_CATALOGUE[WORKFLOW]["request"],
+        elements=[WORKFLOW]
     )
     assert caplog.record_tuples == [
         ('cylc', 40, 'Error communicating with myflow'),
@@ -156,7 +159,8 @@ async def test_workflow_update__stopped_workflow(
     }
     await data_store_mgr._workflow_update(
         ['workflow_id'],
-        SUBSCRIPTION_LEVELS[MAX_LEVEL]["request"]
+        SUBSCRIPTION_CATALOGUE[WORKFLOW]["request"],
+        elements=[WORKFLOW]
     )
     assert caplog.record_tuples == [
         ('cylc', 40, f'WorkflowStopped: {exc}'),
@@ -295,7 +299,7 @@ async def test_workflow_connect_fail(
         # WorkflowRuntimeServer with the correct endpoints and auth
         assert [record.message for record in caplog.records] == [
             "[data-store] connect_workflow('~user/workflow_id', <dict>)",
-            "[data-store] workflow_data_update('~user/workflow_id', 'min')",
+            "[data-store] workflow_data_update('~user/workflow_id', <set>)",
             'failed to connect to ~user/workflow_id',
             "[data-store] disconnect_workflow('~user/workflow_id')",
         ]

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -29,8 +29,9 @@ from cylc.flow.workflow_files import ContactFileFields as CFF
 from cylc.uiserver.data_store_mgr import (
     DataStoreMgr,
     ALL_DELTAS,
-    WORKFLOW,
-    SUBSCRIPTION_CATALOGUE
+    SUBSCRIPTION_CATALOGUE,
+    TASK_PROXIES,
+    WORKFLOW
 )
 
 from typing import TYPE_CHECKING
@@ -353,6 +354,7 @@ async def test_update_workflow_data(
     # Pretend data store is populated for this workflow:
     w_id_data['workflow'].last_updated = time()
     # Call the _update_workflow_data function.
+    data_store_mgr.workflow_sync_level[w_id].add(TASK_PROXIES)
     data_store_mgr._update_workflow_data(ALL_DELTAS, all_updated_delta, w_id)
 
     # The data-store sould now contain info from the delta

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -26,7 +26,12 @@ from cylc.flow.id import Tokens
 from cylc.flow.network import ZMQSocketBase
 from cylc.flow.workflow_files import ContactFileFields as CFF
 
-from cylc.uiserver.data_store_mgr import DataStoreMgr, ALL_DELTAS
+from cylc.uiserver.data_store_mgr import (
+    DataStoreMgr,
+    ALL_DELTAS,
+    MAX_LEVEL,
+    SUBSCRIPTION_LEVELS
+)
 
 from typing import TYPE_CHECKING
 
@@ -34,12 +39,12 @@ if TYPE_CHECKING:
     from .conftest import AsyncClientFixture
 
 
-async def test_entire_workflow_update(
+async def test_workflow_update(
     async_client: 'AsyncClientFixture',
     data_store_mgr: DataStoreMgr,
     make_entire_workflow
 ):
-    """Test that ``entire_workflow_update`` is executed successfully."""
+    """Test that ``_workflow_update`` is executed successfully."""
     w_id = 'workflow_id'
     entire_workflow = make_entire_workflow(f'{w_id}')
     async_client.will_return(entire_workflow.SerializeToString())
@@ -49,10 +54,13 @@ async def test_entire_workflow_update(
         'req_client': async_client
     }
 
-    # Call the entire_workflow_update function.
+    # Call the _workflow_update function.
     # This should use the client defined above (``async_client``) when
     # calling ``workflow_request``.
-    await data_store_mgr._entire_workflow_update()
+    await data_store_mgr._workflow_update(
+        [w_id],
+        SUBSCRIPTION_LEVELS[MAX_LEVEL]["request"]
+    )
 
     # The ``DataStoreMgr`` sets the workflow data retrieved in its
     # own ``.data`` dictionary, which will contain Protobuf message
@@ -65,12 +73,12 @@ async def test_entire_workflow_update(
     assert entire_workflow.workflow.id == w_id_data['workflow'].id
 
 
-async def test_entire_workflow_update_ignores_timeout_message(
+async def test_workflow_update_ignores_timeout_message(
     async_client: 'AsyncClientFixture',
     data_store_mgr: DataStoreMgr
 ):
     """
-    Test that ``entire_workflow_update`` ignores if the client
+    Test that ``_workflow_update`` ignores if the client
     receives a ``MSG_TIMEOUT`` message.
     """
     w_id = 'workflow_id'
@@ -81,10 +89,13 @@ async def test_entire_workflow_update_ignores_timeout_message(
         'req_client': async_client
     }
 
-    # Call the entire_workflow_update function.
+    # Call the _workflow_update function.
     # This should use the client defined above (``async_client``) when
     # calling ``workflow_request``.
-    await data_store_mgr._entire_workflow_update()
+    await data_store_mgr._workflow_update(
+        [w_id],
+        SUBSCRIPTION_LEVELS[MAX_LEVEL]["request"]
+    )
 
     # When a ClientTimeout happens, the ``DataStoreMgr`` object ignores
     # that message. So it means that its ``.data`` dictionary MUST NOT
@@ -92,13 +103,13 @@ async def test_entire_workflow_update_ignores_timeout_message(
     assert w_id not in data_store_mgr.data
 
 
-async def test_entire_workflow_update_gather_error(
+async def test_workflow_update_gather_error(
     async_client: 'AsyncClientFixture',
     data_store_mgr: DataStoreMgr,
     caplog: pytest.LogCaptureFixture,
 ):
     """
-    Test that if ``asyncio.gather`` in ``entire_workflow_update``
+    Test that if ``asyncio.gather`` in ``_workflow_update``
     has a coroutine raising an error, it will handle the error correctly.
     """
     # The ``AsyncClient`` will raise an error. This will happen when
@@ -114,10 +125,13 @@ async def test_entire_workflow_update_gather_error(
         'req_client': async_client
     }
 
-    # Call the entire_workflow_update function.
+    # Call the _workflow_update function.
     # This should use the client defined above (``async_client``) when
     # calling ``workflow_request``.
-    await data_store_mgr._entire_workflow_update()
+    await data_store_mgr._workflow_update(
+        ['workflow_id'],
+        SUBSCRIPTION_LEVELS[MAX_LEVEL]["request"]
+    )
     assert caplog.record_tuples == [
         ('cylc', 40, 'Error communicating with myflow'),
         ('cylc', 40, 'x'),
@@ -128,19 +142,22 @@ async def test_entire_workflow_update_gather_error(
     assert exc_info and exc_info[0] is ValueError
 
 
-async def test_entire_workflow_update__stopped_workflow(
+async def test_workflow_update__stopped_workflow(
     async_client: 'AsyncClientFixture',
     data_store_mgr: DataStoreMgr,
     caplog: pytest.LogCaptureFixture,
 ):
-    """Test that DataStoreMgr._entire_workflow_update() handles a stopped
+    """Test that DataStoreMgr._workflow_update() handles a stopped
     workflow reasonably."""
     exc = WorkflowStopped('myflow')
     async_client.will_return(exc)
     data_store_mgr.workflows_mgr.workflows['workflow_id'] = {
         'req_client': async_client
     }
-    await data_store_mgr._entire_workflow_update()
+    await data_store_mgr._workflow_update(
+        ['workflow_id'],
+        SUBSCRIPTION_LEVELS[MAX_LEVEL]["request"]
+    )
     assert caplog.record_tuples == [
         ('cylc', 40, f'WorkflowStopped: {exc}'),
     ]
@@ -278,6 +295,7 @@ async def test_workflow_connect_fail(
         # WorkflowRuntimeServer with the correct endpoints and auth
         assert [record.message for record in caplog.records] == [
             "[data-store] connect_workflow('~user/workflow_id', <dict>)",
+            "[data-store] workflow_data_update('~user/workflow_id', 'min')",
             'failed to connect to ~user/workflow_id',
             "[data-store] disconnect_workflow('~user/workflow_id')",
         ]


### PR DESCRIPTION
addresses https://github.com/cylc/cylc-uiserver/issues/585
addresses https://github.com/cylc/cylc-uiserver/issues/568

Sibling https://github.com/cylc/cylc-flow/pull/6113

This change aims to:
- [x] interrogate the graphql subscription for data requirements.
- [x] Sync only the data required.
- [x] Reduce the protobuf subscription topics and all data dump size.
- [x] Handle data requirements for queries.

This first attempt is functional, reads the fragments requested by the UI with
```{'AddedDelta', 'WorkflowData', 'UpdatedDelta'}```
being the workflow summary information of the dashboard subscription.

~~The UI doesn't seem to reduce the subscription if you go from tree view to dashboard, however, closing the UI will reduce it back down.~~

- [x] One thing we need to be able to handle is general queries hitting the UIS, as we'll want CLI via UIS in at some point and to be able to handle random queries.. For this I think we can use that timer concept, keeping a full sync of workflows queried for some amount of time.. **Done**


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
