### PR TITLE
GH Actions: fix create PR step

### DIFF
--- a/.github/workflows/update_ui.yml
+++ b/.github/workflows/update_ui.yml
@@ -77,5 +77,7 @@ jobs:
           ASSIGNEE: ${{ github.triggering_actor }}
         run: |
           gh pr create -R "$GITHUB_REPOSITORY" \
-            -H "$HEAD_BRANCH" -B "$BASE_BRANCH" -t "$TITLE" -b "$BODY" \
-            -a "$ASSIGNEE" -r "$ASSIGNEE"
+            -H "$HEAD_BRANCH" -B "$BASE_BRANCH" -t "$TITLE" -b "$BODY"
+          # Separate commands in case they fail:
+          gh pr edit --add-assignee "$ASSIGNEE" || true
+          gh pr edit --add-reviewer "$ASSIGNEE" || true


### PR DESCRIPTION
Follow-up to #705, #706, #707

I think the problem may be to do with adding the assignee and/or reviewer, so I've split them off into separate commands that are allowed to fail.

I think it's a bug in GH CLI or the GitHub token permissions: https://github.com/orgs/community/discussions/113519