### PR TITLE
gui: always allow starting a standalone GUI with --new

### DIFF
--- a/changes.d/661.feat.md
+++ b/changes.d/661.feat.md
@@ -1,0 +1,1 @@
+The GUI can now be launched in standalone mode even if `[hub]url` is configured using the `--new` option.

--- a/changes.d/661.feat.md
+++ b/changes.d/661.feat.md
@@ -1,1 +1,1 @@
-The GUI can now be launched in standalone mode even if `[hub]url` is configured using the `--new` option.
+The GUI can now be launched in standalone mode even if `[hub]url` is configured, using the `--new` option.

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -142,7 +142,9 @@ class CylcUIServer(ExtensionApp):
     cylc gui                  # Start the Cylc GUI (at the dashboard page)
     cylc gui [workflow]       # Start the Cylc GUI (at the workflow page)
     cylc gui --new [workflow] # Start a new Cylc server instance if an old one
-                              # has become unresponsive.
+                              # has become unresponsive, or, if the GUI has
+                              # been configured to launch via a centralised
+                              # hub.
     cylc gui --no-browser     # Start the server but don't open the browser
 
     ''')  # type: ignore[assignment]

--- a/cylc/uiserver/scripts/gui.py
+++ b/cylc/uiserver/scripts/gui.py
@@ -75,7 +75,7 @@ def main(*argv):
             '''))
         return
     if not {'--help', '--help-all'} & set(sys.argv):
-        if hub_url:
+        if hub_url and not new_gui:
             print(f"Running on {hub_url } as specified in global config.")
             webbrowser.open(
                 update_url(hub_url, workflow_id), autoraise=True


### PR DESCRIPTION
This way, when we configure `[hub]url`, we are not prohibiting standalone use.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.