### PR TITLE
flake8: address B042

### DIFF
--- a/cylc/uiserver/graphql/tornado.py
+++ b/cylc/uiserver/graphql/tornado.py
@@ -112,7 +112,8 @@ def get_accepted_content_types(request: 'HTTPServerRequest') -> list:
 
 
 class ExecutionError(Exception):
-    def __init__(self, status_code=400, errors=None):
+    def __init__(self, status_code, errors):
+        super().__init__(status_code, errors)
         self.status_code = status_code
         if errors is None:
             self.errors = []


### PR DESCRIPTION
Satisfy B042.

tldr; Python exceptions have some strange bespoke stuff goin on. Don't use kwargs (status_code was only ever set to 400), and always init the superclass using all args.