### PR TITLE
Towncrier: check fragment names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,8 +79,7 @@ jobs:
         run: mypy
 
       - name: Check changelog
-        if: startsWith(matrix.os, 'ubuntu')
-        run: towncrier build --draft
+        uses: cylc/release-actions/towncrier-draft@v1
 
       - name: Test
         run: pytest

--- a/changes.d/607.fix.md
+++ b/changes.d/607.fix.md
@@ -1,0 +1,1 @@
+Log any errors when trying to list the workflow/job log files in the UI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ template = "changes.d/changelog-template.jinja"
 underlines = ["", "", ""]
 title_format = "## cylc-uiserver-{version} (Released {project_date})"
 issue_format = "[#{issue}](https://github.com/cylc/cylc-uiserver/pull/{issue})"
+ignore = ["changelog-template.jinja"]
 
 # These changelog sections will be shown in the defined order:
 [[tool.towncrier.type]]

--- a/setup.cfg
+++ b/setup.cfg
@@ -102,7 +102,7 @@ tests =
     pytest-tornasync>=0.5.0
     # https://github.com/pytest-dev/pytest/issues/12263
     pytest>=6,<8.2
-    towncrier>=23
+    towncrier>=24.7.0
     types-setuptools
     types-requests>2
 all =


### PR DESCRIPTION
Thanks to [twisted/towncrier#622](https://github.com/twisted/towncrier/pull/622), `towncrier build` will now fail on CI if anyone creates a changelog fragment with an invalid name.

Also added a changelog entry for #607 after changing my mind and realising one would be useful

