### PR TITLE
fix authorization limit-permission case mismatch

### DIFF
--- a/cylc/uiserver/authorise.py
+++ b/cylc/uiserver/authorise.py
@@ -227,6 +227,9 @@ class Authorization:
                 permission_set.remove(action_group)
                 permission_set.update(expansion)
 
+        # lowercase all before negation i.e. Play -> play
+        permission_set = {p.lower() for p in permission_set}
+
         # Remove negated permissions
         remove = set()
         for perm in permission_set:


### PR DESCRIPTION
closes #692

Before this change a config like this:
```

```
Would internally be expanded as:
https://github.com/cylc/cylc-uiserver/blob/98c9e397ba23c978beeb87067635cab864abe72b/cylc/uiserver/authorise.py#L305
https://github.com/cylc/cylc-uiserver/blob/98c9e397ba23c978beeb87067635cab864abe72b/cylc/uiserver/authorise.py#L191
```
limits_owner_can_give: {'CONTROL', 'READ'}
user_conf_permitted_ops: {'Play', 'Stop', 'READ', 'Poll', 'Pause'}
expanded user_conf_permitted_ops: {'Play', 'read', 'Stop', 'Poll', 'Pause'}
expanded limits_owner_can_give: {'trigger', 'pause', 'scan', 'set_verbosity', 'play', 'ext_trigger', 'set', 'read', 'hold', 'release_hold_point', 'message', 'clean', 'stop', 'kill', 'resume', 'set_graph_window_extent', 'release', 'remove', 'poll', 'reload', 'set_hold_point'}
```
The via:
```
        # subtract permissions that the site does not permit to be granted
        allowed_operations = limits_owner_can_give.intersection(
            user_conf_permitted_ops
        )
```
give `read`
```
[I 2025-05-23 14:27:42.958 CylcUIServer] User other-suther authorized permissions: ['read']
{'read'}
```

With this small fix, the permissions are correct:
```
[I 2025-05-23 16:09:28.239 CylcUIServer] User other-suther authorized permissions: ['pause', 'play', 'poll', 'read', 'stop']
{'poll', 'play', 'stop', 'pause', 'read'}
```
And UI menu correctly making available the corresponding options:
![image](https://github.com/user-attachments/assets/bd907264-b512-46db-9649-979cc96eb447)



**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
