### PR TITLE
Fix non-live jobs query missing `jobId` and `jobRunnerName` fields

### DIFF
--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -435,7 +435,7 @@ GROUP BY
             'state': _state_to_status(row[3], row[4], row[5]),
             'started_time': row[5],
             'finished_time': row[6],
-            'job_ID': row[7],
+            'job_id': row[7],
             'platform': row[8],
             'submitted_time': row[9],
             # Queue time stats
@@ -705,7 +705,8 @@ def run_jobs_query(
             submit_status,
             time_run AS started_time,
             time_run_exit AS finished_time,
-            job_id AS job_ID,
+            job_id,
+            job_runner_name,
             platform_name AS platform,
             time_submit AS submitted_time,
             STRFTIME('%s', time_run_exit) - STRFTIME('%s', time_submit)

--- a/cylc/uiserver/tests/test_workflow_retrieval.py
+++ b/cylc/uiserver/tests/test_workflow_retrieval.py
@@ -16,20 +16,20 @@
 """This file tests the ability for the cylc UI to retrieve workflow information
 and perform simple statistical calculations for the analysis tab"""
 
+import sqlite3
 from typing import Union
 from unittest.mock import Mock
-import pytest
-import sqlite3
-
-from graphene.test import Client
 
 from cylc.flow.id import Tokens
+from graphene.test import Client
+import pytest
+
 from cylc.uiserver.schema import (
+    get_elements,
+    list_elements,
+    run_jobs_query,
     run_task_query,
     schema,
-    run_jobs_query,
-    list_elements,
-    get_elements,
 )
 
 
@@ -93,40 +93,34 @@ def test_make_task_query_1():
     )
     workflow = Tokens('~user/workflow')
 
-    return_value = run_task_query(conn, workflow)
+    ret = run_task_query(conn, workflow)[0]
 
-    assert return_value[0]['count'] == 1
-    assert return_value[0]['cycle_point'] == '1'
-    assert return_value[0]['finished_time'] == '2022-12-14T15:10:00Z'
-    assert return_value[0]['queue_quartiles'][0] == 60
-    assert return_value[0]['run_quartiles'][0] == 540
-    assert return_value[0]['total_quartiles'][0] == 600
-    assert return_value[0]['id'].id == '~user/workflow//1/Task_1/01'
-    assert return_value[0]['job_ID'] == 'UsersJob'
-    assert return_value[0]['max_queue_time'] == 60
-    assert return_value[0]['max_run_time'] == 540
-    assert return_value[0]['max_total_time'] == 600
-    assert return_value[0]['mean_queue_time'] == pytest.approx(60.0, 0.01)
-    assert return_value[0]['mean_run_time'] == pytest.approx(540.0, 0.01)
-    assert return_value[0]['mean_total_time'] == pytest.approx(600.0, 0.01)
-    assert return_value[0]['min_queue_time'] == 60
-    assert return_value[0]['min_run_time'] == 540
-    assert return_value[0]['min_total_time'] == 600
-    assert return_value[0]['name'] == 'Task_1'
-    assert return_value[0]['platform'] == 'MyPlatform'
-    assert return_value[0]['queue_quartiles'][1] == 60
-    assert return_value[0]['run_quartiles'][1] == 540
-    assert return_value[0]['total_quartiles'][1] == 600
-    assert return_value[0]['started_time'] == '2022-12-14T15:01:00Z'
-    assert return_value[0]['state'] == 'succeeded'
-    assert return_value[0]['std_dev_queue_time'] == pytest.approx(0.0, 0.01)
-    assert return_value[0]['std_dev_run_time'] == pytest.approx(0.0, 0.01)
-    assert return_value[0]['std_dev_total_time'] == pytest.approx(0.0, 0.01)
-    assert return_value[0]['submit_num'] == 1
-    assert return_value[0]['submitted_time'] == '2022-12-14T15:00:00Z'
-    assert return_value[0]['queue_quartiles'][2] == 60
-    assert return_value[0]['run_quartiles'][2] == 540
-    assert return_value[0]['total_quartiles'][2] == 600
+    assert ret['count'] == 1
+    assert ret['cycle_point'] == '1'
+    assert ret['finished_time'] == '2022-12-14T15:10:00Z'
+    assert ret['queue_quartiles'] == [60, 60, 60]
+    assert ret['run_quartiles'] == [540, 540, 540]
+    assert ret['total_quartiles'] == [600, 600, 600]
+    assert ret['id'].id == '~user/workflow//1/Task_1/01'
+    assert ret['job_id'] == 'UsersJob'
+    assert ret['max_queue_time'] == 60
+    assert ret['max_run_time'] == 540
+    assert ret['max_total_time'] == 600
+    assert ret['mean_queue_time'] == pytest.approx(60.0, 0.01)
+    assert ret['mean_run_time'] == pytest.approx(540.0, 0.01)
+    assert ret['mean_total_time'] == pytest.approx(600.0, 0.01)
+    assert ret['min_queue_time'] == 60
+    assert ret['min_run_time'] == 540
+    assert ret['min_total_time'] == 600
+    assert ret['name'] == 'Task_1'
+    assert ret['platform'] == 'MyPlatform'
+    assert ret['started_time'] == '2022-12-14T15:01:00Z'
+    assert ret['state'] == 'succeeded'
+    assert ret['std_dev_queue_time'] == pytest.approx(0.0, 0.01)
+    assert ret['std_dev_run_time'] == pytest.approx(0.0, 0.01)
+    assert ret['std_dev_total_time'] == pytest.approx(0.0, 0.01)
+    assert ret['submit_num'] == 1
+    assert ret['submitted_time'] == '2022-12-14T15:00:00Z'
 
 
 def test_make_task_query_2():
