### PR TITLE
events: create an event to open a new tab in Jupyter Lab

### DIFF
--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -95,6 +95,7 @@ from cylc.uiserver.data_store_mgr import DataStoreMgr
 from cylc.uiserver.handlers import (
     CylcStaticHandler,
     CylcVersionHandler,
+    CylcLabBridgeHandler,
     SubscriptionHandler,
     UIServerGraphQLHandler,
     UserProfileHandler,
@@ -491,6 +492,11 @@ class CylcUIServer(ExtensionApp):
             self.scan_interval * 1000
         ).start()
 
+        # register Jupyter Event schemas
+        self.serverapp.event_logger.register_event_schema(
+            Path(__file__).parent / 'event_schemas/test.yml'
+        )
+
     def initialize_handlers(self):
         self.authobj = self.set_auth()
         self.set_sub_server()
@@ -499,6 +505,11 @@ class CylcUIServer(ExtensionApp):
             (
                 'cylc/version',
                 CylcVersionHandler,
+                {'auth': self.authobj}
+            ),
+            (
+                'cylc/lab-bridge/([^/]+)/(.*)',
+                CylcLabBridgeHandler,
                 {'auth': self.authobj}
             ),
             (

--- a/cylc/uiserver/event_schemas/test.yml
+++ b/cylc/uiserver/event_schemas/test.yml
@@ -1,0 +1,11 @@
+$id: http://events.cylc.org/test
+version: 1
+title: Test
+description: An interesting event to collect
+properties:
+  name:
+    title: Name of Event
+    type: string
+  path:
+    title: File to open
+    type: string

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -18,6 +18,7 @@ from functools import wraps
 import json
 import getpass
 import os
+from pathlib import Path
 import re
 from typing import TYPE_CHECKING, Callable, Dict
 
@@ -204,6 +205,26 @@ class CylcStaticHandler(CylcAppHandler, web.StaticFileHandler):
             # (doesn't prevent browser storing the response):
             self.set_header('Cache-Control', 'no-cache')
         return web.StaticFileHandler.get(self, path)
+
+
+class CylcLabBridgeHandler(CylcAppHandler):
+
+    @authorised
+    @web.authenticated
+    def get(self, event, path):
+        from urllib.parse import unquote
+        path = Path(unquote(path))
+        if not path.is_absolute():
+            path = Path('~', path)
+        path.expanduser()
+        path = path.relative_to(Path('~').expanduser())
+
+        event = {'name': event, 'path': str(path)}
+        self.serverapp.event_logger.emit(
+            schema_id='http://events.cylc.org/test',
+            data=event,
+        )
+        self.write(f'<pre>{event}</pre>')
 
 
 class CylcVersionHandler(CylcAppHandler):


### PR DESCRIPTION
Training day exercise: Write a Jupyter Lab plugin

* Offers an "open in Jupyter Lab" button in the Log view (when Jupyter Lab is installed).
* Works with https://github.com/oliver-sanders/cylc-jupyterlab-extension

How it works:

* The user is presented an "Open in Jupyter Lab" button in cylc-ui.
* When pressed, cylc-ui sends a REST request to the URL lab-bridge/open/<file>
* When this request is received, cylc-uiserver logs an "event" with [Jupyter Events](https://github.com/jupyter/jupyter_events).
* This event is bubbled up to all components (incl, Lab).
* [A Jupyter Lab extension](https://github.com/oliver-sanders/cylc-jupyterlab-extension) listens for this event and opens files when it receives one.

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
