### PR TITLE
cat log: handle longer lines in files

### DIFF
--- a/cylc/uiserver/utils.py
+++ b/cylc/uiserver/utils.py
@@ -14,15 +14,32 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from typing import TYPE_CHECKING
+from typing import (
+    TYPE_CHECKING,
+    TypeVar,
+    cast,
+)
 
 from jupyter_server.auth.identity import PasswordIdentityProvider
 
+
 if TYPE_CHECKING:
-    from cylc.uiserver.handlers import CylcAppHandler
     from jupyter_server.auth.identity import (
         IdentityProvider as JPSIdentityProvider,
     )
+
+    from cylc.uiserver.handlers import CylcAppHandler
+
+
+_T = TypeVar('_T')
+
+
+def cast_non_null(var: _T | None) -> _T:
+    """Type cast an "Optional" variable to its non-None type.
+
+    Does not perform any runtime checks.
+    """
+    return cast('_T', var)
 
 
 def is_bearer_token_authenticated(handler: 'CylcAppHandler') -> bool:


### PR DESCRIPTION
Addresses a bug reported by a user where they said they saw an red error snackbar in the UI that said
> ValueError: Separator is not found, and chunk exceed the limit

I have not managed to reproduce in exactly this way, but if a line is [longer than 64 kiB](https://docs.python.org/3/library/asyncio-stream.html#asyncio.open_connection), the log view in the UI will stop at that line, but there is no hint that anything is wrong. Later in the uiserver log I saw the error message and traceback once  I closed the UI.

This PR increases the line limit to 200 kiB as a precaution, and properly displays a "line too long" error in the log view should a line exceed this.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
