### PR TITLE
shutdown: terminate subprocesses

### DIFF
--- a/changes.d/619.fix.md
+++ b/changes.d/619.fix.md
@@ -1,0 +1,1 @@
+Ensure that subprocesses created by Cylc UI Server are cleaned up correctly when the server shuts down.

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -580,10 +580,17 @@ class CylcUIServer(ExtensionApp):
     async def stop_extension(self):
         # stop the async scan task
         await self.workflows_mgr.stop()
+
+        # stop active subscriptions
         for sub in self.data_store_mgr.w_subs.values():
             sub.stop()
-        # Shutdown the thread pool executor
+
+        # Shutdown the thread pool executor (used for subscription processing)
         self.data_store_mgr.executor.shutdown(wait=False)
+
+        # stop the process pool (used for background commands)
+        self.executor.shutdown()
+
         # Destroy ZeroMQ context of all sockets
         self.workflows_mgr.context.destroy()
         self.profiler.stop()


### PR DESCRIPTION
Backport of https://github.com/cylc/cylc-uiserver/pull/619

Not sure why I put the original fix on master. It might have been because I was anticipating bumping the jupyterhub min requirement to pick up the bugfix, it might just have been an accident.

We could do with this sooner rather than later now we've got a larger deployment in the wild.

---

* We use a subprocess pool for running backgorund commands (e.g. `cylc clean`).
* This creates subprocesses to run our commands in, however, it does not kill the subprocess once the command has completed, it keeps the subprocess open for future reuse (more efficient than creating and destroying them every time).
* On shutdown we need to close the pool to mop up these subprocesses (this doesn't happen automatically).


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.