### PR TITLE
Make `/version` endpoint return cylc-flow and UIS versions as JSON

### DIFF
--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -15,33 +15,42 @@
 
 from asyncio import Queue
 from functools import wraps
-import json
 import getpass
+import json
 import os
 import re
-from typing import TYPE_CHECKING, Callable, Dict
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+)
 
+from cylc.flow import __version__ as cylc_flow_version
 from graphene_tornado.tornado_graphql_handler import TornadoGraphQLHandler
 from graphql import get_default_backend
 from graphql_ws.constants import GRAPHQL_WS
 from jupyter_server.base.handlers import JupyterHandler
-from tornado import web, websocket
+from tornado import (
+    web,
+    websocket,
+)
 from tornado.ioloop import IOLoop
 
-from cylc.flow.scripts.cylc import (
-    get_version as get_cylc_version,
-    list_plugins as list_cylc_plugins,
+from cylc.uiserver import __version__
+from cylc.uiserver.authorise import (
+    Authorization,
+    AuthorizationMiddleware,
 )
-
-from cylc.uiserver.authorise import Authorization, AuthorizationMiddleware
 from cylc.uiserver.utils import is_bearer_token_authenticated
 from cylc.uiserver.websockets import authenticated as websockets_authenticated
 
+
 if TYPE_CHECKING:
-    from cylc.uiserver.resolvers import Resolvers
-    from cylc.uiserver.websockets.tornado import TornadoSubscriptionServer
     from graphql.execution import ExecutionResult
     from jupyter_server.auth.identity import User as JPSUser
+
+    from cylc.uiserver.resolvers import Resolvers
+    from cylc.uiserver.websockets.tornado import TornadoSubscriptionServer
 
 
 ME = getpass.getuser()
@@ -169,6 +178,12 @@ class CylcAppHandler(JupyterHandler):
         return None
 
 
+class CylcJSONHandler(CylcAppHandler):
+    def set_default_headers(self) -> None:
+        super().set_default_headers()
+        self.set_header("Content-Type", 'application/json')
+
+
 class CylcStaticHandler(CylcAppHandler, web.StaticFileHandler):
     """Serves the Cylc UI static files.
 
@@ -206,7 +221,7 @@ class CylcStaticHandler(CylcAppHandler, web.StaticFileHandler):
         return web.StaticFileHandler.get(self, path)
 
 
-class CylcVersionHandler(CylcAppHandler):
+class CylcVersionHandler(CylcJSONHandler):
     """Renders information about the Cylc environment.
 
     Equivalent to running `cylc version --long` in the UIS environment.
@@ -216,11 +231,10 @@ class CylcVersionHandler(CylcAppHandler):
     @web.authenticated
     def get(self):
         self.write(
-            '<pre>'
-            + get_cylc_version(long=True)
-            + '\n'
-            + list_cylc_plugins()
-            + '</pre>'
+            json.dumps({
+                'cylc-flow': cylc_flow_version,
+                'cylc-uiserver': __version__,
+            })
         )
 
 
@@ -246,7 +260,7 @@ def snake_to_camel(snake):
     raise TypeError(type(snake))
 
 
-class UserProfileHandler(CylcAppHandler):
+class UserProfileHandler(CylcJSONHandler):
     """Provides information about the user in JSON format.
 
     When running via the hub this returns the hub user information.
@@ -255,27 +269,22 @@ class UserProfileHandler(CylcAppHandler):
     would have returned.
     """
 
-    def set_default_headers(self) -> None:
-        super().set_default_headers()
-        self.set_header("Content-Type", 'application/json')
-
     @web.authenticated
     def get(self):
         user_info = {
             **self.current_user.__dict__,
-            **get_user_info(self)
+            **get_user_info(self),
+            # add an entry for the workflow owner
+            # NOTE: when running behind a hub this may be different from the
+            # authenticated user
+            'owner': ME,
         }
 
-        # add an entry for the workflow owner
-        # NOTE: when running behind a hub this may be different from the
-        # authenticated user
-        user_info['owner'] = ME
-
         # Make user permissions available to the ui
-        user_info['permissions'] = [
-            snake_to_camel(perm) for perm in (
-                self.auth.get_permitted_operations(user_info['name']))
-        ]
+        user_info['permissions'] = sorted(
+            snake_to_camel(perm)
+            for perm in self.auth.get_permitted_operations(user_info['name'])
+        )
         # Pass the gui mode to the ui
         # (used for functionality not security)
         if not os.environ.get("JUPYTERHUB_SINGLEUSER_APP"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,28 @@ testpaths = [
 markers = [
     'integration: tests which run servers and try to connect to them'
 ]
+
+
+# Not mandated to use these tools, but if you do:
+
+[tool.ruff]
+line-length = 79
+target-version = "py37"
+
+[tool.ruff.format]
+quote-style = "preserve"
+
+
+[tool.black]
+line-length = 79
+target-version = ['py37']
+skip-string-normalization = true
+
+
+[tool.isort]
+profile = "black"
+line_length = 79
+force_grid_wrap = 2
+lines_after_imports = 2
+combine_as_imports = true
+force_sort_within_sections = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,6 +103,7 @@ tests =
     # https://github.com/pytest-dev/pytest/issues/12263
     pytest>=6,<8.2
     towncrier>=24.7.0
+    setuptools>=71.1
     types-setuptools
     types-requests>2
 all =


### PR DESCRIPTION
This is probably more useful info than the UI build version that we currently show. At the very least it is useful to developers who can check whether they are on master or the stable branch.

Plus:
- ~fix `c.CylcUIServer.log_level` not working in jupyter config.~
- copied ruff/black/isort config from cylc-flow

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are not needed.
- [x] Changelog entry not included as minor change
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
