### PR TITLE
More gracefully override JPS `ExtensionApp.config_file_paths`

### DIFF
--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -59,7 +59,7 @@ import os
 from pathlib import Path, PurePath
 import sys
 from textwrap import dedent
-from typing import List
+from typing import List, Optional
 
 from pkg_resources import parse_version
 from tornado import ioloop
@@ -145,15 +145,6 @@ class CylcUIServer(ExtensionApp):
     cylc gui --no-browser     # Start the server but don't open the browser
 
     ''')  # type: ignore[assignment]
-    config_file_paths = get_conf_dir_hierarchy(
-        [
-            SITE_CONF_ROOT,  # site configuration
-            USER_CONF_ROOT,  # user configuration
-        ], filename=False
-    )
-    # Next include currently needed for directory making
-    config_file_paths.insert(0, str(Path(uis_pkg).parent))  # packaged config
-    config_file_paths.reverse()
     # TODO: Add a link to the access group table mappings in cylc documentation
     # https://github.com/cylc/cylc-uiserver/issues/466
     AUTH_DESCRIPTION = '''
@@ -405,6 +396,7 @@ class CylcUIServer(ExtensionApp):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._config_file_paths: Optional[List[str]] = None
         self.executor = ProcessPoolExecutor(max_workers=self.max_workers)
         self.workflows_mgr = WorkflowsManager(self, log=self.log)
         self.data_store_mgr = DataStoreMgr(
@@ -420,6 +412,21 @@ class CylcUIServer(ExtensionApp):
             executor=self.executor,
             workflows_mgr=self.workflows_mgr,
         )
+
+    @property
+    def config_file_paths(self) -> List[str]:
+        if self._config_file_paths is None:
+            ret = get_conf_dir_hierarchy(
+                [
+                    SITE_CONF_ROOT,  # site configuration
+                    USER_CONF_ROOT,  # user configuration
+                ], filename=False
+            )
+            # Next include currently needed for directory making
+            ret.insert(0, str(Path(uis_pkg).parent))  # packaged config
+            ret.reverse()
+            self._config_file_paths = ret
+        return self._config_file_paths
 
     def initialize_settings(self):
         """Update extension settings.

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -14,17 +14,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Test code and fixtures."""
 
-from getpass import getuser
 import inspect
 import logging
 from pathlib import Path
 from shutil import rmtree
-from socket import gethostname
 from tempfile import TemporaryDirectory
 from uuid import uuid4
 
 import pytest
-from tornado.web import HTTPError
 from traitlets.config import Config
 import zmq
 
@@ -46,6 +43,7 @@ from cylc.uiserver.workflows_mgr import WorkflowsManager
 from cylc.flow.cfgspec.globalcfg import SPEC
 from cylc.flow.parsec.config import ParsecConfig
 from cylc.flow.parsec.validate import cylc_config_validate
+
 
 class AsyncClientFixture(WorkflowRuntimeClient):
     pattern = zmq.REQ
@@ -223,7 +221,7 @@ def mock_authentication_yossarian(monkeypatch):
 def jp_server_config(jp_template_dir):
     """Config to turn the CylcUIServer extension on.
 
-    Auto-loading, add as an argument in the test function to activate.
+    Overrides jupyter server fixture of the same name.
     """
     config = {
         "ServerApp": {
@@ -235,12 +233,9 @@ def jp_server_config(jp_template_dir):
     return config
 
 
-@pytest.fixture
-def patch_conf_files(monkeypatch):
-    """Auto-patches the CylcUIServer to prevent it loading config files.
-
-    Auto-loading, add as an argument in the test function to activate.
-    """
+@pytest.fixture(autouse=True)
+def patch_conf_files(monkeypatch: pytest.MonkeyPatch):
+    """Auto-patches the CylcUIServer to prevent it loading config files."""
     monkeypatch.setattr(
         'cylc.uiserver.app.CylcUIServer.config_file_paths', []
     )
@@ -363,6 +358,7 @@ def workflow_run_dir(request):
     yield flow_name, log_dir
     if not request.session.testsfailed:
         rmtree(run_dir)
+
 
 @pytest.fixture
 def mock_glbl_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/cylc/uiserver/tests/test_auth.py
+++ b/cylc/uiserver/tests/test_auth.py
@@ -23,7 +23,7 @@ from tornado.httpclient import HTTPClientError
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("mock_authentication_yossarian")
-async def test_cylc_handler(patch_conf_files, jp_fetch):
+async def test_cylc_handler(jp_fetch):
     """The Cylc endpoints have been added and work."""
     resp = await jp_fetch(
         'cylc', 'userprofile', method='GET'
@@ -60,7 +60,6 @@ async def test_cylc_handler(patch_conf_files, jp_fetch):
     ]
 )
 async def test_authorised_and_authenticated(
-    patch_conf_files,
     jp_fetch,
     endpoint,
     code,
@@ -95,7 +94,6 @@ async def test_authorised_and_authenticated(
     ]
 )
 async def test_unauthorised(
-    patch_conf_files,
     jp_fetch,
     endpoint,
     code,


### PR DESCRIPTION
This allows patching in the tests so the tests don't pick up our user/site configs. Currently the tests fail locally for me because they pick up my config.