### PR TITLE
GH Actions: Add contents write permission to allow push

### DIFF
--- a/.github/workflows/update_ui.yml
+++ b/.github/workflows/update_ui.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       HEAD_BRANCH: update-ui-${{ github.run_number }}
     permissions:
+      contents: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
Follow-up to #705 as the push step now failed: https://github.com/cylc/cylc-uiserver/actions/runs/16476193074/job/46578367114

