### PR TITLE
services: validate-reinstall

### DIFF
--- a/changes.d/746.feat.md
+++ b/changes.d/746.feat.md
@@ -1,0 +1,1 @@
+Add support for the `cylc validate-reinstall` command.

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -28,6 +28,7 @@ from subprocess import (
     DEVNULL,
     PIPE,
     Popen,
+    TimeoutExpired,
 )
 from textwrap import indent
 from time import time
@@ -309,6 +310,7 @@ class Services:
                 The application log, used to record this command invocation.
             timeout:
                 Length of time to wait for the command to complete.
+                The command will be killed if the timeout elapses.
             success_msg:
                 Message to be used in the response if the command succeeds.
             fail_msg:
@@ -344,7 +346,7 @@ class Services:
                     env.pop('CYLC_ENV_NAME', None)
                     env['CYLC_VERSION'] = cylc_version
 
-                # run cylc play
+                # run command
                 proc = Popen(
                     cmd,
                     env=env,
@@ -353,11 +355,21 @@ class Services:
                     stderr=PIPE,
                     text=True
                 )
-                ret_code = proc.wait(timeout=timeout)
+
+                try:
+                    ret_code = proc.wait(timeout=timeout)
+                except TimeoutExpired as exc:
+                    proc.kill()
+                    ret_code = 124  # mimic `timeout` command error code
+                    # NOTE: preserve any stderr that the command produced this
+                    # far as this may help with debugging
+                    out, err = proc.communicate()
+                    err = str(exc) + (('\n' + err) if err else '')
+                else:
+                    out, err = proc.communicate()
 
                 if ret_code:
                     msg = f"{fail_msg} ({ret_code}): {cmd_repr}"
-                    out, err = proc.communicate()
                     results[wflow] = err.strip() or out.strip() or msg
                     log.error(
                         f"{msg}\n"

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -219,31 +219,34 @@ class Services:
     # log file stream lag
     CAT_LOG_SLEEP = 1
 
+    #  command timeout for commands which start schedulers
+    START_TIMEOUT = 120
+
     @staticmethod
     def _error(message: Union[Exception, str]):
         """Format error case response."""
-        return [
+        return (
             False,
             str(message)
-        ]
+        )
 
     @staticmethod
     def _return(message: str):
         """Format success case response."""
-        return [
+        return (
             True,
             message
-        ]
+        )
 
     @classmethod
     async def clean(
         cls,
+        workflows_mgr: 'WorkflowsManager',
         workflows: Iterable['Tokens'],
         args: dict,
-        workflows_mgr: 'WorkflowsManager',
         executor: 'Executor',
         log: 'Logger'
-    ):
+    ) -> tuple[bool, str]:
         """Calls `cylc clean`"""
         # Convert Schema options → cylc.flow.workflow_files.init_clean opts:
         opts = _schema_opts_to_api_opts(args, schema=CleanOptions)
@@ -276,25 +279,50 @@ class Services:
         cls,
         args: dict,
         workflows_mgr: 'WorkflowsManager',
-    ):
+    ) -> tuple[bool, str]:
         await workflows_mgr.scan()
         return cls._return("Scan requested")
 
     @classmethod
-    async def play(
+    async def run_command(
         cls,
+        command: Iterable[str],
         workflows: Iterable[Tokens],
         args: Dict[str, Any],
-        workflows_mgr: 'WorkflowsManager',
         log: 'Logger',
-    ) -> List[Union[bool, str]]:
-        """Calls `cylc play`."""
+        timeout: int,
+        success_msg: str = 'Command succeeded',
+        fail_msg: str = 'Command failed',
+    ) -> tuple[bool, str]:
+        """Calls the specified Cylc command.
+
+        Args:
+            command:
+                The Cylc subcommand to run.
+                e.g ["play"] or ["cat-log", "-m", "p"].
+            workflows:
+                The workflows to run this command against.
+            args:
+                CLI arguments to be provided to this command.
+                e.g {'color': 'never'} would result in "--color=never".
+            log:
+                The application log, used to record this command invocation.
+            timeout:
+                Length of time to wait for the command to complete.
+            success_msg:
+                Message to be used in the response if the command succeeds.
+            fail_msg:
+                Message to be used in the response if the command fails.
+
+        Returns:
+
+        """
         cylc_version = args.pop('cylc_version', None)
         results: Dict[str, str] = {}
         failed = False
         for tokens in workflows:
             try:
-                cmd = _build_cmd(['cylc', 'play', '--color=never'], args)
+                cmd = _build_cmd(['cylc', *command, '--color=never'], args)
 
                 if tokens['user'] and tokens['user'] != getuser():
                     return cls._error(
@@ -325,10 +353,10 @@ class Services:
                     stderr=PIPE,
                     text=True
                 )
-                ret_code = proc.wait(timeout=120)
+                ret_code = proc.wait(timeout=timeout)
 
                 if ret_code:
-                    msg = f"Command failed ({ret_code}): {cmd_repr}"
+                    msg = f"{fail_msg} ({ret_code}): {cmd_repr}"
                     out, err = proc.communicate()
                     results[wflow] = err.strip() or out.strip() or msg
                     log.error(
@@ -338,7 +366,7 @@ class Services:
                     )
                     failed = True
                 else:
-                    results[wflow] = 'started'
+                    results[wflow] = success_msg
 
             except Exception as exc:  # unexpected error
                 log.exception(exc)
@@ -346,18 +374,71 @@ class Services:
 
         if failed:
             if len(results) == 1:
+                # all commands failed
                 return cls._error(results.popitem()[1])
-            # else log each workflow result on separate lines
+
+            # some commands failed
             return cls._error(
+                # log each workflow result on separate lines
                 "\n\n" + "\n\n".join(
                     f"{wflow}: {msg}" for wflow, msg in results.items()
                 )
             )
 
+        # all commands succeeded
+        return cls._return(f'Workflow(s) {success_msg}')
+
+    @classmethod
+    async def play(
+        cls,
+        workflows_mgr: 'WorkflowsManager',
+        workflows: Iterable[Tokens],
+        args: dict,
+        log,
+        **kwargs,
+    ) -> tuple[bool, str]:
+        """Calls `cylc play`."""
+        ret = await cls.run_command(
+            ('play',),
+            workflows,
+            args,
+            log,
+            cls.START_TIMEOUT,
+            **kwargs,
+            success_msg='started',
+        )
+
         # trigger a re-scan
         await workflows_mgr.scan()
