### PR TITLE
Add command to enable Cylc uiserver in Jupyter launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ However, you can also deploy Jupyter Hub separately from the servers it
 deploys (e.g. Jupyter Lab or Cylc UI Server) and launch it via the `jupyterhub`
 command.
 
+Enable the Cylc UI Server in `jupyterhub` or `jupyter lab` by running
+```bash
+jupyter server extension enable --py cylc.uiserver
+```
+The Cylc UI will be available by replacing `/lab` in the URL with `/cylc`.
+
 If you are deploying Jupyter Hub separately from Cylc UI Server, these
 configurations may be relevant:
 


### PR DESCRIPTION
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

An `enable` command appears to be necessary to have the UI server installed alongside Jupyter lab, add this to the instructions.

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
