### PR TITLE
Fix possible sort error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ install_requires =
     importlib-resources>=1.3.0; python_version < "3.9"
     jupyter_server>=2.7
     requests
+    packaging
     psutil
     tornado>=6.1.0  # matches jupyter_server value
     traitlets>=5.2.1  # required for logging_config (5.2.0 had bugs)


### PR DESCRIPTION
Follow-up to https://github.com/cylc/cylc-uiserver/pull/684#discussion_r2044018397

`packaging.version.Version` is not guaranteed to parse all valid Node semver versions (e.g. `1.0.0+21AF` would raise an `InvalidVersion` error), however I have tested it against all possible `npm version` (which is the command we run to bump UI version) output and it holds up for them. 

