### PR TITLE
fix UIS-Schd dump delta race condition

### DIFF
--- a/changes.d/721.fix.md
+++ b/changes.d/721.fix.md
@@ -1,0 +1,2 @@
+Fixes a race condition in the UIS data-store sync which showed as a
+traceback in the log.

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -273,10 +273,10 @@ class DataStoreMgr:
         """
         # Wait until data-store is populated for this workflow,
         # carry on otherwise, errors will be reconciled with data validation.
-        if w_id not in self.data:
+        if self.data[w_id][WORKFLOW].last_updated == 0:
             loop_cnt = 0
             while loop_cnt < self.INIT_DATA_WAIT_CHECKS:
-                if w_id in self.data:
+                if self.data[w_id][WORKFLOW].last_updated > 0:
                     break
                 time.sleep(self.INIT_DATA_RETRY_DELAY)
                 loop_cnt += 1

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -93,7 +93,7 @@ class DataStoreMgr:
 
     """
 
-    INIT_DATA_WAIT_TIME = 5.  # seconds
+    INIT_DATA_WAIT_CHECKS = 30  # check attempts
     INIT_DATA_RETRY_DELAY = 0.5  # seconds
     RECONCILE_TIMEOUT = 5.  # seconds
     PENDING_DELTA_CHECK_INTERVAL = 0.5
@@ -271,10 +271,11 @@ class DataStoreMgr:
             w_id (str): Workflow external ID.
 
         """
-        # wait until data-store is populated for this workflow
+        # Wait until data-store is populated for this workflow,
+        # carry on otherwise, errors will be reconciled with data validation.
         if w_id not in self.data:
             loop_cnt = 0
-            while loop_cnt < self.INIT_DATA_WAIT_TIME:
+            while loop_cnt < self.INIT_DATA_WAIT_CHECKS:
                 if w_id in self.data:
                     break
                 time.sleep(self.INIT_DATA_RETRY_DELAY)
@@ -296,19 +297,20 @@ class DataStoreMgr:
 
     def _apply_all_delta(self, w_id, delta):
         """Apply the AllDeltas delta."""
+        delta_times = self.data[w_id]['delta_times']
         for field, sub_delta in delta.ListFields():
             delta_time = getattr(sub_delta, 'time', 0.0)
             # If the workflow has reloaded clear the data before
             # delta application.
             if sub_delta.reloaded:
                 self._clear_data_field(w_id, field.name)
-                self.data[w_id]['delta_times'][field.name] = 0.0
+                delta_times[field.name] = 0.0
             # hard to catch errors in a threaded async app, so use try-except.
             try:
                 # Apply the delta if newer than the previously applied.
-                if delta_time >= self.data[w_id]['delta_times'][field.name]:
+                if delta_time >= delta_times.get(field.name, 0.0):
                     apply_delta(field.name, sub_delta, self.data[w_id])
-                    self.data[w_id]['delta_times'][field.name] = delta_time
+                    delta_times[field.name] = delta_time
                     if not sub_delta.reloaded:
                         self._reconcile_update(field.name, sub_delta, w_id)
             except Exception as exc:


### PR DESCRIPTION
closes #700 

This fix increases the amount of time a delta waits for the initial dump, and carries on otherwise (relying on the data reconciliation/validation to redo the store if needed).

Hard to test without decreasing this wait time again, but can demonstrate it has done the job by running a highly parallel `cylc-flow` integration test with a UIS running.



**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
