### PR TITLE
GH Actions: downgrade MacOS runner to 12 to retain Python 3.9 testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         os: ['ubuntu-latest']
         python: ['3.8', '3.9']
         include:
-          - os: 'macos-latest'
+          - os: 'macos-12'
             python: '3.8'
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         os: ['ubuntu-latest']
         python: ['3.8', '3.9']
         include:
-          - os: 'macos-latest'
+          - os: 'macos-12'
             python: '3.9'
     env:
       PYTEST_ADDOPTS: --cov --color=yes


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10812