### PR TITLE
Drop usage of pkg_resources

### DIFF
--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -63,7 +63,6 @@ from types import SimpleNamespace
 from typing import List, Optional, Union
 
 from jupyter_server.extension.application import ExtensionApp
-from pkg_resources import parse_version
 from tornado import ioloop
 from tornado.web import RedirectHandler
 from traitlets import (
@@ -385,7 +384,10 @@ class CylcUIServer(ExtensionApp):
                 for version in path.glob('[0-9][0-9.]*')
                 if version
             ),
-            key=parse_version
+            key=lambda x: tuple(
+                int(x) if x.isdecimal() else x
+                for x in x.split('.')
+            )
         )
 
     @default('ui_path')

--- a/cylc/uiserver/jupyter_config.py
+++ b/cylc/uiserver/jupyter_config.py
@@ -16,11 +16,19 @@
 # Configuration file for jupyterhub.
 
 from pathlib import Path
-import pkg_resources
+import sys
+
+
+if sys.version_info[:2] > (3, 8):
+    from importlib.resources import files
+else:
+    # BACK_COMPAT: importlib_resources
+    from importlib_resources import files
 
 from cylc.uiserver import (
     __file__ as uis_pkg,
-    getenv)
+    getenv,
+)
 from cylc.uiserver.app import USER_CONF_ROOT
 from cylc.uiserver.authorise import CylcAuthorizer
 
@@ -49,10 +57,7 @@ c.JupyterHub.logo_file = str(Path(uis_pkg).parent / 'logo.svg')
 c.JupyterHub.log_datefmt = '%Y-%m-%dT%H:%M:%S'  # ISO8601 (expanded)
 c.JupyterHub.template_paths = [
     # custom HTML templates
-    pkg_resources.resource_filename(
-        'cylc.uiserver',
-        'templates'
-    )
+    str(files('cylc.uiserver') / 'templates')
 ]
 
 # store JupyterHub runtime files in the user config directory

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ install_requires =
     graphene
     graphene-tornado==2.6.*
     graphql-ws==0.4.4
+    importlib-resources>=1.3.0; python_version < "3.9"
     jupyter_server>=2.7
     requests
     psutil
@@ -103,7 +104,6 @@ tests =
     # https://github.com/pytest-dev/pytest/issues/12263
     pytest>=6,<8.2
     towncrier>=24.7.0
-    setuptools>=71.1
     types-setuptools
     types-requests>2
 all =


### PR DESCRIPTION
> Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)).

Also, currently `cylc hub` is broken if you don't have setuptools installed (setuptools was never a dependency)!

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg` (no `conda-environment.yml` present).
- [x] Tests are not needed
- [x] Changelog entry not needed as not user-facing
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
