### PR TITLE
GH Actions: fix create PR step

### DIFF
--- a/.github/workflows/update_ui.yml
+++ b/.github/workflows/update_ui.yml
@@ -20,10 +20,6 @@ jobs:
     timeout-minutes: 5
     env:
       HEAD_BRANCH: update-ui-${{ github.run_number }}
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
       - name: checkout cylc-uiserver
         uses: actions/checkout@v4
@@ -72,7 +68,7 @@ jobs:
 
       - name: Create pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_BRANCH: ${{ inputs.base-branch }}
           TITLE: 'Update UI'
           BODY: |


### PR DESCRIPTION
Follow-up to #705 and #706, as we are still seeing the same error with `gh pr create`:

> error fetching organization teams: GraphQL: Resource not accessible by integration (organization.teams)


Hopefully this PR fixes it, based on https://github.com/cylc/cylc-uiserver/pull/705#issuecomment-3109234298

> ...is it that the gh cli changed the name of the env var it uses from `GITHUB_TOKEN` to `GH_TOKEN`?
> 
> > For each step that uses GitHub CLI, you must set an environment variable called **`GH_TOKEN`** to a token with the required scopes.
> 
> https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows

However I don't understand why other parts of our release process haven't broken. Possibly something special about `workflow_dispatch`?