-        # send a success message
-        return cls._return('Workflow(s) started')
+
+        # return results
+        return ret
+
+    @classmethod
+    async def validate_reinstall(
+        cls,
+        workflows_mgr: 'WorkflowsManager',
+        workflows: Iterable[Tokens],
+        args: dict,
+        log,
+        **kwargs,
+    ) -> tuple[bool, str]:
+        """Calls `cylc validate-reinstall`."""
+        ret = await cls.run_command(
+            ('validate-reinstall', '--yes'),
+            workflows,
+            args,
+            log,
+            cls.START_TIMEOUT,
+            **kwargs,
+            success_msg='reinstalled',
+        )
+
+        # trigger a re-scan
+        await workflows_mgr.scan()
+
+        # return results
+        return ret
 
     @staticmethod
     async def enqueue(
@@ -602,8 +683,7 @@ class Resolvers(BaseResolvers):
         command: str,
         workflows: Iterable['Tokens'],
         kwargs: Dict[str, Any],
-    ) -> List[Union[bool, str]]:
-
+    ) -> tuple[bool, str]:
         # GraphQL v3 includes all variables that are set, even if set to null.
         kwargs = {
             k: v
@@ -613,18 +693,25 @@ class Resolvers(BaseResolvers):
 
         if command == 'clean':  # noqa: SIM116
             return await Services.clean(
+                self.workflows_mgr,
                 workflows,
                 kwargs,
-                self.workflows_mgr,
                 log=self.log,
                 executor=self.executor
             )
-        elif command == 'play':
+        elif command == 'play':  # noqa: SIM116
             return await Services.play(
+                self.workflows_mgr,
                 workflows,
                 kwargs,
-                self.workflows_mgr,
                 log=self.log
+            )
+        elif command == 'validate_reinstall':
+            return await Services.validate_reinstall(
+                self.workflows_mgr,
+                workflows,
+                kwargs,
+                log=self.log,
             )
         elif command == 'scan':
             return await Services.scan(

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -156,6 +156,35 @@ def _build_cmd(cmd: List, args: Dict) -> List:
     return cmd
 
 
+def _rename_keys(
+    dictionary: dict[str, Any], substitutions: Iterable[tuple[str, str]]
+) -> dict[str, Any]:
+    """Rename dictionary keys.
+
+    Args:
+        dictionary: The dictionary to modify.
+        substitutions: `[(before, after)]` pairs of keys to rename.
+
+    Returns:
+        The provided dictionary post-modification.
+
+    Examples:
+        >>> _rename_keys({'a': 1, 'b': 2}, [('b', 'c')])
+        {'a': 1, 'c': 2}
+
+        >>> _rename_keys({'a': 1, 'b': 2}, [('b', 'c'), ('c', 'd')])
+        {'a': 1, 'd': 2}
+
+        >>> _rename_keys({'a': 1, 'b': 2}, [('x', 'y')])
+        {'a': 1, 'b': 2}
+
+    """
+    for before, after in substitutions:
+        if before in dictionary:
+            dictionary[after] = dictionary.pop(before)
+    return dictionary
+
+
 def process_cat_log_stderr(text: bytes) -> str:
     """Tidy up cylc cat-log stderr.
 
@@ -439,7 +468,15 @@ class Services:
         ret = await cls.run_command(
             ('validate-reinstall', '--yes'),
             workflows,
-            args,
+            # map GraphQL fields to CLI args where they differ
+            _rename_keys(args, [
+                # from "cylc reload":
+                ('reload_global', 'global'),
+                # from "cylc reinstall"
+                ('rose_opt_conf_keys', 'opt_conf_key'),
+                ('rose_suite_defines', 'define'),
+                ('rose_template_variables', 'rose_template_variable'),
+            ]),
             log,
             cls.START_TIMEOUT,
             **kwargs,

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -157,6 +157,35 @@ def _build_cmd(cmd: List, args: Dict) -> List:
     return cmd
 
 
+def _rename_keys(
+    dictionary: dict[str, Any], substitutions: Iterable[tuple[str, str]]
+) -> dict[str, Any]:
+    """Rename dictionary keys.
+
+    Args:
+        dictionary: The dictionary to modify.
+        substitutions: `[(before, after)]` pairs of keys to rename.
+
+    Returns:
+        The provided dictionary post-modification.
+
+    Examples:
+        >>> _rename_keys({'a': 1, 'b': 2}, [('b', 'c')])
+        {'a': 1, 'c': 2}
+
+        >>> _rename_keys({'a': 1, 'b': 2}, [('b', 'c'), ('c', 'd')])
+        {'a': 1, 'd': 2}
+
+        >>> _rename_keys({'a': 1, 'b': 2}, [('x', 'y')])
+        {'a': 1, 'b': 2}
+
+    """
+    for before, after in substitutions:
+        if before in dictionary:
+            dictionary[after] = dictionary.pop(before)
+    return dictionary
+
+
 def process_cat_log_stderr(text: bytes) -> str:
     """Tidy up cylc cat-log stderr.
 
@@ -440,7 +469,15 @@ class Services:
         ret = await cls.run_command(
             ('validate-reinstall', '--yes'),
             workflows,
-            args,
+            # map GraphQL fields to CLI args where they differ
+            _rename_keys(args, [
+                # from "cylc reload":
+                ('reload_global', 'global'),
+                # from "cylc reinstall"
+                ('rose_opt_conf_keys', 'opt_conf_key'),
+                ('rose_suite_defines', 'define'),
+                ('rose_template_variables', 'rose_template_variable'),
+            ]),
             log,
             cls.START_TIMEOUT,
             **kwargs,

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -29,6 +29,7 @@ from subprocess import (
     DEVNULL,
     PIPE,
     Popen,
+    TimeoutExpired,
 )
 from textwrap import indent
 from time import time
@@ -310,6 +311,7 @@ class Services:
                 The application log, used to record this command invocation.
             timeout:
                 Length of time to wait for the command to complete.
+                The command will be killed if the timeout elapses.
             success_msg:
                 Message to be used in the response if the command succeeds.
             fail_msg:
@@ -345,7 +347,7 @@ class Services:
                     env.pop('CYLC_ENV_NAME', None)
                     env['CYLC_VERSION'] = cylc_version
 
-                # run cylc play
+                # run command
                 proc = Popen(
                     cmd,
                     env=env,
@@ -354,11 +356,21 @@ class Services:
                     stderr=PIPE,
                     text=True
                 )
-                ret_code = proc.wait(timeout=timeout)
+
+                try:
+                    ret_code = proc.wait(timeout=timeout)
+                except TimeoutExpired as exc:
+                    proc.kill()
+                    ret_code = 124  # mimic `timeout` command error code
+                    # NOTE: preserve any stderr that the command produced this
+                    # far as this may help with debugging
+                    out, err = proc.communicate()
+                    err = str(exc) + (('\n' + err) if err else '')
+                else:
+                    out, err = proc.communicate()
 
                 if ret_code:
                     msg = f"{fail_msg} ({ret_code}): {cmd_repr}"
-                    out, err = proc.communicate()
                     results[wflow] = err.strip() or out.strip() or msg
                     log.error(
                         f"{msg}\n"

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -220,31 +220,34 @@ class Services:
     # log file stream lag
     CAT_LOG_SLEEP = 1
 
+    #  command timeout for commands which start schedulers
+    START_TIMEOUT = 120
+
     @staticmethod
     def _error(message: Union[Exception, str]):
         """Format error case response."""
-        return [
+        return (
             False,
             str(message)
-        ]
+        )
 
     @staticmethod
     def _return(message: str):
         """Format success case response."""
-        return [
+        return (
             True,
             message
-        ]
+        )
 
     @classmethod
     async def clean(
         cls,
+        workflows_mgr: 'WorkflowsManager',
         workflows: Iterable['Tokens'],
         args: dict,
-        workflows_mgr: 'WorkflowsManager',
         executor: 'Executor',
         log: 'Logger'
-    ):
+    ) -> tuple[bool, str]:
         """Calls `cylc clean`"""
         # Convert Schema options → cylc.flow.workflow_files.init_clean opts:
         opts = _schema_opts_to_api_opts(args, schema=CleanOptions)
@@ -277,25 +280,50 @@ class Services:
         cls,
         args: dict,
         workflows_mgr: 'WorkflowsManager',
-    ):
+    ) -> tuple[bool, str]:
         await workflows_mgr.scan()
         return cls._return("Scan requested")
 
     @classmethod
-    async def play(
+    async def run_command(
         cls,
+        command: Iterable[str],
         workflows: Iterable[Tokens],
         args: Dict[str, Any],
-        workflows_mgr: 'WorkflowsManager',
         log: 'Logger',
-    ) -> List[Union[bool, str]]:
-        """Calls `cylc play`."""
+        timeout: int,
+        success_msg: str = 'Command succeeded',
+        fail_msg: str = 'Command failed',
+    ) -> tuple[bool, str]:
+        """Calls the specified Cylc command.
+
+        Args:
+            command:
+                The Cylc subcommand to run.
+                e.g ["play"] or ["cat-log", "-m", "p"].
+            workflows:
+                The workflows to run this command against.
+            args:
+                CLI arguments to be provided to this command.
+                e.g {'color': 'never'} would result in "--color=never".
+            log:
+                The application log, used to record this command invocation.
+            timeout:
+                Length of time to wait for the command to complete.
+            success_msg:
+                Message to be used in the response if the command succeeds.
+            fail_msg:
+                Message to be used in the response if the command fails.
+
+        Returns:
+
+        """
         cylc_version = args.pop('cylc_version', None)
         results: Dict[str, str] = {}
         failed = False
         for tokens in workflows:
             try:
-                cmd = _build_cmd(['cylc', 'play', '--color=never'], args)
+                cmd = _build_cmd(['cylc', *command, '--color=never'], args)
 
                 if tokens['user'] and tokens['user'] != getuser():
                     return cls._error(
@@ -326,10 +354,10 @@ class Services:
                     stderr=PIPE,
                     text=True
                 )
-                ret_code = proc.wait(timeout=120)
+                ret_code = proc.wait(timeout=timeout)
 
                 if ret_code:
-                    msg = f"Command failed ({ret_code}): {cmd_repr}"
+                    msg = f"{fail_msg} ({ret_code}): {cmd_repr}"
                     out, err = proc.communicate()
                     results[wflow] = err.strip() or out.strip() or msg
                     log.error(
@@ -339,7 +367,7 @@ class Services:
                     )
                     failed = True
                 else:
-                    results[wflow] = 'started'
+                    results[wflow] = success_msg
 
             except Exception as exc:  # unexpected error
                 log.exception(exc)
@@ -347,18 +375,71 @@ class Services:
 
         if failed:
             if len(results) == 1:
+                # all commands failed
                 return cls._error(results.popitem()[1])
-            # else log each workflow result on separate lines
+
+            # some commands failed
             return cls._error(
+                # log each workflow result on separate lines
                 "\n\n" + "\n\n".join(
                     f"{wflow}: {msg}" for wflow, msg in results.items()
                 )
             )
 
+        # all commands succeeded
+        return cls._return(f'Workflow(s) {success_msg}')
+
+    @classmethod
+    async def play(
+        cls,
+        workflows_mgr: 'WorkflowsManager',
+        workflows: Iterable[Tokens],
+        args: dict,
+        log,
+        **kwargs,
+    ) -> tuple[bool, str]:
+        """Calls `cylc play`."""
+        ret = await cls.run_command(
+            ('play',),
+            workflows,
+            args,
+            log,
+            cls.START_TIMEOUT,
+            **kwargs,
+            success_msg='started',
+        )
+
         # trigger a re-scan
         await workflows_mgr.scan()
-        # send a success message
-        return cls._return('Workflow(s) started')
+
+        # return results
+        return ret
+
+    @classmethod
+    async def validate_reinstall(
+        cls,
+        workflows_mgr: 'WorkflowsManager',
+        workflows: Iterable[Tokens],
+        args: dict,
+        log,
+        **kwargs,
+    ) -> tuple[bool, str]:
+        """Calls `cylc validate-reinstall`."""
+        ret = await cls.run_command(
+            ('validate-reinstall', '--yes'),
+            workflows,
+            args,
+            log,
+            cls.START_TIMEOUT,
+            **kwargs,
+            success_msg='reinstalled',
+        )
+
+        # trigger a re-scan
+        await workflows_mgr.scan()
+
+        # return results
+        return ret
 
     @staticmethod
     async def enqueue(
@@ -602,8 +683,7 @@ class Resolvers(BaseResolvers):
         command: str,
         workflows: Iterable['Tokens'],
         kwargs: Dict[str, Any],
-    ) -> List[Union[bool, str]]:
-
+    ) -> tuple[bool, str]:
         # GraphQL v3 includes all variables that are set, even if set to null.
         kwargs = {
             k: v
@@ -613,18 +693,25 @@ class Resolvers(BaseResolvers):
 
         if command == 'clean':  # noqa: SIM116
             return await Services.clean(
+                self.workflows_mgr,
                 workflows,
                 kwargs,
-                self.workflows_mgr,
                 log=self.log,
                 executor=self.executor
             )
-        elif command == 'play':
+        elif command == 'play':  # noqa: SIM116
             return await Services.play(
+                self.workflows_mgr,
                 workflows,
                 kwargs,
-                self.workflows_mgr,
                 log=self.log
+            )
+        elif command == 'validate_reinstall':
+            return await Services.validate_reinstall(
+                self.workflows_mgr,
+                workflows,
+                kwargs,
+                log=self.log,
             )
         elif command == 'scan':
             return await Services.scan(

--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -241,6 +241,48 @@ class Play(graphene.Mutation):
     result = GenericScalar()
 
 
+class ValidateReinstall(graphene.Mutation):
+    class Meta:
+        description = sstrip('''
+            Validate, reinstall, then reload or restart as appropriate.
+
+            This command updates a workflow to reflect any new changes made in
+            the workflow source directory since it was installed.
+
+            The workflow will be reinstalled, then either:
+            * Reloaded (if the workflow is running),
+            * or restarted (if it is stopped).
+        ''')
+        resolver = partial(mutator, command='validate_reinstall')
+
+    class Arguments:
+        workflows = graphene.List(WorkflowID, required=True)
+        cylc_version = CylcVersion(
+            description=sstrip('''
+                Set the Cylc version that the workflow starts with.
+            ''')
+        )
+        set = graphene.List(  # noqa: A003 (graphql field name)
+            graphene.String,
+            description=sstrip('''
+                Set the value of a Jinja2 template variable in the workflow
+                definition. Values should be valid Python literals so strings
+                must be quoted e.g. `STR="string"`, `INT=43`, `BOOL=True`.
+                This option can be used multiple  times on the command line.
+                NOTE: these settings persist across workflow restarts, but can
+                be set again on the `cylc play` command line if they need to be
+                overridden.
+            ''')
+        )
+        reload_global = graphene.Boolean(
+            default_value=False,
+            required=False,
+            description="Reload global config as well as the workflow config"
+        )
+
+    result = GenericScalar()
+
+
 class Clean(graphene.Mutation):
     class Meta:
         description = sstrip('''
@@ -894,6 +936,7 @@ class UISSubscriptions(Subscriptions):
 
 class UISMutations(Mutations):
     play = _mut_field(Play)
+    validate_reinstall = _mut_field(ValidateReinstall)
     clean = _mut_field(Clean)
     scan = _mut_field(Scan)
 

--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -40,14 +40,15 @@ from cylc.flow.data_store_mgr import (
 )
 from cylc.flow.id import Tokens
 from cylc.flow.network.schema import (
-    NODE_MAP,
-    STRIP_NULL_DEFAULT,
-    SUB_RESOLVER_MAPPING,
     CyclePoint,
     GenericResponse,
     Job,
     Mutations,
+    NODE_MAP,
     Queries,
+    Reload,
+    STRIP_NULL_DEFAULT,
+    SUB_RESOLVER_MAPPING,
     SortArgs,
     Subscriptions,
     Task,
@@ -241,20 +242,7 @@ class Play(graphene.Mutation):
     result = GenericScalar()
 
 
-class ValidateReinstall(graphene.Mutation):
-    class Meta:
-        description = sstrip('''
-            Validate, reinstall, then reload or restart as appropriate.
-
-            This command updates a workflow to reflect any new changes made in
-            the workflow source directory since it was installed.
-
-            The workflow will be reinstalled, then either:
-            * Reloaded (if the workflow is running),
-            * or restarted (if it is stopped).
-        ''')
-        resolver = partial(mutator, command='validate_reinstall')
-
+class Reinstall:
     class Arguments:
         workflows = graphene.List(WorkflowID, required=True)
         cylc_version = CylcVersion(
@@ -262,23 +250,75 @@ class ValidateReinstall(graphene.Mutation):
                 Set the Cylc version that the workflow starts with.
             ''')
         )
-        set = graphene.List(  # noqa: A003 (graphql field name)
+        # cylc-rose
+        rose_opt_conf_keys = graphene.List(
             graphene.String,
             description=sstrip('''
-                Set the value of a Jinja2 template variable in the workflow
-                definition. Values should be valid Python literals so strings
-                must be quoted e.g. `STR="string"`, `INT=43`, `BOOL=True`.
-                This option can be used multiple  times on the command line.
-                NOTE: these settings persist across workflow restarts, but can
-                be set again on the `cylc play` command line if they need to be
-                overridden.
+                Add Rose optional configurations (if Rose is used).
             ''')
         )
-        reload_global = graphene.Boolean(
+        clear_rose_install_options = graphene.Boolean(
             default_value=False,
-            required=False,
-            description="Reload global config as well as the workflow config"
+            description=sstrip('''
+                Clear options previous set by cylc-rose.
+            ''')
         )
+        rose_suite_defines = graphene.List(
+            graphene.String,
+            description=sstrip('''
+                Each of these overrides the `[SECTION]KEY` setting in a
+                `rose-suite.conf` file.
+
+                Can be used to disable a setting using the syntax
+                `[SECTION]!KEY` or even `[!SECTION]`.
+            ''')
+        )
+        rose_template_variables = graphene.List(
+            graphene.String,
+            description=sstrip('''
+                Define a Rose `[template variable]`s e.g, `FOO=1`.
+
+                Note: Specifying `FOO=1` to this argument is equivalent to
+                specifying `[template variables]FOO=1` to the `define`
+                argument.
+            ''')
+        )
+
+
+class ReinstallReload(graphene.Mutation):
+    class Meta:
+        description = sstrip('''
+            Validate, reinstall, then reload workflows.
+
+            This command updates a workflow to reflect any new changes made in
+            the workflow source directory since it was installed.
+
+            Valid for: paused, running workflows.
+        ''')
+        resolver = partial(mutator, command='validate_reinstall')
+
+    class Arguments(Reinstall.Arguments, Reload.Arguments):
+        """Compound command inherits arguments from the subcommands it proxies.
+        """
+
+    result = GenericScalar()
+
+
+class ReinstallRestart(graphene.Mutation):
+    class Meta:
+        description = sstrip('''
+            Validate, reinstall, then restart workflows.
+
+            This command updates a workflow to reflect any new changes made in
+            the workflow source directory since it was installed.
+
+            Valid for: stopped workflows.
+        ''')
+        resolver = partial(mutator, command='validate_reinstall')
+
+    class Arguments(Reinstall.Arguments, Play.Arguments):
+        """Compound command inherits arguments from the subcommands it proxies.
+        """
 
     result = GenericScalar()
 
@@ -936,7 +976,8 @@ class UISSubscriptions(Subscriptions):
 
 class UISMutations(Mutations):
     play = _mut_field(Play)
-    validate_reinstall = _mut_field(ValidateReinstall)
+    reinstall_reload = _mut_field(ReinstallReload)
+    reinstall_restart = _mut_field(ReinstallRestart)
     clean = _mut_field(Clean)
     scan = _mut_field(Scan)
 

--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -41,14 +41,15 @@ from cylc.flow.data_store_mgr import (
 )
 from cylc.flow.id import Tokens
 from cylc.flow.network.schema import (
-    NODE_MAP,
-    STRIP_NULL_DEFAULT,
-    SUB_RESOLVER_MAPPING,
     CyclePoint,
     GenericResponse,
     Job,
     Mutations,
+    NODE_MAP,
     Queries,
+    Reload,
+    STRIP_NULL_DEFAULT,
+    SUB_RESOLVER_MAPPING,
     SortArgs,
     Subscriptions,
     Task,
@@ -242,44 +243,78 @@ class Play(graphene.Mutation):
     result = GenericScalar()
 
 
-class ValidateReinstall(graphene.Mutation):
+class Reinstall:
+    class Arguments:
+        workflows = graphene.List(WorkflowID, required=True)
+        # cylc-rose
+        rose_opt_conf_keys = graphene.List(
+            graphene.String,
+            description=sstrip('''
+                Add Rose optional configurations (if Rose is used).
+            ''')
+        )
+        clear_rose_install_options = graphene.Boolean(
+            default_value=False,
+            description=sstrip('''
+                Clear options previous set by cylc-rose.
+            ''')
+        )
+        rose_suite_defines = graphene.List(
+            graphene.String,
+            description=sstrip('''
+                Each of these overrides the `[SECTION]KEY` setting in a
+                `rose-suite.conf` file.
+
+                Can be used to disable a setting using the syntax
+                `[SECTION]!KEY` or even `[!SECTION]`.
+            ''')
+        )
+        rose_template_variables = graphene.List(
+            graphene.String,
+            description=sstrip('''
+                Define a Rose `[template variable]`s e.g, `FOO=1`.
+
+                Note: Specifying `FOO=1` to this argument is equivalent to
+                specifying `[template variables]FOO=1` to the `define`
+                argument.
+            ''')
+        )
+
+
+class ReinstallReload(graphene.Mutation):
     class Meta:
         description = sstrip('''
-            Validate, reinstall, then reload or restart as appropriate.
+            Validate, reinstall, then reload the workflow.
 
             This command updates a workflow to reflect any new changes made in
             the workflow source directory since it was installed.
 
-            The workflow will be reinstalled, then either:
-            * Reloaded (if the workflow is running),
-            * or restarted (if it is stopped).
+            Valid for: paused, running workflows.
         ''')
         resolver = partial(mutator, command='validate_reinstall')
 
-    class Arguments:
-        workflows = graphene.List(WorkflowID, required=True)
-        cylc_version = CylcVersion(
-            description=sstrip('''
-                Set the Cylc version that the workflow starts with.
-            ''')
-        )
-        set = graphene.List(  # noqa: A003 (graphql field name)
-            graphene.String,
-            description=sstrip('''
-                Set the value of a Jinja2 template variable in the workflow
-                definition. Values should be valid Python literals so strings
-                must be quoted e.g. `STR="string"`, `INT=43`, `BOOL=True`.
-                This option can be used multiple  times on the command line.
-                NOTE: these settings persist across workflow restarts, but can
-                be set again on the `cylc play` command line if they need to be
-                overridden.
-            ''')
-        )
-        reload_global = graphene.Boolean(
-            default_value=False,
-            required=False,
-            description="Reload global config as well as the workflow config"
-        )
+    class Arguments(Reinstall.Arguments, Reload.Arguments):
+        """Compound command inherits arguments from the subcommands it proxies.
+        """
+
+    result = GenericScalar()
+
+
+class ReinstallRestart(graphene.Mutation):
+    class Meta:
+        description = sstrip('''
+            Validate, reinstall, then restart the workflow.
+
+            This command updates a workflow to reflect any new changes made in
+            the workflow source directory since it was installed.
+
+            Valid for: stopped workflows.
+        ''')
+        resolver = partial(mutator, command='validate_reinstall')
+
+    class Arguments(Reinstall.Arguments, Play.Arguments):
+        """Compound command inherits arguments from the subcommands it proxies.
+        """
 
     result = GenericScalar()
 
@@ -937,7 +972,8 @@ class UISSubscriptions(Subscriptions):
 
 class UISMutations(Mutations):
     play = _mut_field(Play)
-    validate_reinstall = _mut_field(ValidateReinstall)
+    reinstall_reload = _mut_field(ReinstallReload)
+    reinstall_restart = _mut_field(ReinstallRestart)
     clean = _mut_field(Clean)
     scan = _mut_field(Scan)
 

--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -242,6 +242,48 @@ class Play(graphene.Mutation):
     result = GenericScalar()
 
 
+class ValidateReinstall(graphene.Mutation):
+    class Meta:
+        description = sstrip('''
+            Validate, reinstall, then reload or restart as appropriate.
+
+            This command updates a workflow to reflect any new changes made in
+            the workflow source directory since it was installed.
+
+            The workflow will be reinstalled, then either:
+            * Reloaded (if the workflow is running),
+            * or restarted (if it is stopped).
+        ''')
+        resolver = partial(mutator, command='validate_reinstall')
+
+    class Arguments:
+        workflows = graphene.List(WorkflowID, required=True)
+        cylc_version = CylcVersion(
+            description=sstrip('''
+                Set the Cylc version that the workflow starts with.
+            ''')
+        )
+        set = graphene.List(  # noqa: A003 (graphql field name)
+            graphene.String,
+            description=sstrip('''
+                Set the value of a Jinja2 template variable in the workflow
+                definition. Values should be valid Python literals so strings
+                must be quoted e.g. `STR="string"`, `INT=43`, `BOOL=True`.
+                This option can be used multiple  times on the command line.
+                NOTE: these settings persist across workflow restarts, but can
+                be set again on the `cylc play` command line if they need to be
+                overridden.
+            ''')
+        )
+        reload_global = graphene.Boolean(
+            default_value=False,
+            required=False,
+            description="Reload global config as well as the workflow config"
+        )
+
+    result = GenericScalar()
+
+
 class Clean(graphene.Mutation):
     class Meta:
         description = sstrip('''
@@ -895,6 +937,7 @@ class UISSubscriptions(Subscriptions):
 
 class UISMutations(Mutations):
     play = _mut_field(Play)
+    validate_reinstall = _mut_field(ValidateReinstall)
     clean = _mut_field(Clean)
     scan = _mut_field(Scan)
 

--- a/cylc/uiserver/tests/test_authorise.py
+++ b/cylc/uiserver/tests/test_authorise.py
@@ -52,31 +52,13 @@ CONTROL_OPS = [
     "set_verbosity",
     "stop",
     "trigger",
+    "validate_reinstall",
 ]
 
 ALL_OPS = [
-    "clean",
+    *CONTROL_OPS,
     "read",
     "broadcast",
-    "ext_trigger",
-    "hold",
-    "kill",
-    "message",
-    "pause",
-    "play",
-    "poll",
-    "release",
-    "release_hold_point",
-    "reload",
-    "remove",
-    "resume",
-    "scan",
-    "set",
-    "set_graph_window_extent",
-    "set_hold_point",
-    "set_verbosity",
-    "stop",
-    "trigger",
 ]
 
 FAKE_SITE_CONF = {
@@ -154,6 +136,7 @@ FAKE_USER_CONF = {
                 "pause",
                 "set",
                 "release",
+                "validate_reinstall",
             },
             id="user in * and groups, owner in * and groups",
         ),

--- a/cylc/uiserver/tests/test_authorise.py
+++ b/cylc/uiserver/tests/test_authorise.py
@@ -40,6 +40,8 @@ CONTROL_OPS = [
     "pause",
     "play",
     "poll",
+    "reinstall_reload",
+    "reinstall_restart",
     "release",
     "release_hold_point",
     "reload",
@@ -52,7 +54,6 @@ CONTROL_OPS = [
     "set_verbosity",
     "stop",
     "trigger",
-    "validate_reinstall",
 ]
 
 ALL_OPS = [
@@ -136,7 +137,8 @@ FAKE_USER_CONF = {
                 "pause",
                 "set",
                 "release",
-                "validate_reinstall",
+                "reinstall_reload",
+                "reinstall_restart",
             },
             id="user in * and groups, owner in * and groups",
         ),

--- a/cylc/uiserver/tests/test_authorise.py
+++ b/cylc/uiserver/tests/test_authorise.py
@@ -41,6 +41,8 @@ CONTROL_OPS = [
     "pause",
     "play",
     "poll",
+    "reinstall_reload",
+    "reinstall_restart",
     "release",
     "release_hold_point",
     "reload",
@@ -53,7 +55,6 @@ CONTROL_OPS = [
     "set_verbosity",
     "stop",
     "trigger",
-    "validate_reinstall",
 ]
 
 ALL_OPS = [
@@ -136,7 +137,8 @@ FAKE_USER_CONF = {
                 "pause",
                 "set",
                 "release",
-                "validate_reinstall",
+                "reinstall_reload",
+                "reinstall_restart",
             },
             id="user in * and groups, owner in * and groups",
         ),

--- a/cylc/uiserver/tests/test_authorise.py
+++ b/cylc/uiserver/tests/test_authorise.py
@@ -53,31 +53,13 @@ CONTROL_OPS = [
     "set_verbosity",
     "stop",
     "trigger",
+    "validate_reinstall",
 ]
 
 ALL_OPS = [
-    "clean",
+    *CONTROL_OPS,
     "read",
     "broadcast",
-    "ext_trigger",
-    "hold",
-    "kill",
-    "message",
-    "pause",
-    "play",
-    "poll",
-    "release",
-    "release_hold_point",
-    "reload",
-    "remove",
-    "resume",
-    "scan",
-    "set",
-    "set_graph_window_extent",
-    "set_hold_point",
-    "set_verbosity",
-    "stop",
-    "trigger",
 ]
 
 FAKE_SITE_CONF = {
@@ -154,6 +136,7 @@ FAKE_USER_CONF = {
                 "pause",
                 "set",
                 "release",
+                "validate_reinstall",
             },
             id="user in * and groups, owner in * and groups",
         ),

--- a/cylc/uiserver/tests/test_resolvers.py
+++ b/cylc/uiserver/tests/test_resolvers.py
@@ -15,6 +15,7 @@
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+import re
 from typing import Any, Dict, List, Tuple
 import logging
 import os
@@ -64,8 +65,8 @@ def test__schema_opts_to_api_opts(schema_opts, schema, expect):
 @pytest.mark.parametrize(
     'func, message, expect',
     [
-        (services._return, 'Hello.', [True, 'Hello.']),
-        (services._error, 'Goodbye.', [False, 'Goodbye.'])
+        (services._return, 'Hello.', (True, 'Hello.')),
+        (services._error, 'Goodbye.', (False, 'Goodbye.'))
     ]
 )
 def test_Services_anciliary_methods(func, message, expect):
@@ -75,13 +76,16 @@ def test_Services_anciliary_methods(func, message, expect):
 
 
 @pytest.mark.parametrize(
+    'service', (Services.play, Services.validate_reinstall)
+)
+@pytest.mark.parametrize(
     'workflows, args, env, expected_ret, expected_env',
     [
         pytest.param(
             [Tokens('wflow1'), Tokens('~murray/wflow2')],
             {},
             {},
-            [True, "Workflow(s) started"],
+            (True, r"Workflow\(s\) .*ed"),
             {},
             id="multiple"
         ),
@@ -89,7 +93,7 @@ def test_Services_anciliary_methods(func, message, expect):
             [Tokens('~feynman/wflow1')],
             {},
             {},
-            [False, "Cannot start workflows for other users."],
+            (False, "Cannot start workflows for other users."),
             {},
             id="other user's wflow"
         ),
@@ -97,7 +101,7 @@ def test_Services_anciliary_methods(func, message, expect):
             [Tokens('wflow1')],
             {'cylc_version': 'top'},
             {'CYLC_VERSION': 'bottom', 'CYLC_ENV_NAME': 'quark'},
-            [True, "Workflow(s) started"],
+            (True, r"Workflow\(s\) .*ed"),
             {'CYLC_VERSION': 'top'},
             id="cylc version overrides env"
         ),
@@ -105,13 +109,14 @@ def test_Services_anciliary_methods(func, message, expect):
             [Tokens('wflow1')],
             {},
             {'CYLC_VERSION': 'charm', 'CYLC_ENV_NAME': 'quark'},
-            [True, "Workflow(s) started"],
+            (True, r"Workflow\(s\) .*ed"),
             {'CYLC_VERSION': 'charm', 'CYLC_ENV_NAME': 'quark'},
             id="cylc env not overriden if no version specified"
         ),
     ]
 )
-async def test_play(
+async def test_start_services(
+    service,
     monkeypatch: pytest.MonkeyPatch,
     workflows: List[Tokens],
     args: Dict[str, Any],
@@ -119,7 +124,7 @@ async def test_play(
     expected_ret: list,
     expected_env: Dict[str, str],
 ):
-    """It runs cylc play correctly.
+    """It runs cylc play / vr correctly.
 
     Params:
         workflows: list of workflow tokens
@@ -143,24 +148,28 @@ async def test_play(
     )
     monkeypatch.setattr('cylc.uiserver.resolvers.Popen', mock_popen)
 
-    ret = await Services.play(
+    status, message = await service(
+        Mock(spec=WorkflowsManager),
         workflows,
         {'some': 'opt', **args},
-        workflows_mgr=Mock(spec=WorkflowsManager),
         log=Mock(),
     )
 
-    assert ret == expected_ret
+    assert status == expected_ret[0]
+    assert re.match(expected_ret[1], message)
 
     for i, call_args in enumerate(mock_popen.call_args_list):
         cmd_str = ' '.join(call_args.args[0])
-        assert cmd_str.startswith('cylc play')
+        assert cmd_str.startswith('cylc ')
         assert '--some opt' in cmd_str
         assert workflows[i]['workflow'] in cmd_str
 
         assert call_args.kwargs['env'] == expected_env
 
 
+@pytest.mark.parametrize(
+    'service', (Services.play, Services.validate_reinstall)
+)
 @pytest.mark.parametrize(
     'workflows, popen_ret_codes, popen_communicate,'
     'expected_ret, expected_log',
@@ -169,37 +178,38 @@ async def test_play(
             [Tokens('wflow1')],
             [1],
             ("something", "bad things!!"),
-            "bad things!!",
-            ["Command failed (1): cylc play", "something", "bad things!!"],
+            r"bad things!!.*",
+            ["Command failed \(1\): cylc ", "something", "bad things!!"],
             id="one"
         ),
         pytest.param(
             [Tokens('wflow1'), Tokens('wflow2')],
             [1, 0],
             ("", "bad things!!"),
-            "\n\nwflow1: bad things!!\n\nwflow2: started",
-            ["Command failed (1): cylc play", "bad things!!"],
+            r"\n\nwflow1: bad things!!\n\nwflow2: .*ed.*",
+            [r"Command failed \(1\): cylc ", "bad things!!"],
             id="multiple"
         ),
         pytest.param(
             [Tokens('wflow1')],
             [1],
             ("something", ""),
-            "something",
-            ["Command failed (1): cylc play", "something"],
+            r"something.*",
+            [r"Command failed \(1\): cylc ", "something"],
             id="uses stdout if stderr empty"
         ),
         pytest.param(
             [Tokens('wflow1')],
             [4],
             ("", ""),
-            "Command failed (4): cylc play",
-            ["Command failed (4): cylc play"],
+            r"Command failed \(4\): cylc .*",
+            [r"Command failed \(4\): cylc "],
             id="fallback msg if stdout/stderr empty"
         ),
     ]
 )
-async def test_play_fail(
+async def test_start_services_fail(
+    service,
     monkeypatch: pytest.MonkeyPatch,
     workflows: List[Tokens],
     popen_ret_codes: List[int],
@@ -208,7 +218,7 @@ async def test_play_fail(
     expected_log: List[str],
     caplog: pytest.LogCaptureFixture,
 ):
-    """It returns suitable error messages if cylc play fails.
+    """It returns suitable error messages if cylc play / vr fails.
 
     Params:
         workflows: list of workflow tokens
@@ -216,6 +226,7 @@ async def test_play_fail(
         popen_communicate: stdout, stderr for cylc play
         expected: (beginning of) expected returned error message
     """
+    popen_ret_codes = list(popen_ret_codes)
     mock_popen = Mock(
         spec=Popen,
         return_value=Mock(
@@ -227,17 +238,18 @@ async def test_play_fail(
     monkeypatch.setattr('cylc.uiserver.resolvers.Popen', mock_popen)
     caplog.set_level(logging.ERROR)
 
-    status, message = await Services.play(
+    status, message = await service(
+        Mock(spec=WorkflowsManager),
         workflows,
         {},
-        workflows_mgr=Mock(spec=WorkflowsManager),
         log=logging.root,
     )
     assert status is False
-    assert message.startswith(expected_ret)
+    assert re.match(expected_ret, message)
+
     # Should be logged too:
     for msg in expected_log:
-        assert msg in caplog.text
+        assert re.search(msg, caplog.text)
 
 
 async def test_play_timeout(monkeypatch: pytest.MonkeyPatch):
@@ -252,9 +264,9 @@ async def test_play_timeout(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr('cylc.uiserver.resolvers.Popen', mock_popen)
 
     ret = await Services.play(
+        Mock(spec=WorkflowsManager),
         [Tokens('wflow1')],
         {},
-        workflows_mgr=Mock(spec=WorkflowsManager),
         log=Mock(),
     )
     assert ret == [
@@ -401,12 +413,12 @@ async def test_clean__error(
     caplog.set_level(logging.ERROR)
 
     ret = Services.clean(
+        Mock(spec=WorkflowsManager),
         [Tokens('wflow1')],
         {},
-        workflows_mgr=Mock(spec=WorkflowsManager),
         executor=ThreadPoolExecutor(1),
         log=logging.root,
     )
     err_msg = "CylcError: bad things!!"
-    assert (await ret) == [False, err_msg]
+    assert (await ret) == (False, err_msg)
     assert err_msg in caplog.text

--- a/cylc/uiserver/tests/test_resolvers.py
+++ b/cylc/uiserver/tests/test_resolvers.py
@@ -174,7 +174,7 @@ async def test_start_services(
             [1],
             ("something", "bad things!!"),
             r"bad things!!.*",
-            ["Command failed \(1\): cylc ", "something", "bad things!!"],
+            [r"Command failed \(1\): cylc ", "something", "bad things!!"],
             id="one"
         ),
         pytest.param(

--- a/cylc/uiserver/tests/test_resolvers.py
+++ b/cylc/uiserver/tests/test_resolvers.py
@@ -16,6 +16,7 @@
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+import re
 from typing import Any, Dict, List, Tuple
 import logging
 import os
@@ -65,8 +66,8 @@ def test__schema_opts_to_api_opts(schema_opts, schema, expect):
 @pytest.mark.parametrize(
     'func, message, expect',
     [
-        (services._return, 'Hello.', [True, 'Hello.']),
-        (services._error, 'Goodbye.', [False, 'Goodbye.'])
+        (services._return, 'Hello.', (True, 'Hello.')),
+        (services._error, 'Goodbye.', (False, 'Goodbye.'))
     ]
 )
 def test_Services_anciliary_methods(func, message, expect):
@@ -76,13 +77,16 @@ def test_Services_anciliary_methods(func, message, expect):
 
 
 @pytest.mark.parametrize(
+    'service', (Services.play, Services.validate_reinstall)
+)
+@pytest.mark.parametrize(
     'workflows, args, env, expected_ret, expected_env',
     [
         pytest.param(
             [Tokens('wflow1'), Tokens('~murray/wflow2')],
             {},
             {},
-            [True, "Workflow(s) started"],
+            (True, r"Workflow\(s\) .*ed"),
             {},
             id="multiple"
         ),
@@ -90,7 +94,7 @@ def test_Services_anciliary_methods(func, message, expect):
             [Tokens('~feynman/wflow1')],
             {},
             {},
-            [False, "Cannot start workflows for other users."],
+            (False, "Cannot start workflows for other users."),
             {},
             id="other user's wflow"
         ),
@@ -98,7 +102,7 @@ def test_Services_anciliary_methods(func, message, expect):
             [Tokens('wflow1')],
             {'cylc_version': 'top'},
             {'CYLC_VERSION': 'bottom', 'CYLC_ENV_NAME': 'quark'},
-            [True, "Workflow(s) started"],
+            (True, r"Workflow\(s\) .*ed"),
             {'CYLC_VERSION': 'top'},
             id="cylc version overrides env"
         ),
@@ -106,13 +110,14 @@ def test_Services_anciliary_methods(func, message, expect):
             [Tokens('wflow1')],
             {},
             {'CYLC_VERSION': 'charm', 'CYLC_ENV_NAME': 'quark'},
-            [True, "Workflow(s) started"],
+            (True, r"Workflow\(s\) .*ed"),
             {'CYLC_VERSION': 'charm', 'CYLC_ENV_NAME': 'quark'},
             id="cylc env not overriden if no version specified"
         ),
     ]
 )
-async def test_play(
+async def test_start_services(
+    service,
     monkeypatch: pytest.MonkeyPatch,
     workflows: List[Tokens],
     args: Dict[str, Any],
@@ -120,7 +125,7 @@ async def test_play(
     expected_ret: list,
     expected_env: Dict[str, str],
 ):
-    """It runs cylc play correctly.
+    """It runs cylc play / vr correctly.
 
     Params:
         workflows: list of workflow tokens
@@ -144,24 +149,28 @@ async def test_play(
     )
     monkeypatch.setattr('cylc.uiserver.resolvers.Popen', mock_popen)
 
-    ret = await Services.play(
+    status, message = await service(
+        Mock(spec=WorkflowsManager),
         workflows,
         {'some': 'opt', **args},
-        workflows_mgr=Mock(spec=WorkflowsManager),
         log=Mock(),
     )
 
-    assert ret == expected_ret
+    assert status == expected_ret[0]
+    assert re.match(expected_ret[1], message)
 
     for i, call_args in enumerate(mock_popen.call_args_list):
         cmd_str = ' '.join(call_args.args[0])
-        assert cmd_str.startswith('cylc play')
+        assert cmd_str.startswith('cylc ')
         assert '--some opt' in cmd_str
         assert workflows[i]['workflow'] in cmd_str
 
         assert call_args.kwargs['env'] == expected_env
 
 
+@pytest.mark.parametrize(
+    'service', (Services.play, Services.validate_reinstall)
+)
 @pytest.mark.parametrize(
     'workflows, popen_ret_codes, popen_communicate,'
     'expected_ret, expected_log',
@@ -170,37 +179,38 @@ async def test_play(
             [Tokens('wflow1')],
             [1],
             ("something", "bad things!!"),
-            "bad things!!",
-            ["Command failed (1): cylc play", "something", "bad things!!"],
+            r"bad things!!.*",
+            ["Command failed \(1\): cylc ", "something", "bad things!!"],
             id="one"
         ),
         pytest.param(
             [Tokens('wflow1'), Tokens('wflow2')],
             [1, 0],
             ("", "bad things!!"),
-            "\n\nwflow1: bad things!!\n\nwflow2: started",
-            ["Command failed (1): cylc play", "bad things!!"],
+            r"\n\nwflow1: bad things!!\n\nwflow2: .*ed.*",
+            [r"Command failed \(1\): cylc ", "bad things!!"],
             id="multiple"
         ),
         pytest.param(
             [Tokens('wflow1')],
             [1],
             ("something", ""),
-            "something",
-            ["Command failed (1): cylc play", "something"],
+            r"something.*",
+            [r"Command failed \(1\): cylc ", "something"],
             id="uses stdout if stderr empty"
         ),
         pytest.param(
             [Tokens('wflow1')],
             [4],
             ("", ""),
-            "Command failed (4): cylc play",
-            ["Command failed (4): cylc play"],
+            r"Command failed \(4\): cylc .*",
+            [r"Command failed \(4\): cylc "],
             id="fallback msg if stdout/stderr empty"
         ),
     ]
 )
-async def test_play_fail(
+async def test_start_services_fail(
+    service,
     monkeypatch: pytest.MonkeyPatch,
     workflows: List[Tokens],
     popen_ret_codes: List[int],
@@ -209,7 +219,7 @@ async def test_play_fail(
     expected_log: List[str],
     caplog: pytest.LogCaptureFixture,
 ):
-    """It returns suitable error messages if cylc play fails.
+    """It returns suitable error messages if cylc play / vr fails.
 
     Params:
         workflows: list of workflow tokens
@@ -217,6 +227,7 @@ async def test_play_fail(
         popen_communicate: stdout, stderr for cylc play
         expected: (beginning of) expected returned error message
     """
+    popen_ret_codes = list(popen_ret_codes)
     mock_popen = Mock(
         spec=Popen,
         return_value=Mock(
@@ -228,17 +239,18 @@ async def test_play_fail(
     monkeypatch.setattr('cylc.uiserver.resolvers.Popen', mock_popen)
     caplog.set_level(logging.ERROR)
 
-    status, message = await Services.play(
+    status, message = await service(
+        Mock(spec=WorkflowsManager),
         workflows,
         {},
-        workflows_mgr=Mock(spec=WorkflowsManager),
         log=logging.root,
     )
     assert status is False
-    assert message.startswith(expected_ret)
+    assert re.match(expected_ret, message)
+
     # Should be logged too:
     for msg in expected_log:
-        assert msg in caplog.text
+        assert re.search(msg, caplog.text)
 
 
 async def test_play_timeout(monkeypatch: pytest.MonkeyPatch):
@@ -253,9 +265,9 @@ async def test_play_timeout(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr('cylc.uiserver.resolvers.Popen', mock_popen)
 
     ret = await Services.play(
+        Mock(spec=WorkflowsManager),
         [Tokens('wflow1')],
         {},
-        workflows_mgr=Mock(spec=WorkflowsManager),
         log=Mock(),
     )
     assert ret == [
@@ -402,12 +414,12 @@ async def test_clean__error(
     caplog.set_level(logging.ERROR)
 
     ret = Services.clean(
+        Mock(spec=WorkflowsManager),
         [Tokens('wflow1')],
         {},
-        workflows_mgr=Mock(spec=WorkflowsManager),
         executor=ThreadPoolExecutor(1),
         log=logging.root,
     )
     err_msg = "CylcError: bad things!!"
-    assert (await ret) == [False, err_msg]
+    assert (await ret) == (False, err_msg)
     assert err_msg in caplog.text

--- a/cylc/uiserver/tests/test_resolvers.py
+++ b/cylc/uiserver/tests/test_resolvers.py
@@ -175,7 +175,7 @@ async def test_start_services(
             [1],
             ("something", "bad things!!"),
             r"bad things!!.*",
-            ["Command failed \(1\): cylc ", "something", "bad things!!"],
+            [r"Command failed \(1\): cylc ", "something", "bad things!!"],
             id="one"
         ),
         pytest.param(

--- a/cylc/uiserver/tests/test_resolvers.py
+++ b/cylc/uiserver/tests/test_resolvers.py
@@ -25,12 +25,6 @@ from unittest.mock import MagicMock, Mock
 from subprocess import Popen, TimeoutExpired
 from types import SimpleNamespace
 
-import sys
-if sys.version_info >= (3, 11):
-    from asyncio import timeout
-else:
-    from async_timeout import timeout
-
 from cylc.flow import CYLC_LOG
 from cylc.flow.exceptions import CylcError
 from cylc.flow.id import Tokens
@@ -145,6 +139,7 @@ async def test_start_services(
         return_value=Mock(
             spec=Popen,
             wait=Mock(return_value=0),
+            communicate=lambda: ('out', 'err'),
         )
     )
     monkeypatch.setattr('cylc.uiserver.resolvers.Popen', mock_popen)
@@ -260,7 +255,11 @@ async def test_play_timeout(monkeypatch: pytest.MonkeyPatch):
 
     mock_popen = Mock(
         spec=Popen,
-        return_value=Mock(spec=Popen, wait=wait)
+        return_value=Mock(
+            spec=Popen,
+            wait=wait,
+            communicate=lambda: ('out', 'err'),
+        ),
     )
     monkeypatch.setattr('cylc.uiserver.resolvers.Popen', mock_popen)
 
@@ -270,9 +269,9 @@ async def test_play_timeout(monkeypatch: pytest.MonkeyPatch):
         {},
         log=Mock(),
     )
-    assert ret == [
-        False, "Command 'cylc play wflow1' timed out after 120 seconds"
-    ]
+    assert ret == (
+        False, "Command 'cylc play wflow1' timed out after 120 seconds\nerr"
+    )
 
 
 @pytest.fixture
@@ -331,7 +330,7 @@ async def test_cat_log(workflow_run_dir, app, fast_sleep):
 
     # note - timeout tests that the cat-log process is being stopped correctly
     first_response = None
-    async with timeout(20):
+    async with asyncio.timeout(20):
         ret = services.cat_log(workflow, app, info)
         actual = ''
         is_first = True
@@ -380,7 +379,7 @@ async def test_cat_log_timeout(workflow_run_dir, app, fast_sleep):
 
     ret = services.cat_log(workflow, app, info)
     responses = []
-    async with timeout(5):
+    async with asyncio.timeout(5):
         async for response in ret:
             responses.append(response)
             await asyncio.sleep(0)


### PR DESCRIPTION
Closes #526

I somehow forgot that we have `cylc vr` support in the Tui, but not the GUI!

Trivial to add support. Supporting the `cylc install` command is also possible, however, that will require #512.

UI sibling: https://github.com/cylc/cylc-ui/pull/2347


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.