### PR TITLE
cat-log: add timeout to processes

### DIFF
--- a/changes.d/645.fix.md
+++ b/changes.d/645.fix.md
@@ -1,0 +1,2 @@
+Add a default timeout for the `cylc cat-log` command which is used to provide access to log files in the cylc-ui.
+This timeout can be adjusted with the `log_timeout` option.

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -339,6 +339,26 @@ class CylcUIServer(ExtensionApp):
         default_value=False,
     )
 
+    log_timeout = Float(
+        # Note: This timeout it intended to clean up log streams that are no
+        # longer being actively monitored and prevent the associated "cat-log"
+        # processes from persisting in situations where they should not be
+        # (e.g. if the websocket connection unexpectedly closes)
+        config=True,
+        help='''
+            The maximum length of time Cylc will stream a log file for in
+            seconds.
+
+            The "Log" view in the Cylc GUI streams log files allowing you to
+            monitor the file while is grows.
+
+            After the configured timeout, the stream will close. The log
+            view in the GUI will display a "reconnect" button allowing you
+            to restart the stream if desired.
+        ''',
+        default_value=(60 * 60 * 4),  # 4 hours
+    )
+
     @validate('ui_build_dir')
     def _check_ui_build_dir_exists(self, proposed):
         if proposed['value'].exists():
@@ -407,6 +427,7 @@ class CylcUIServer(ExtensionApp):
         # sub_status dictionary storing status of subscriptions
         self.sub_statuses = {}
         self.resolvers = Resolvers(
+            self,
             self.data_store_mgr,
             log=self.log,
             executor=self.executor,

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -392,7 +392,7 @@ class Services:
         # track the number of lines received so far
         line_count = 0
 
-        # the time we started the cylc cat-loo process
+        # the time we started the cylc cat-log process
         start_time = time()
 
         # configured cat-log process timeout


### PR DESCRIPTION
* Partially addresses #643
* Add a timeout to `cylc cat-log` processes:
  * Ensures we don't accumulate them by accident.
  * Improves efficiency by closing long-lived log streams (the user probably isn't looking at the log file any more and the log file has probably stopped growing anyway).
* At present, `cylc cat-log` processes may be left behind if the websocket is closed abruptly. This has been observed as the result of a proxy timeout.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.