@@ -171,40 +165,34 @@ def test_make_task_query_2():
     conn.commit()
     workflow = Tokens('~user/workflow')
 
-    return_value = run_task_query(conn, workflow)
+    ret = run_task_query(conn, workflow)[0]
 
-    assert return_value[0]['count'] == 2
-    assert return_value[0]['cycle_point'] == '2'
-    assert return_value[0]['finished_time'] == '2022-12-15T15:12:00Z'
-    assert return_value[0]['queue_quartiles'][0] == 60
-    assert return_value[0]['run_quartiles'][0] == 540
-    assert return_value[0]['total_quartiles'][0] == 600
-    assert return_value[0]['id'].id == '~user/workflow//2/Task_1/01'
-    assert return_value[0]['job_ID'] == 'UsersJob'
-    assert return_value[0]['max_queue_time'] == 76
-    assert return_value[0]['max_run_time'] == 644
-    assert return_value[0]['max_total_time'] == 720
-    assert return_value[0]['mean_queue_time'] == pytest.approx(68.0, 0.01)
-    assert return_value[0]['mean_run_time'] == pytest.approx(592.0, 0.01)
-    assert return_value[0]['mean_total_time'] == pytest.approx(660.0, 0.01)
-    assert return_value[0]['min_queue_time'] == 60
-    assert return_value[0]['min_run_time'] == 540
-    assert return_value[0]['min_total_time'] == 600
-    assert return_value[0]['name'] == 'Task_1'
-    assert return_value[0]['platform'] == 'MyPlatform'
-    assert return_value[0]['queue_quartiles'][1] == 76
-    assert return_value[0]['run_quartiles'][1] == 644
-    assert return_value[0]['total_quartiles'][1] == 720
-    assert return_value[0]['started_time'] == '2022-12-15T15:01:16Z'
-    assert return_value[0]['state'] == 'succeeded'
-    assert return_value[0]['std_dev_queue_time'] == pytest.approx(8.00, 0.01)
-    assert return_value[0]['std_dev_run_time'] == pytest.approx(52.0, 0.01)
-    assert return_value[0]['std_dev_total_time'] == pytest.approx(60.0, 0.01)
-    assert return_value[0]['submit_num'] == 1
-    assert return_value[0]['submitted_time'] == '2022-12-15T15:00:00Z'
-    assert return_value[0]['queue_quartiles'][2] == 60
-    assert return_value[0]['run_quartiles'][2] == 540
-    assert return_value[0]['total_quartiles'][2] == 600
+    assert ret['count'] == 2
+    assert ret['cycle_point'] == '2'
+    assert ret['finished_time'] == '2022-12-15T15:12:00Z'
+    assert ret['queue_quartiles'] == [60, 76, 60]
+    assert ret['run_quartiles'] == [540, 644, 540]
+    assert ret['total_quartiles'] == [600, 720, 600]
+    assert ret['id'].id == '~user/workflow//2/Task_1/01'
+    assert ret['job_id'] == 'UsersJob'
+    assert ret['max_queue_time'] == 76
+    assert ret['max_run_time'] == 644
+    assert ret['max_total_time'] == 720
+    assert ret['mean_queue_time'] == pytest.approx(68.0, 0.01)
+    assert ret['mean_run_time'] == pytest.approx(592.0, 0.01)
+    assert ret['mean_total_time'] == pytest.approx(660.0, 0.01)
+    assert ret['min_queue_time'] == 60
+    assert ret['min_run_time'] == 540
+    assert ret['min_total_time'] == 600
+    assert ret['name'] == 'Task_1'
+    assert ret['platform'] == 'MyPlatform'
+    assert ret['started_time'] == '2022-12-15T15:01:16Z'
+    assert ret['state'] == 'succeeded'
+    assert ret['std_dev_queue_time'] == pytest.approx(8.00, 0.01)
+    assert ret['std_dev_run_time'] == pytest.approx(52.0, 0.01)
+    assert ret['std_dev_total_time'] == pytest.approx(60.0, 0.01)
+    assert ret['submit_num'] == 1
+    assert ret['submitted_time'] == '2022-12-15T15:00:00Z'
 
 
 def test_make_task_query_3():
