### PR TITLE
setup: types-pkg-resources -> types-setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -103,7 +103,7 @@ tests =
     # https://github.com/pytest-dev/pytest/issues/12263
     pytest>=6,<8.2
     towncrier>=23
-    types-pkg_resources>=0.1.2
+    types-setuptools
     types-requests>2
 all =
     %(hub)s


### PR DESCRIPTION
Dev installation is currently broken due to a "yanked" project ?!

Follow the instructions on this page:

https://pypi.org/project/types-pkg-resources/