### PR TITLE
add jupyter extensions to userprofile handler

### DIFF
--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
 
 ME = getpass.getuser()
-RE_SLASH = x = re.compile(r'\/+')
+RE_SLASH = re.compile(r'\/+')
 
 
 def authorised(fun: Callable) -> Callable:

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -18,6 +18,7 @@ from functools import wraps
 import json
 import getpass
 import os
+import re
 from typing import TYPE_CHECKING, Callable, Dict
 
 from graphene_tornado.tornado_graphql_handler import TornadoGraphQLHandler
@@ -44,6 +45,7 @@ if TYPE_CHECKING:
 
 
 ME = getpass.getuser()
+RE_SLASH = x = re.compile(r'\/+')
 
 
 def authorised(fun: Callable) -> Callable:
@@ -258,7 +260,6 @@ class UserProfileHandler(CylcAppHandler):
         self.set_header("Content-Type", 'application/json')
 
     @web.authenticated
-    # @authorised  TODO: I can't think why we would want to authorise this
     def get(self):
         user_info = {
             **self.current_user.__dict__,
@@ -281,6 +282,19 @@ class UserProfileHandler(CylcAppHandler):
             user_info['mode'] = 'single user'
         else:
             user_info['mode'] = 'multi user'
+
+        user_info['extensions'] = {
+            app.name: RE_SLASH.sub(
+                '/', f'{self.serverapp.base_url}/{app.default_url}'
+            )
+            for extension_apps
+            in self.serverapp.extension_manager.extension_apps.values()
+            # filter out extensions that do not provide a default_url OR
+            # set it to the root endpoint.
+            for app in extension_apps
+            if getattr(app, 'default_url', '/') != '/'
+        }
+
         self.write(json.dumps(user_info))
 
 

--- a/cylc/uiserver/tests/test_handlers.py
+++ b/cylc/uiserver/tests/test_handlers.py
@@ -15,6 +15,7 @@
 
 from functools import partial
 from getpass import getuser
+import json
 from unittest import mock
 from unittest.mock import MagicMock
 import pytest
@@ -120,3 +121,19 @@ class SubscriptionHandlerTest(AsyncHTTPTestCase):
         self.io_loop.run_sync(handler.open,
                               get_async_test_timeout())
         handler.subscription_server.handle.assert_called_once()
+
+
+@pytest.mark.integration
+async def test_userprofile(
+    jp_fetch, cylc_uis, jp_serverapp,
+):
+    """Test the userprofile endpoint."""
+    # patch the default_url back to how it is set in cylc.uiserver.app
+    cylc_uis.default_url = '/cylc'
+
+    response = await jp_fetch('cylc', 'userprofile')
+    user_profile = json.loads(response.body.decode())
+    assert user_profile['username'] == getuser()
+    assert user_profile['owner'] == getuser()
+    assert 'read' in user_profile['permissions']
+    assert 'cylc' in user_profile['extensions']


### PR DESCRIPTION
Partially addresses https://github.com/cylc/cylc-uiserver/issues/470

List Jupyter server extensions that provide web applications (i.e. cylc & lab) in the "userprofile".

* https://github.com/cylc/cylc-ui/pull/1982 uses this to add a Jupyter Lab button to the dashboard page of the Cylc UI.
* A Jupyter Lab plugin might use this to add a button to Cylc (and any other Jupyter web apps) into the Jupyter Lab menu, similar to https://github.com/cylc/cylc-uiserver/issues/298#issuecomment-1054848447.

I might see if I can get the implementation into Jupyter Server in the future (opened https://github.com/jupyter-server/jupyter_server/pull/1469). We will probably want to continue merging this into our own `userprofile` endpoint for convenience though.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users (it doesn't)
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.