@@ -267,41 +255,36 @@ def test_make_task_query_3():
     conn.commit()
     workflow = Tokens('~user/workflow')
 
-    return_value = run_task_query(conn, workflow)
+    ret = run_task_query(conn, workflow)
 
-    assert len(return_value) == 1
-    assert return_value[0]['count'] == 3
-    assert return_value[0]['cycle_point'] == '3'
-    assert return_value[0]['finished_time'] == '2022-12-16T15:12:00Z'
-    assert return_value[0]['queue_quartiles'][0] == 60
-    assert return_value[0]['run_quartiles'][0] == 540
-    assert return_value[0]['total_quartiles'][0] == 600
-    assert return_value[0]['id'].id == '~user/workflow//3/Task_1/01'
-    assert return_value[0]['job_ID'] == 'UsersJob'
-    assert return_value[0]['max_queue_time'] == 76
-    assert return_value[0]['max_run_time'] == 644
-    assert return_value[0]['max_total_time'] == 720
-    assert return_value[0]['mean_queue_time'] == pytest.approx(70.66, 0.01)
-    assert return_value[0]['mean_run_time'] == pytest.approx(609.33, 0.01)
-    assert return_value[0]['mean_total_time'] == pytest.approx(680.0, 0.01)
-    assert return_value[0]['min_queue_time'] == 60
-    assert return_value[0]['min_run_time'] == 540
-    assert return_value[0]['min_total_time'] == 600
-    assert return_value[0]['name'] == 'Task_1'
-    assert return_value[0]['platform'] == 'MyPlatform'
-    assert return_value[0]['queue_quartiles'][1] == 76
-    assert return_value[0]['run_quartiles'][1] == 644
-    assert return_value[0]['total_quartiles'][1] == 720
-    assert return_value[0]['started_time'] == '2022-12-16T15:01:16Z'
-    assert return_value[0]['state'] == 'succeeded'
-    assert return_value[0]['std_dev_queue_time'] == pytest.approx(7.54, 0.01)
-    assert return_value[0]['std_dev_run_time'] == pytest.approx(49.02, 0.01)
-    assert return_value[0]['std_dev_total_time'] == pytest.approx(56.56, 0.01)
-    assert return_value[0]['submit_num'] == 1
-    assert return_value[0]['submitted_time'] == '2022-12-16T15:00:00Z'
-    assert return_value[0]['queue_quartiles'][2] == 76
-    assert return_value[0]['run_quartiles'][2] == 644
-    assert return_value[0]['total_quartiles'][2] == 720
+    assert len(ret) == 1
+    ret = ret[0]
+    assert ret['count'] == 3
+    assert ret['cycle_point'] == '3'
+    assert ret['finished_time'] == '2022-12-16T15:12:00Z'
+    assert ret['queue_quartiles'] == [60, 76, 76]
+    assert ret['run_quartiles'] == [540, 644, 644]
+    assert ret['total_quartiles'] == [600, 720, 720]
+    assert ret['id'].id == '~user/workflow//3/Task_1/01'
+    assert ret['job_id'] == 'UsersJob'
+    assert ret['max_queue_time'] == 76
+    assert ret['max_run_time'] == 644
+    assert ret['max_total_time'] == 720
+    assert ret['mean_queue_time'] == pytest.approx(70.66, 0.01)
+    assert ret['mean_run_time'] == pytest.approx(609.33, 0.01)
+    assert ret['mean_total_time'] == pytest.approx(680.0, 0.01)
+    assert ret['min_queue_time'] == 60
+    assert ret['min_run_time'] == 540
+    assert ret['min_total_time'] == 600
+    assert ret['name'] == 'Task_1'
+    assert ret['platform'] == 'MyPlatform'
+    assert ret['started_time'] == '2022-12-16T15:01:16Z'
+    assert ret['state'] == 'succeeded'
+    assert ret['std_dev_queue_time'] == pytest.approx(7.54, 0.01)
+    assert ret['std_dev_run_time'] == pytest.approx(49.02, 0.01)
+    assert ret['std_dev_total_time'] == pytest.approx(56.56, 0.01)
+    assert ret['submit_num'] == 1
+    assert ret['submitted_time'] == '2022-12-16T15:00:00Z'
 
 
 def test_make_jobs_query_1():
