### PR TITLE
GH Actions: automatically use latest `pypa/gh-action-pypi-publish` 

### DIFF
--- a/.github/workflows/2_auto_publish_release.yml
+++ b/.github/workflows/2_auto_publish_release.yml
@@ -39,7 +39,7 @@ jobs:
       uses: cylc/release-actions/build-python-package@v1
 
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.12.2
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__ # uses the API token feature of PyPI - least permissions possible
         password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Like we do in https://github.com/cylc/cylc-flow/pull/6522

