### PR TITLE
actions: update to new permissions model

### DIFF
--- a/.github/workflows/update_ui.yml
+++ b/.github/workflows/update_ui.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 5
     env:
       HEAD_BRANCH: update-ui-${{ github.run_number }}
+    permissions:
+      pull-requests: write
 
     steps:
       - name: checkout cylc-uiserver


### PR DESCRIPTION
Sometime after the last minor release, this workflow has become broken by some kind of permissions change.

Failed run: https://github.com/cylc/cylc-uiserver/actions/runs/16474895473/job/46573696822

Using `GITHUB_TOKEN` to authenticate GitHub actions in this way is still the documented approach:

https://docs.github.com/en/actions/tutorials/use-github_token-in-workflows#example-1-passing-the-github_token-as-an-input

But you need to specify perms at the workflow level:

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions

I think this'll do it.