@@ -365,31 +348,31 @@ def test_make_jobs_query_1():
     workflow = Tokens('~user/workflow')
     tasks = []
 
-    return_value = run_jobs_query(conn, workflow, tasks)
+    ret = run_jobs_query(conn, workflow, tasks)
 
-    assert len(return_value) == 3
+    assert len(ret) == 3
 
-    assert return_value[0]['cycle_point'] == '1'
-    assert return_value[0]['finished_time'] == '2022-12-14T15:10:00Z'
-    assert return_value[0]['id'].id == '~user/workflow//1/Task_1/01'
-    assert return_value[0]['job_ID'] == 'UsersJob'
-    assert return_value[0]['name'] == 'Task_1'
-    assert return_value[0]['platform'] == 'MyPlatform'
-    assert return_value[0]['started_time'] == '2022-12-14T15:01:00Z'
-    assert return_value[0]['state'] == 'succeeded'
-    assert return_value[0]['submit_num'] == 1
-    assert return_value[0]['submitted_time'] == '2022-12-14T15:00:00Z'
+    assert ret[0]['cycle_point'] == '1'
+    assert ret[0]['finished_time'] == '2022-12-14T15:10:00Z'
+    assert ret[0]['id'].id == '~user/workflow//1/Task_1/01'
+    assert ret[0]['job_id'] == 'UsersJob'
+    assert ret[0]['name'] == 'Task_1'
+    assert ret[0]['platform'] == 'MyPlatform'
+    assert ret[0]['started_time'] == '2022-12-14T15:01:00Z'
+    assert ret[0]['state'] == 'succeeded'
+    assert ret[0]['submit_num'] == 1
+    assert ret[0]['submitted_time'] == '2022-12-14T15:00:00Z'
 
-    assert return_value[1]['cycle_point'] == '2'
-    assert return_value[1]['finished_time'] == '2022-12-15T15:12:00Z'
-    assert return_value[1]['id'].id == '~user/workflow//2/Task_1/01'
-    assert return_value[1]['job_ID'] == 'UsersJob'
-    assert return_value[1]['name'] == 'Task_1'
-    assert return_value[1]['platform'] == 'MyPlatform'
-    assert return_value[1]['started_time'] == '2022-12-15T15:01:16Z'
-    assert return_value[1]['state'] == 'succeeded'
-    assert return_value[1]['submit_num'] == 1
-    assert return_value[1]['submitted_time'] == '2022-12-15T15:00:00Z'
+    assert ret[1]['cycle_point'] == '2'
+    assert ret[1]['finished_time'] == '2022-12-15T15:12:00Z'
+    assert ret[1]['id'].id == '~user/workflow//2/Task_1/01'
+    assert ret[1]['job_id'] == 'UsersJob'
+    assert ret[1]['name'] == 'Task_1'
+    assert ret[1]['platform'] == 'MyPlatform'
+    assert ret[1]['started_time'] == '2022-12-15T15:01:16Z'
+    assert ret[1]['state'] == 'succeeded'
+    assert ret[1]['submit_num'] == 1
+    assert ret[1]['submitted_time'] == '2022-12-15T15:00:00Z'
 
 
 async def test_list_elements(monkeypatch):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ testpaths = [
 markers = [
     'integration: tests which run servers and try to connect to them'
 ]
+verbosity_assertions = 2
 
 
 # Not mandated to use these tools, but if you do:


### PR DESCRIPTION
### Repro

For a workflow that has run a job

```gql
query {
  jobs(live: false, ids: ["5/foo/01"], workflows: ["wflow"]) {
    jobId
    jobRunnerName
  }
}
```

```json
{
  "data": {
    "jobs": [
      {
        "jobId": null,
        "jobRunnerName": null
      }
    ]
  }
}
```

### Check list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] No changelog entry included as not really visible to users yet
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
