### PR TITLE
add graphql websocket subsciption tests

### DIFF
--- a/cylc/uiserver/graphql/tornado.py
+++ b/cylc/uiserver/graphql/tornado.py
@@ -40,7 +40,6 @@ from typing import (
 from tornado import web
 from tornado.escape import json_encode
 from tornado.escape import to_unicode
-from tornado.httpclient import HTTPClientError
 from tornado.log import app_log
 from tornado.web import HTTPError
 
@@ -146,46 +145,35 @@ class TornadoGraphQLHandler(web.RequestHandler):
             self.handle_error(ex)
 
     async def run(self, *args, **kwargs):
-        try:
-            data = self.parse_body()
+        data = self.parse_body()
 
-            if self.batch:
-                responses = [
-                    await self.get_response(entry)
-                    for entry in data
-                ]
-                result = "[{}]".format(
-                    ",".join([response[0] for response in responses])
-                )
-                status_code = (
-                    responses
-                    and max(responses, key=lambda response: response[1])[1]
-                    or 200
-                )
-            else:
-                result, status_code = await self.get_response(data)
-
-            if status_code == 400:
-                self.set_status(status_code, reason=result)
-            else:
-                self.set_status(status_code)
-
-            self.set_header("Content-Type", "application/json")
-            self.write(result)
-            await self.finish()
-
-        except HTTPClientError as e:
-            response = e.response
-            response["Content-Type"] = "application/json"
-            response.content = self.json_encode(
-                {"errors": [self.format_error(e)]}
+        if self.batch:
+            responses = [
+                await self.get_response(entry)
+                for entry in data
+            ]
+            result = "[{}]".format(
+                ",".join([response[0] for response in responses])
             )
-            return response
+            status_code = (
+                responses
+                and max(responses, key=lambda response: response[1])[1]
+                or 200
+            )
+        else:
+            result, status_code = await self.get_response(data)
+
+        if status_code == 400:
+            self.set_status(status_code, reason=result)
+        else:
+            self.set_status(status_code)
+
+        self.set_header("Content-Type", "application/json")
+        self.write(result)
+        await self.finish()
 
     async def get_response(self, data):
-        query, variables, operation_name, _id = self.get_graphql_params(
-            self.request, data
-        )
+        query, variables, operation_name, _id = self.get_graphql_params(data)
 
         execution_result = await self.execute_graphql_request(
             data, query, variables, operation_name
@@ -253,10 +241,10 @@ class TornadoGraphQLHandler(web.RequestHandler):
                 request_json = json.loads(body)
                 if self.batch:
                     if not isinstance(request_json, list):
-                        raise AssertionError(
+                        raise AssertionError((
                             "Batch requests should receive a list"
                             ", but received {}."
-                        ).format(repr(request_json))
+                        ).format(repr(request_json)))
                     if len(request_json) <= 0:
                         raise AssertionError(
                             "Received an empty list in the batch request."
@@ -354,14 +342,14 @@ class TornadoGraphQLHandler(web.RequestHandler):
     async def execute(self, *args, **kwargs):
         return execute(*args, **kwargs)
 
-    def get_graphql_params(self, request, data):
+    def get_graphql_params(self, data):
         if self.graphql_params:
             return self.graphql_params
 
         single_args = {}
-        for key in request.arguments.keys():
+        for key in self.request.arguments.keys():
             single_args[key] = self.decode_argument(
-                request.arguments.get(key)[0])
+                self.request.arguments.get(key)[0])
 
         query = single_args.get("query") or data.get("query")
         variables = single_args.get("variables") or data.get("variables")

--- a/cylc/uiserver/graphql/tornado.py
+++ b/cylc/uiserver/graphql/tornado.py
@@ -235,7 +235,7 @@ class TornadoGraphQLHandler(web.RequestHandler):
             try:
                 body = self.request.body
             except Exception as e:
-                raise ExecutionError(400, e)
+                raise ExecutionError(400, [e])
 
             try:
                 request_json = json.loads(body)
@@ -337,7 +337,7 @@ class TornadoGraphQLHandler(web.RequestHandler):
 
             return result
         except Exception as e:
-            return ExecutionResult(errors=[e])
+            return ExecutionResult(data=None, errors=[e])
 
     async def execute(self, *args, **kwargs):
         return execute(*args, **kwargs)

--- a/cylc/uiserver/graphql/tornado.py
+++ b/cylc/uiserver/graphql/tornado.py
@@ -59,11 +59,7 @@ from graphql.execution.middleware import MiddlewareManager
 from graphql.pyutils import is_awaitable
 from graphql.validation import validate
 
-from cylc.flow.network.graphql import (
-    NULL_VALUE,
-    instantiate_middleware,
-    strip_null
-)
+from cylc.flow.network.graphql import instantiate_middleware
 
 if TYPE_CHECKING:
     from graphene import Schema
@@ -71,20 +67,6 @@ if TYPE_CHECKING:
 
 MUTATION_ERRORS_FLAG = "graphene_mutation_has_errors"
 MAX_VALIDATION_ERRORS = None
-
-
-def data_search_action(data, action):
-    if isinstance(data, dict):
-        return {
-            key: data_search_action(val, action)
-            for key, val in data.items()
-        }
-    if isinstance(data, list):
-        return [
-            data_search_action(val, action)
-            for val in data
-        ]
-    return action(data)
 
 
 def get_content_type(request: 'HTTPServerRequest') -> str:
@@ -183,7 +165,11 @@ class TornadoGraphQLHandler(web.RequestHandler):
             else:
                 result, status_code = await self.get_response(data)
 
-            self.set_status(status_code)
+            if status_code == 400:
+                self.set_status(status_code, reason=result)
+            else:
+                self.set_status(status_code)
+
             self.set_header("Content-Type", "application/json")
             self.write(result)
             await self.finish()
@@ -192,7 +178,7 @@ class TornadoGraphQLHandler(web.RequestHandler):
             response = e.response
             response["Content-Type"] = "application/json"
             response.content = self.json_encode(
-                self.request, {"errors": [self.format_error(e)]}
+                {"errors": [self.format_error(e)]}
             )
             return response
 
@@ -232,39 +218,16 @@ class TornadoGraphQLHandler(web.RequestHandler):
             if self.batch:
                 response["id"] = _id
                 response["status"] = status_code
-            try:
-                result = self.json_encode(response)
-            except TypeError:
-                # Catch exceptions in response
-                errors = []
 
-                def exc_to_errors(data):
-                    if isinstance(data, Exception):
-                        errors.append({
-                            'message': (
-                                f'{data.value}'
-                                if hasattr(data, 'value') else f'{data}'
-                            )
-                        })
-                        return NULL_VALUE
-                    return data
-
-                response = data_search_action(
-                    response,
-                    exc_to_errors
-                )
-                response.setdefault("errors", []).extend(errors)
-                response = strip_null(response)
-
-                result = self.json_encode(response)
+            result = self.json_encode(response)
         else:
             result = None
 
         return result, status_code
 
-    def json_encode(self, d, pretty=False):
+    def json_encode(self, d):
         if (
-            (self.pretty or pretty)
+            self.pretty
             or self.get_query_argument("pretty", False)
             or self.get_body_argument("pretty", False)
         ):

--- a/cylc/uiserver/graphql/tornado.py
+++ b/cylc/uiserver/graphql/tornado.py
@@ -263,7 +263,11 @@ class TornadoGraphQLHandler(web.RequestHandler):
         return result, status_code
 
     def json_encode(self, d, pretty=False):
-        if (self.pretty or pretty) or self.get_query_argument("pretty", False):
+        if (
+            (self.pretty or pretty)
+            or self.get_query_argument("pretty", False)
+            or self.get_body_argument("pretty", False)
+        ):
             return json.dumps(
                 d, sort_keys=True, indent=2, separators=(",", ": "))
 
@@ -290,7 +294,7 @@ class TornadoGraphQLHandler(web.RequestHandler):
                             "Batch requests should receive a list"
                             ", but received {}."
                         ).format(repr(request_json))
-                    if len(request_json <= 0):
+                    if len(request_json) <= 0:
                         raise AssertionError(
                             "Received an empty list in the batch request."
                         )

--- a/cylc/uiserver/graphql/tornado.py
+++ b/cylc/uiserver/graphql/tornado.py
@@ -24,7 +24,6 @@
 
 from asyncio import iscoroutinefunction
 import json
-import re
 import sys
 import traceback
 from typing import (
@@ -90,25 +89,6 @@ def data_search_action(data, action):
 
 def get_content_type(request: 'HTTPServerRequest') -> str:
     return request.headers.get("Content-Type", "").split(";", 1)[0].lower()
-
-
-def get_accepted_content_types(request: 'HTTPServerRequest') -> list:
-    def qualify(x):
-        parts = x.split(";", 1)
-        if len(parts) == 2:
-            match = re.match(
-                r"(^|;)q=(0(\.\d{,3})?|1(\.0{,3})?)(;|$)", parts[1])
-            if match:
-                return parts[0].strip(), float(match.group(2))
-        return parts[0].strip(), 1
-
-    raw_content_types = request.headers.get("Accept", "*/*").split(",")
-    qualified_content_types = map(qualify, raw_content_types)
-    return [
-        x[0]
-        for x in sorted(
-            qualified_content_types, key=lambda x: x[1], reverse=True)
-    ]
 
 
 class ExecutionError(Exception):
@@ -406,24 +386,6 @@ class TornadoGraphQLHandler(web.RequestHandler):
 
     async def execute(self, *args, **kwargs):
         return execute(*args, **kwargs)
-
-    def request_wants_html(self):
-        accepted = get_accepted_content_types(self.request)
-        accepted_length = len(accepted)
-        # the list will be ordered in preferred first - so we have to make
-        # sure the most preferred gets the highest number
-        html_priority = (
-            accepted_length - accepted.index("text/html")
-            if "text/html" in accepted
-            else 0
-        )
-        json_priority = (
-            accepted_length - accepted.index("application/json")
-            if "application/json" in accepted
-            else 0
-        )
-
-        return html_priority > json_priority
 
     def get_graphql_params(self, request, data):
         if self.graphql_params:

--- a/cylc/uiserver/graphql/tornado.py
+++ b/cylc/uiserver/graphql/tornado.py
@@ -235,7 +235,7 @@ class TornadoGraphQLHandler(web.RequestHandler):
             try:
                 body = self.request.body
             except Exception as e:
-                raise ExecutionError(400, e) from e
+                raise ExecutionError(400, [e]) from e
 
             try:
                 request_json = json.loads(body)
@@ -337,7 +337,7 @@ class TornadoGraphQLHandler(web.RequestHandler):
 
             return result
         except Exception as e:
-            return ExecutionResult(errors=[e])
+            return ExecutionResult(data=None, errors=[e])
 
     async def execute(self, *args, **kwargs):
         return execute(*args, **kwargs)

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -280,6 +280,13 @@ def patch_conf_files(monkeypatch: pytest.MonkeyPatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def remove_data_store_sleep(monkeypatch):
+    monkeypatch.setattr(
+        'cylc.uiserver.data_store_mgr.time.sleep', lambda x: None
+    )
+
+
 @pytest.fixture
 def cylc_uis(jp_serverapp):
     """Return the UIS extension for the JupyterServer ServerApp."""

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -51,11 +51,16 @@ def gql_query(jp_fetch):
         }
         if not kwargs.get('method'):
             kwargs['method'] = 'POST'
+        params = {}
         if 'body' not in kwargs:
-            kwargs['body'] = json.dumps({'query': query}, indent=4)
+            if kwargs['method'] in ("POST", "PATCH", "PUT"):
+                kwargs['body'] = json.dumps({'query': query}, indent=4)
+            else:
+                params = {'query': query}
         return await jp_fetch(
             *endpoint,
             headers=headers,
+            params=params,
             **kwargs
         )
 
@@ -127,21 +132,27 @@ async def test_query(gql_query, dummy_workflow):
     await dummy_workflow('foo')
     await dummy_workflow('bar')
 
-    query = '''
-        query {
-            workflows {
-                id
-                status
-            }
-        }
-    '''
+    query = '''query {workflows {id status}}'''
 
     # perform the request
-    response = await gql_query(*('cylc', 'graphql'), query=query)
-    assert response.code == 200
+    get_response = await gql_query(
+        *('cylc', 'graphql'),
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        query=query,
+        method='GET'
+    )
+    assert get_response.code == 200
+
+    # test against same query different method
+    post_response = await gql_query(
+        *('cylc', 'graphql'),
+        query=query,
+        method='POST'
+    )
+    assert get_response.body == post_response.body
 
     # we should find the two dummy workflows in the response
-    body = json.loads(response.body)
+    body = json.loads(get_response.body)
     assert body['data'] == {
         'workflows': [
             {
@@ -190,7 +201,7 @@ async def test_query(gql_query, dummy_workflow):
     assert response_form.code == 200
     assert json.loads(response_form.body) == body
     # should be pretty
-    assert response_form.body != response.body
+    assert response_form.body != get_response.body
 
 
 async def test_batch_query(gql_query, dummy_workflow):

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -57,6 +57,64 @@ def gql_query(jp_fetch):
     return _fetch
 
 
+@pytest.fixture
+def gql_subscription(jp_ws_fetch):
+    """Open a GraphQL subscription.
+
+    E.G:
+
+    ws = await gql_subscription(
+        *('cylc', 'subscriptions'),
+        sub={
+            'id': '1',
+            'type': 'start',
+            'payload': {
+                'query': '''
+                    subscription {
+                      workflows {
+                        id
+                        status
+                      }
+                    }
+                '''
+            }
+        }
+    )
+    # Can loop on this
+    response = json.loads(await ws.read_message())
+    assert response == . . .
+
+    ws.close()
+    """
+
+    async def _fetch(*endpoint, sub=None, headers=None):
+        headers = headers or {}
+        headers = {
+            **headers,
+            'Content-Type': 'application/json',
+            'Sec-Websocket-Protocol': 'graphql-ws',
+        }
+        ws = await jp_ws_fetch(
+            *endpoint,
+            headers=headers,
+        )
+
+        # Using graphql-ws protocol, so send connection_init
+        await ws.write_message(
+            json.dumps({"type": "connection_init", "payload": {}})
+        )
+        ack = json.loads(await ws.read_message())
+        assert ack["type"] == "connection_ack"
+
+        # Start subscription
+        sub = sub or {}
+        await ws.write_message(json.dumps(sub))
+
+        return ws
+
+    return _fetch
+
+
 async def test_query(gql_query, dummy_workflow):
     """Test sending the most basic GraphQL query."""
     # configure two dummy workflows so we have something to look at
@@ -176,3 +234,53 @@ async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
         ),
     )
     assert response.code == 200
+
+
+async def test_graphql_subscription(gql_subscription, dummy_workflow):
+    """Test opening a GraphQL subscription and receive a message."""
+
+    # Start a workflow for subscription content.
+    await dummy_workflow('foo')
+
+    # Start subscription
+    sub_id = "1"
+    ws = await gql_subscription(
+        *('cylc', 'subscriptions'),
+        sub={
+            "id": sub_id,
+            "type": "start",
+            "payload": {
+                "query": """
+                    subscription {
+                      workflows {
+                        id
+                        status
+                      }
+                    }
+                """
+            }
+        }
+    )
+
+    # Receive the next message
+    response = json.loads(await ws.read_message())
+
+    assert response == {
+        'id': sub_id,
+        'type': 'data',
+        'payload': {
+            'data': {
+                'workflows': [
+                    {
+                        'id': '~me/foo',
+                        'status': 'stopped'
+                    }
+                ]
+            }
+        }
+    }
+
+    # Run the stop/cleanup code
+    await ws.write_message(json.dumps({"id": sub_id, "type": "stop"}))
+
+    ws.close()

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -248,6 +248,11 @@ async def test_batch_query(gql_query, dummy_workflow):
             *('cylc', 'graphql', 'batch'), body=json.dumps([]))
     assert 'Bad Request' in str(exc)
 
+    # Test a non-list "batch"
+    response = await gql_query(
+        *('cylc', 'graphql', 'batch'), body=json.dumps({}), raise_error=False)
+    assert response.reason == 'Bad Request'
+
 
 async def test_mutation(gql_query, dummy_workflow):
     """Test simple mutation scenarios."""

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -15,12 +15,14 @@
 
 import json
 from textwrap import dedent
+from time import time
 from urllib.parse import urlencode
 
 import pytest
 from tornado.httpclient import HTTPClientError
 
 from cylc.flow.id import Tokens
+from cylc.uiserver.data_store_mgr import DataStoreMgr, ALL_DELTAS
 
 
 @pytest.fixture
@@ -420,6 +422,151 @@ async def test_subscription(gql_subscription, dummy_workflow):
             }
         }
     }
+
+    # Run the stop/cleanup code
+    await ws.write_message(json.dumps({"id": sub_id, "type": "stop"}))
+
+    ws.close()
+
+
+async def test_subscription_deltas(
+    cylc_uis, gql_subscription, make_all_delta):
+    """Test deltas being processesed and recieved by a GraphQL subscription."""
+
+    data_store_mgr = cylc_uis.data_store_mgr
+
+    # Start subscription
+    sub_id = "1"
+    ws = await gql_subscription(
+        *('cylc', 'subscriptions'),
+        sub={
+            "id": sub_id,
+            "type": "start",
+            "payload": {
+                "query": """
+                    subscription {
+                      deltas (stripNull: true){
+                        id
+                        shutdown
+                        added {
+                          workflow {
+                            status
+                          }
+                          taskProxies {
+                            id
+                            state
+                          }
+                        }
+                        updated {
+                          workflow {
+                            status
+                          }
+                          taskProxies {
+                            id
+                            state
+                          }
+                        }
+                      }
+                    }
+                """
+            }
+        }
+    )
+
+    w_tokens = Tokens(user='user', workflow='this')
+    w_id = w_tokens.id
+
+    # Stop scanning messages
+    cylc_uis.workflows_mgr._stopping = True
+    # Register for data-store entry
+    await data_store_mgr.register_workflow(w_id=w_id, is_active=False)
+
+    # Receive first message
+    response = json.loads(await ws.read_message())
+    assert response == {
+        'id': sub_id,
+        'type': 'data',
+        'payload': {
+            'data': {
+                'deltas': {
+                    'id': w_id,
+                    'shutdown': False,
+                    'added': {
+                        'workflow': {'status': 'stopped'}
+                    },
+                    'updated': {}
+                }
+            }
+        }
+    }
+
+    # Create added delta
+    tp_id = w_tokens.duplicate(cycle='1', task='foo').id
+    all_added_delta = make_all_delta(w_id, 'added', tp_id, 'waiting', time())
+    all_added_delta.workflow.added.status = 'running'
+    all_added_delta.workflow.reloaded = True
+
+    # Process added delta, creating gql subscription delta as a result
+    data_store_mgr._update_workflow_data(ALL_DELTAS, all_added_delta, w_id)
+
+    # Receive next message
+    response = json.loads(await ws.read_message())
+    assert response == {
+        'id': sub_id,
+        'type': 'data',
+        'payload': {
+            'data': {
+                'deltas': {
+                    'id': w_id,
+                    'shutdown': False,
+                    'added': {
+                        'workflow': {'status': 'running'},
+                        'taskProxies': [
+                            {
+                                'id': tp_id,
+                                'state': 'waiting'
+                            }
+                        ]
+                    },
+                    'updated': {}
+                }
+            }
+        }
+    }
+
+    # Create update delta
+    all_updated_delta = make_all_delta(
+        w_id, 'updated', tp_id, 'running', time())
+    all_updated_delta.workflow.updated.status = 'stopping'
+    all_updated_delta.workflow.reloaded = False
+
+    # Process updated delta
+    data_store_mgr._update_workflow_data(ALL_DELTAS, all_updated_delta, w_id)
+
+    # Receive next message
+    response = json.loads(await ws.read_message())
+    assert response['payload']['data']['deltas']['updated'][
+        'workflow'
+    ]['status'] == 'stopping'
+    assert response['payload']['data']['deltas']['updated'][
+        'taskProxies'
+    ][0]['state'] == 'running'
+
+    # Shutdown delta
+    data_store_mgr._update_workflow_data(
+        'shutdown', 'this is the end'.encode('utf-8'), w_id)
+
+    # Receive shutdown message
+    response = json.loads(await ws.read_message())
+    assert response['payload']['data']['deltas']['shutdown']
+
+    # Start scanning messages again
+    cylc_uis.workflows_mgr._stopping = False
+    # Receive scan message
+    response = json.loads(await ws.read_message())
+    assert response['payload']['data']['deltas']['updated'][
+        'workflow'
+    ]['status'] == 'stopped'
 
     # Run the stop/cleanup code
     await ws.write_message(json.dumps({"id": sub_id, "type": "stop"}))

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -15,12 +15,14 @@
 
 import json
 from textwrap import dedent
+from time import time
 from urllib.parse import urlencode
 
 import pytest
 from tornado.httpclient import HTTPClientError
 
 from cylc.flow.id import Tokens
+from cylc.uiserver.data_store_mgr import DataStoreMgr, ALL_DELTAS
 
 
 @pytest.fixture
@@ -416,6 +418,151 @@ async def test_subscription(gql_subscription, dummy_workflow):
             }
         }
     }
+
+    # Run the stop/cleanup code
+    await ws.write_message(json.dumps({"id": sub_id, "type": "stop"}))
+
+    ws.close()
+
+
+async def test_subscription_deltas(
+    cylc_uis, gql_subscription, make_all_delta):
+    """Test deltas being processesed and recieved by a GraphQL subscription."""
+
+    data_store_mgr = cylc_uis.data_store_mgr
+
+    # Start subscription
+    sub_id = "1"
+    ws = await gql_subscription(
+        *('cylc', 'subscriptions'),
+        sub={
+            "id": sub_id,
+            "type": "start",
+            "payload": {
+                "query": """
+                    subscription {
+                      deltas (stripNull: true){
+                        id
+                        shutdown
+                        added {
+                          workflow {
+                            status
+                          }
+                          taskProxies {
+                            id
+                            state
+                          }
+                        }
+                        updated {
+                          workflow {
+                            status
+                          }
+                          taskProxies {
+                            id
+                            state
+                          }
+                        }
+                      }
+                    }
+                """
+            }
+        }
+    )
+
+    w_tokens = Tokens(user='user', workflow='this')
+    w_id = w_tokens.id
+
+    # Stop scanning messages
+    cylc_uis.workflows_mgr._stopping = True
+    # Register for data-store entry
+    await data_store_mgr.register_workflow(w_id=w_id, is_active=False)
+
+    # Receive first message
+    response = json.loads(await ws.read_message())
+    assert response == {
+        'id': sub_id,
+        'type': 'data',
+        'payload': {
+            'data': {
+                'deltas': {
+                    'id': w_id,
+                    'shutdown': False,
+                    'added': {
+                        'workflow': {'status': 'stopped'}
+                    },
+                    'updated': {}
+                }
+            }
+        }
+    }
+
+    # Create added delta
+    tp_id = w_tokens.duplicate(cycle='1', task='foo').id
+    all_added_delta = make_all_delta(w_id, 'added', tp_id, 'waiting', time())
+    all_added_delta.workflow.added.status = 'running'
+    all_added_delta.workflow.reloaded = True
+
+    # Process added delta, creating gql subscription delta as a result
+    data_store_mgr._update_workflow_data(ALL_DELTAS, all_added_delta, w_id)
+
+    # Receive next message
+    response = json.loads(await ws.read_message())
+    assert response == {
+        'id': sub_id,
+        'type': 'data',
+        'payload': {
+            'data': {
+                'deltas': {
+                    'id': w_id,
+                    'shutdown': False,
+                    'added': {
+                        'workflow': {'status': 'running'},
+                        'taskProxies': [
+                            {
+                                'id': tp_id,
+                                'state': 'waiting'
+                            }
+                        ]
+                    },
+                    'updated': {}
+                }
+            }
+        }
+    }
+
+    # Create update delta
+    all_updated_delta = make_all_delta(
+        w_id, 'updated', tp_id, 'running', time())
+    all_updated_delta.workflow.updated.status = 'stopping'
+    all_updated_delta.workflow.reloaded = False
+
+    # Process updated delta
+    data_store_mgr._update_workflow_data(ALL_DELTAS, all_updated_delta, w_id)
+
+    # Receive next message
+    response = json.loads(await ws.read_message())
+    assert response['payload']['data']['deltas']['updated'][
+        'workflow'
+    ]['status'] == 'stopping'
+    assert response['payload']['data']['deltas']['updated'][
+        'taskProxies'
+    ][0]['state'] == 'running'
+
+    # Shutdown delta
+    data_store_mgr._update_workflow_data(
+        'shutdown', 'this is the end'.encode('utf-8'), w_id)
+
+    # Receive shutdown message
+    response = json.loads(await ws.read_message())
+    assert response['payload']['data']['deltas']['shutdown']
+
+    # Start scanning messages again
+    cylc_uis.workflows_mgr._stopping = False
+    # Receive scan message
+    response = json.loads(await ws.read_message())
+    assert response['payload']['data']['deltas']['updated'][
+        'workflow'
+    ]['status'] == 'stopped'
 
     # Run the stop/cleanup code
     await ws.write_message(json.dumps({"id": sub_id, "type": "stop"}))

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -245,6 +245,44 @@ async def test_batch_query(gql_query, dummy_workflow):
     assert 'Bad Request' in str(exc)
 
 
+async def test_mutation(gql_query, dummy_workflow):
+    """Test simple mutation scenarios."""
+
+    # start a workflow
+    await dummy_workflow('foo')
+
+    # make a simple mutation
+    response = await gql_query(
+        *('cylc', 'graphql'),
+        query='''
+            mutation {
+                pause(workflows: ["*"]) {
+                    result
+                }
+            }
+        ''',
+    )
+    assert response.code == 200
+
+    # try a mutation with GET method
+    response = await gql_query(
+        *('cylc', 'graphql'),
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        query='''
+            mutation {
+                stop(workflows: ["*"]) {
+                    result
+                }
+            }
+        ''',
+        method='GET',
+        raise_error=False
+    )
+    # Should be rejected for incorrect method.
+    assert response.code == 405
+    assert response.reason == 'Method Not Allowed'
+
+
 async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
     """Ensure multi-mutation requests are properly forwarded.
 
@@ -255,7 +293,7 @@ async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
       query must be altered so it only contains the single mutation.
 
     """
-    # need at leat one workflow for the request to be forwarded
+    # need at least one workflow for the request to be forwarded
     await dummy_workflow('foo')
     await dummy_workflow('bar')
 

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -15,8 +15,10 @@
 
 import json
 from textwrap import dedent
+from urllib.parse import urlencode
 
 import pytest
+from tornado.httpclient import HTTPClientError
 
 from cylc.flow.id import Tokens
 
@@ -41,17 +43,20 @@ def gql_query(jp_fetch):
 
     """
 
-    async def _fetch(*endpoint, query=None, headers=None):
+    async def _fetch(*endpoint, query=None, headers=None, **kwargs):
         headers = headers or {}
         headers = {
+            'Content-Type': 'application/json',
             **headers,
-            'Content-Type': 'application/json'
         }
+        if not kwargs.get('method'):
+            kwargs['method'] = 'POST'
+        if 'body' not in kwargs:
+            kwargs['body'] = json.dumps({'query': query}, indent=4)
         return await jp_fetch(
             *endpoint,
-            method='POST',
             headers=headers,
-            body=json.dumps({'query': query}, indent=4),
+            **kwargs
         )
 
     return _fetch
@@ -87,16 +92,17 @@ def gql_subscription(jp_ws_fetch):
     ws.close()
     """
 
-    async def _fetch(*endpoint, sub=None, headers=None):
+    async def _fetch(*endpoint, sub=None, headers=None, **kwargs):
         headers = headers or {}
         headers = {
-            **headers,
             'Content-Type': 'application/json',
             'Sec-Websocket-Protocol': 'graphql-ws',
+            **headers,
         }
         ws = await jp_ws_fetch(
             *endpoint,
             headers=headers,
+            **kwargs
         )
 
         # Using graphql-ws protocol, so send connection_init
@@ -116,23 +122,22 @@ def gql_subscription(jp_ws_fetch):
 
 
 async def test_query(gql_query, dummy_workflow):
-    """Test sending the most basic GraphQL query."""
+    """Test sending the most basic GraphQL query in all it's forms."""
     # configure two dummy workflows so we have something to look at
     await dummy_workflow('foo')
     await dummy_workflow('bar')
 
-    # perform the request
-    response = await gql_query(
-        *('cylc', 'graphql'),
-        query='''
-            query {
-                workflows {
-                    id
-                    status
-                }
+    query = '''
+        query {
+            workflows {
+                id
+                status
             }
-        ''',
-    )
+        }
+    '''
+
+    # perform the request
+    response = await gql_query(*('cylc', 'graphql'), query=query)
     assert response.code == 200
 
     # we should find the two dummy workflows in the response
@@ -149,6 +154,76 @@ async def test_query(gql_query, dummy_workflow):
             },
         ]
     }
+
+    # Test a bad query
+    with pytest.raises(HTTPClientError) as exc:
+        await gql_query(*('cylc', 'graphql'), query='not a query')
+    assert 'Bad Request' in str(exc)
+
+    # Test 'application/graphql'
+    response_gql = await gql_query(
+        *('cylc', 'graphql'),
+        headers={'Content-Type': 'application/graphql'},
+        body=query
+    )
+    assert response_gql.code == 200
+    assert json.loads(response_gql.body) == body
+
+    # Test 'application/x-www-form-urlencoded'
+    response_form = await gql_query(
+        *('cylc', f'graphql'),
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        body=urlencode({'query': query, 'pretty': True}),
+    )
+    assert response_form.code == 200
+    assert json.loads(response_form.body) == body
+    # should be pretty
+    assert response_form.body != response.body
+
+
+async def test_batch_query(gql_query, dummy_workflow):
+    """Test sending a GraphQL batch query."""
+    # configure two dummy workflows so we have something to look at
+    await dummy_workflow('foo')
+    await dummy_workflow('bar')
+
+    query = '''
+        query fooFlow {workflows (ids: ["~me/foo"]) {...shared}}
+        query barFlow {workflows (ids: ["~me/bar"]) {...shared}}
+        fragment shared on Workflow { id status }
+    '''
+
+    # perform the request
+    response = await gql_query(
+        *('cylc', 'graphql', 'batch'),
+        body=json.dumps(
+            [{'id': 1, 'query': query, 'operationName': 'fooFlow'}]
+        )
+    )
+    assert response.code == 200
+
+    # we should find the two dummy workflows in the response
+    body = json.loads(response.body)
+    assert body == [
+        {
+            "id":1,
+            "data": {
+                "workflows": [
+                    {
+                        "id": "~me/foo",
+                        "status": "stopped"
+                    }
+                ]
+            },
+            "status":200
+        }
+    ]
+
+    # Test a empty batch
+    with pytest.raises(HTTPClientError) as exc:
+        await gql_query(
+            *('cylc', 'graphql', 'batch'), body=json.dumps([]))
+    assert 'Bad Request' in str(exc)
 
 
 async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
@@ -236,7 +311,7 @@ async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
     assert response.code == 200
 
 
-async def test_graphql_subscription(gql_subscription, dummy_workflow):
+async def test_subscription(gql_subscription, dummy_workflow):
     """Test opening a GraphQL subscription and receive a message."""
 
     # Start a workflow for subscription content.

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -157,8 +157,20 @@ async def test_query(gql_query, dummy_workflow):
 
     # Test a bad query
     with pytest.raises(HTTPClientError) as exc:
-        await gql_query(*('cylc', 'graphql'), query='not a query')
-    assert 'Bad Request' in str(exc)
+        await gql_query(*('cylc', 'graphql'), query='this is not a query')
+    assert r"Syntax Error: Unexpected Name 'this" in str(exc)
+
+    # Test bad graphql query
+    bad_query = '''
+        query {
+            workflows {
+                notAField
+            }
+        }
+    '''
+    result = await gql_query(
+        *('cylc', 'graphql'), query=bad_query, raise_error=False)
+    assert r"Cannot query field 'not" in result.reason
 
     # Test 'application/graphql'
     response_gql = await gql_query(
@@ -202,7 +214,7 @@ async def test_batch_query(gql_query, dummy_workflow):
     )
     assert response.code == 200
 
-    # we should find the two dummy workflows in the response
+    # we should find the 'fooFlow' query result in the response
     body = json.loads(response.body)
     assert body == [
         {

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -244,6 +244,11 @@ async def test_batch_query(gql_query, dummy_workflow):
             *('cylc', 'graphql', 'batch'), body=json.dumps([]))
     assert 'Bad Request' in str(exc)
 
+    # Test a non-list "batch"
+    response = await gql_query(
+        *('cylc', 'graphql', 'batch'), body=json.dumps({}), raise_error=False)
+    assert response.reason == 'Bad Request'
+
 
 async def test_mutation(gql_query, dummy_workflow):
     """Test simple mutation scenarios."""

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -57,6 +57,64 @@ def gql_query(jp_fetch):
     return _fetch
 
 
+@pytest.fixture
+def gql_subscription(jp_ws_fetch):
+    """Open a GraphQL subscription.
+
+    E.G:
+
+    ws = await gql_subscription(
+        *('cylc', 'subscriptions'),
+        sub={
+            'id': '1',
+            'type': 'start',
+            'payload': {
+                'query': '''
+                    subscription {
+                      workflows {
+                        id
+                        status
+                      }
+                    }
+                '''
+            }
+        }
+    )
+    # Can loop on this
+    response = json.loads(await ws.read_message())
+    assert response == . . .
+
+    ws.close()
+    """
+
+    async def _fetch(*endpoint, sub=None, headers=None):
+        headers = headers or {}
+        headers = {
+            **headers,
+            'Content-Type': 'application/json',
+            'Sec-Websocket-Protocol': 'graphql-ws',
+        }
+        ws = await jp_ws_fetch(
+            *endpoint,
+            headers=headers,
+        )
+
+        # Using graphql-ws protocol, so send connection_init
+        await ws.write_message(
+            json.dumps({"type": "connection_init", "payload": {}})
+        )
+        ack = json.loads(await ws.read_message())
+        assert ack["type"] == "connection_ack"
+
+        # Start subscription
+        sub = sub or {}
+        await ws.write_message(json.dumps(sub))
+
+        return ws
+
+    return _fetch
+
+
 async def test_query(gql_query, dummy_workflow):
     """Test sending the most basic GraphQL query."""
     # configure two dummy workflows so we have something to look at
@@ -176,3 +234,53 @@ async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
         ),
     )
     assert response.code == 200
+
+
+async def test_graphql_subscription(gql_subscription, dummy_workflow):
+    """Test opening a GraphQL subscription and receive a message."""
+
+    # Start a workflow for subscription content.
+    await dummy_workflow('foo')
+
+    # Start simple subscription
+    sub_id = "1"
+    ws = await gql_subscription(
+        *('cylc', 'subscriptions'),
+        sub={
+            "id": sub_id,
+            "type": "start",
+            "payload": {
+                "query": """
+                    subscription {
+                      workflows {
+                        id
+                        status
+                      }
+                    }
+                """
+            }
+        }
+    )
+
+    # Receive the next message
+    response = json.loads(await ws.read_message())
+
+    assert response == {
+        'id': sub_id,
+        'type': 'data',
+        'payload': {
+            'data': {
+                'workflows': [
+                    {
+                        'id': '~me/foo',
+                        'status': 'stopped'
+                    }
+                ]
+            }
+        }
+    }
+
+    # Run the stop/cleanup code
+    await ws.write_message(json.dumps({"id": sub_id, "type": "stop"}))
+
+    ws.close()

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -249,6 +249,44 @@ async def test_batch_query(gql_query, dummy_workflow):
     assert 'Bad Request' in str(exc)
 
 
+async def test_mutation(gql_query, dummy_workflow):
+    """Test simple mutation scenarios."""
+
+    # start a workflow
+    await dummy_workflow('foo')
+
+    # make a simple mutation
+    response = await gql_query(
+        *('cylc', 'graphql'),
+        query='''
+            mutation {
+                pause(workflows: ["*"]) {
+                    result
+                }
+            }
+        ''',
+    )
+    assert response.code == 200
+
+    # try a mutation with GET method
+    response = await gql_query(
+        *('cylc', 'graphql'),
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        query='''
+            mutation {
+                stop(workflows: ["*"]) {
+                    result
+                }
+            }
+        ''',
+        method='GET',
+        raise_error=False
+    )
+    # Should be rejected for incorrect method.
+    assert response.code == 405
+    assert response.reason == 'Method Not Allowed'
+
+
 async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
     """Ensure multi-mutation requests are properly forwarded.
 
@@ -259,7 +297,7 @@ async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
       query must be altered so it only contains the single mutation.
 
     """
-    # need at leat one workflow for the request to be forwarded
+    # need at least one workflow for the request to be forwarded
     await dummy_workflow('foo')
     await dummy_workflow('bar')
 

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -51,11 +51,16 @@ def gql_query(jp_fetch):
         }
         if not kwargs.get('method'):
             kwargs['method'] = 'POST'
+        params = {}
         if 'body' not in kwargs:
-            kwargs['body'] = json.dumps({'query': query}, indent=4)
+            if kwargs['method'] in ("POST", "PATCH", "PUT"):
+                kwargs['body'] = json.dumps({'query': query}, indent=4)
+            else:
+                params = {'query': query}
         return await jp_fetch(
             *endpoint,
             headers=headers,
+            params=params,
             **kwargs
         )
 
@@ -127,21 +132,23 @@ async def test_query(gql_query, dummy_workflow):
     await dummy_workflow('foo')
     await dummy_workflow('bar')
 
-    query = '''
-        query {
-            workflows {
-                id
-                status
-            }
-        }
-    '''
+    query = '''query {workflows {id status}}'''
 
     # perform the request
-    response = await gql_query(*('cylc', 'graphql'), query=query)
-    assert response.code == 200
+    get_response = await gql_query(
+        *('cylc', 'graphql'),
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        query=query,
+        method='GET'
+    )
+    assert get_response.code == 200
+
+    # test against same query different method
+    post_response = await gql_query(*('cylc', 'graphql'), query=query)
+    assert get_response.body == post_response.body
 
     # we should find the two dummy workflows in the response
-    body = json.loads(response.body)
+    body = json.loads(get_response.body)
     assert body['data'] == {
         'workflows': [
             {
@@ -190,7 +197,7 @@ async def test_query(gql_query, dummy_workflow):
     assert response_form.code == 200
     assert json.loads(response_form.body) == body
     # should be pretty
-    assert response_form.body != response.body
+    assert response_form.body != get_response.body
 
 
 async def test_batch_query(gql_query, dummy_workflow):

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -22,7 +22,7 @@ import pytest
 from tornado.httpclient import HTTPClientError
 
 from cylc.flow.id import Tokens
-from cylc.uiserver.data_store_mgr import DataStoreMgr, ALL_DELTAS
+from cylc.uiserver.data_store_mgr import ALL_DELTAS
 
 
 @pytest.fixture
@@ -196,7 +196,7 @@ async def test_query(gql_query, dummy_workflow):
 
     # Test 'application/x-www-form-urlencoded'
     response_form = await gql_query(
-        *('cylc', f'graphql'),
+        *('cylc', 'graphql'),
         headers={'Content-Type': 'application/x-www-form-urlencoded'},
         body=urlencode({'query': query, 'pretty': True}),
     )
@@ -231,7 +231,7 @@ async def test_batch_query(gql_query, dummy_workflow):
     body = json.loads(response.body)
     assert body == [
         {
-            "id":1,
+            "id": 1,
             "data": {
                 "workflows": [
                     {
@@ -240,7 +240,7 @@ async def test_batch_query(gql_query, dummy_workflow):
                     }
                 ]
             },
-            "status":200
+            "status": 200
         }
     ]
 
@@ -429,8 +429,7 @@ async def test_subscription(gql_subscription, dummy_workflow):
     ws.close()
 
 
-async def test_subscription_deltas(
-    cylc_uis, gql_subscription, make_all_delta):
+async def test_subscription_deltas(cylc_uis, gql_subscription, make_all_delta):
     """Test deltas being processesed and recieved by a GraphQL subscription."""
 
     data_store_mgr = cylc_uis.data_store_mgr

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -23,7 +23,7 @@ import pytest
 from tornado.httpclient import HTTPClientError
 
 from cylc.flow.id import Tokens
-from cylc.uiserver.data_store_mgr import DataStoreMgr, ALL_DELTAS
+from cylc.uiserver.data_store_mgr import ALL_DELTAS
 
 
 @pytest.fixture
@@ -197,7 +197,7 @@ async def test_query(gql_query, dummy_workflow):
 
     # Test 'application/x-www-form-urlencoded'
     response_form = await gql_query(
-        *('cylc', f'graphql'),
+        *('cylc', 'graphql'),
         headers={'Content-Type': 'application/x-www-form-urlencoded'},
         body=urlencode({'query': query, 'pretty': True}),
     )
@@ -232,7 +232,7 @@ async def test_batch_query(gql_query, dummy_workflow):
     body = json.loads(response.body)
     assert body == [
         {
-            "id":1,
+            "id": 1,
             "data": {
                 "workflows": [
                     {
@@ -241,7 +241,7 @@ async def test_batch_query(gql_query, dummy_workflow):
                     }
                 ]
             },
-            "status":200
+            "status": 200
         }
     ]
 
@@ -431,7 +431,8 @@ async def test_subscription(gql_subscription, dummy_workflow):
 
 
 async def test_subscription_deltas(
-    cylc_uis, gql_subscription, make_all_delta):
+    cylc_uis, gql_subscription, make_all_delta
+):
     """Test deltas being processesed and recieved by a GraphQL subscription."""
 
     data_store_mgr = cylc_uis.data_store_mgr

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -16,12 +16,14 @@
 
 import json
 from textwrap import dedent
+from time import time
 from urllib.parse import urlencode
 
 import pytest
 from tornado.httpclient import HTTPClientError
 
 from cylc.flow.id import Tokens
+from cylc.uiserver.data_store_mgr import DataStoreMgr, ALL_DELTAS
 
 
 @pytest.fixture
@@ -421,6 +423,151 @@ async def test_subscription(gql_subscription, dummy_workflow):
             }
         }
     }
+
+    # Run the stop/cleanup code
+    await ws.write_message(json.dumps({"id": sub_id, "type": "stop"}))
+
+    ws.close()
+
+
+async def test_subscription_deltas(
+    cylc_uis, gql_subscription, make_all_delta):
+    """Test deltas being processesed and recieved by a GraphQL subscription."""
+
+    data_store_mgr = cylc_uis.data_store_mgr
+
+    # Start subscription
+    sub_id = "1"
+    ws = await gql_subscription(
+        *('cylc', 'subscriptions'),
+        sub={
+            "id": sub_id,
+            "type": "start",
+            "payload": {
+                "query": """
+                    subscription {
+                      deltas (stripNull: true){
+                        id
+                        shutdown
+                        added {
+                          workflow {
+                            status
+                          }
+                          taskProxies {
+                            id
+                            state
+                          }
+                        }
+                        updated {
+                          workflow {
+                            status
+                          }
+                          taskProxies {
+                            id
+                            state
+                          }
+                        }
+                      }
+                    }
+                """
+            }
+        }
+    )
+
+    w_tokens = Tokens(user='user', workflow='this')
+    w_id = w_tokens.id
+
+    # Stop scanning messages
+    cylc_uis.workflows_mgr._stopping = True
+    # Register for data-store entry
+    await data_store_mgr.register_workflow(w_id=w_id, is_active=False)
+
+    # Receive first message
+    response = json.loads(await ws.read_message())
+    assert response == {
+        'id': sub_id,
+        'type': 'data',
+        'payload': {
+            'data': {
+                'deltas': {
+                    'id': w_id,
+                    'shutdown': False,
+                    'added': {
+                        'workflow': {'status': 'stopped'}
+                    },
+                    'updated': {}
+                }
+            }
+        }
+    }
+
+    # Create added delta
+    tp_id = w_tokens.duplicate(cycle='1', task='foo').id
+    all_added_delta = make_all_delta(w_id, 'added', tp_id, 'waiting', time())
+    all_added_delta.workflow.added.status = 'running'
+    all_added_delta.workflow.reloaded = True
+
+    # Process added delta, creating gql subscription delta as a result
+    data_store_mgr._update_workflow_data(ALL_DELTAS, all_added_delta, w_id)
+
+    # Receive next message
+    response = json.loads(await ws.read_message())
+    assert response == {
+        'id': sub_id,
+        'type': 'data',
+        'payload': {
+            'data': {
+                'deltas': {
+                    'id': w_id,
+                    'shutdown': False,
+                    'added': {
+                        'workflow': {'status': 'running'},
+                        'taskProxies': [
+                            {
+                                'id': tp_id,
+                                'state': 'waiting'
+                            }
+                        ]
+                    },
+                    'updated': {}
+                }
+            }
+        }
+    }
+
+    # Create update delta
+    all_updated_delta = make_all_delta(
+        w_id, 'updated', tp_id, 'running', time())
+    all_updated_delta.workflow.updated.status = 'stopping'
+    all_updated_delta.workflow.reloaded = False
+
+    # Process updated delta
+    data_store_mgr._update_workflow_data(ALL_DELTAS, all_updated_delta, w_id)
+
+    # Receive next message
+    response = json.loads(await ws.read_message())
+    assert response['payload']['data']['deltas']['updated'][
+        'workflow'
+    ]['status'] == 'stopping'
+    assert response['payload']['data']['deltas']['updated'][
+        'taskProxies'
+    ][0]['state'] == 'running'
+
+    # Shutdown delta
+    data_store_mgr._update_workflow_data(
+        'shutdown', 'this is the end'.encode('utf-8'), w_id)
+
+    # Receive shutdown message
+    response = json.loads(await ws.read_message())
+    assert response['payload']['data']['deltas']['shutdown']
+
+    # Start scanning messages again
+    cylc_uis.workflows_mgr._stopping = False
+    # Receive scan message
+    response = json.loads(await ws.read_message())
+    assert response['payload']['data']['deltas']['updated'][
+        'workflow'
+    ]['status'] == 'stopped'
 
     # Run the stop/cleanup code
     await ws.write_message(json.dumps({"id": sub_id, "type": "stop"}))

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -16,8 +16,10 @@
 
 import json
 from textwrap import dedent
+from urllib.parse import urlencode
 
 import pytest
+from tornado.httpclient import HTTPClientError
 
 from cylc.flow.id import Tokens
 
@@ -42,17 +44,20 @@ def gql_query(jp_fetch):
 
     """
 
-    async def _fetch(*endpoint, query=None, headers=None):
+    async def _fetch(*endpoint, query=None, headers=None, **kwargs):
         headers = headers or {}
         headers = {
+            'Content-Type': 'application/json',
             **headers,
-            'Content-Type': 'application/json'
         }
+        if not kwargs.get('method'):
+            kwargs['method'] = 'POST'
+        if 'body' not in kwargs:
+            kwargs['body'] = json.dumps({'query': query}, indent=4)
         return await jp_fetch(
             *endpoint,
-            method='POST',
             headers=headers,
-            body=json.dumps({'query': query}, indent=4),
+            **kwargs
         )
 
     return _fetch
@@ -88,16 +93,17 @@ def gql_subscription(jp_ws_fetch):
     ws.close()
     """
 
-    async def _fetch(*endpoint, sub=None, headers=None):
+    async def _fetch(*endpoint, sub=None, headers=None, **kwargs):
         headers = headers or {}
         headers = {
-            **headers,
             'Content-Type': 'application/json',
             'Sec-Websocket-Protocol': 'graphql-ws',
+            **headers,
         }
         ws = await jp_ws_fetch(
             *endpoint,
             headers=headers,
+            **kwargs
         )
 
         # Using graphql-ws protocol, so send connection_init
@@ -117,23 +123,22 @@ def gql_subscription(jp_ws_fetch):
 
 
 async def test_query(gql_query, dummy_workflow):
-    """Test sending the most basic GraphQL query."""
+    """Test sending the most basic GraphQL query in all it's forms."""
     # configure two dummy workflows so we have something to look at
     await dummy_workflow('foo')
     await dummy_workflow('bar')
 
-    # perform the request
-    response = await gql_query(
-        *('cylc', 'graphql'),
-        query='''
-            query {
-                workflows {
-                    id
-                    status
-                }
+    query = '''
+        query {
+            workflows {
+                id
+                status
             }
-        ''',
-    )
+        }
+    '''
+
+    # perform the request
+    response = await gql_query(*('cylc', 'graphql'), query=query)
     assert response.code == 200
 
     # we should find the two dummy workflows in the response
@@ -150,6 +155,76 @@ async def test_query(gql_query, dummy_workflow):
             },
         ]
     }
+
+    # Test a bad query
+    with pytest.raises(HTTPClientError) as exc:
+        await gql_query(*('cylc', 'graphql'), query='not a query')
+    assert 'Bad Request' in str(exc)
+
+    # Test 'application/graphql'
+    response_gql = await gql_query(
+        *('cylc', 'graphql'),
+        headers={'Content-Type': 'application/graphql'},
+        body=query
+    )
+    assert response_gql.code == 200
+    assert json.loads(response_gql.body) == body
+
+    # Test 'application/x-www-form-urlencoded'
+    response_form = await gql_query(
+        *('cylc', f'graphql'),
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        body=urlencode({'query': query, 'pretty': True}),
+    )
+    assert response_form.code == 200
+    assert json.loads(response_form.body) == body
+    # should be pretty
+    assert response_form.body != response.body
+
+
+async def test_batch_query(gql_query, dummy_workflow):
+    """Test sending a GraphQL batch query."""
+    # configure two dummy workflows so we have something to look at
+    await dummy_workflow('foo')
+    await dummy_workflow('bar')
+
+    query = '''
+        query fooFlow {workflows (ids: ["~me/foo"]) {...shared}}
+        query barFlow {workflows (ids: ["~me/bar"]) {...shared}}
+        fragment shared on Workflow { id status }
+    '''
+
+    # perform the request
+    response = await gql_query(
+        *('cylc', 'graphql', 'batch'),
+        body=json.dumps(
+            [{'id': 1, 'query': query, 'operationName': 'fooFlow'}]
+        )
+    )
+    assert response.code == 200
+
+    # we should find the two dummy workflows in the response
+    body = json.loads(response.body)
+    assert body == [
+        {
+            "id":1,
+            "data": {
+                "workflows": [
+                    {
+                        "id": "~me/foo",
+                        "status": "stopped"
+                    }
+                ]
+            },
+            "status":200
+        }
+    ]
+
+    # Test a empty batch
+    with pytest.raises(HTTPClientError) as exc:
+        await gql_query(
+            *('cylc', 'graphql', 'batch'), body=json.dumps([]))
+    assert 'Bad Request' in str(exc)
 
 
 async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
@@ -237,7 +312,7 @@ async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
     assert response.code == 200
 
 
-async def test_graphql_subscription(gql_subscription, dummy_workflow):
+async def test_subscription(gql_subscription, dummy_workflow):
     """Test opening a GraphQL subscription and receive a message."""
 
     # Start a workflow for subscription content.

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -58,6 +58,64 @@ def gql_query(jp_fetch):
     return _fetch
 
 
+@pytest.fixture
+def gql_subscription(jp_ws_fetch):
+    """Open a GraphQL subscription.
+
+    E.G:
+
+    ws = await gql_subscription(
+        *('cylc', 'subscriptions'),
+        sub={
+            'id': '1',
+            'type': 'start',
+            'payload': {
+                'query': '''
+                    subscription {
+                      workflows {
+                        id
+                        status
+                      }
+                    }
+                '''
+            }
+        }
+    )
+    # Can loop on this
+    response = json.loads(await ws.read_message())
+    assert response == . . .
+
+    ws.close()
+    """
+
+    async def _fetch(*endpoint, sub=None, headers=None):
+        headers = headers or {}
+        headers = {
+            **headers,
+            'Content-Type': 'application/json',
+            'Sec-Websocket-Protocol': 'graphql-ws',
+        }
+        ws = await jp_ws_fetch(
+            *endpoint,
+            headers=headers,
+        )
+
+        # Using graphql-ws protocol, so send connection_init
+        await ws.write_message(
+            json.dumps({"type": "connection_init", "payload": {}})
+        )
+        ack = json.loads(await ws.read_message())
+        assert ack["type"] == "connection_ack"
+
+        # Start subscription
+        sub = sub or {}
+        await ws.write_message(json.dumps(sub))
+
+        return ws
+
+    return _fetch
+
+
 async def test_query(gql_query, dummy_workflow):
     """Test sending the most basic GraphQL query."""
     # configure two dummy workflows so we have something to look at
@@ -177,3 +235,53 @@ async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
         ),
     )
     assert response.code == 200
+
+
+async def test_graphql_subscription(gql_subscription, dummy_workflow):
+    """Test opening a GraphQL subscription and receive a message."""
+
+    # Start a workflow for subscription content.
+    await dummy_workflow('foo')
+
+    # Start simple subscription
+    sub_id = "1"
+    ws = await gql_subscription(
+        *('cylc', 'subscriptions'),
+        sub={
+            "id": sub_id,
+            "type": "start",
+            "payload": {
+                "query": """
+                    subscription {
+                      workflows {
+                        id
+                        status
+                      }
+                    }
+                """
+            }
+        }
+    )
+
+    # Receive the next message
+    response = json.loads(await ws.read_message())
+
+    assert response == {
+        'id': sub_id,
+        'type': 'data',
+        'payload': {
+            'data': {
+                'workflows': [
+                    {
+                        'id': '~me/foo',
+                        'status': 'stopped'
+                    }
+                ]
+            }
+        }
+    }
+
+    # Run the stop/cleanup code
+    await ws.write_message(json.dumps({"id": sub_id, "type": "stop"}))
+
+    ws.close()

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -158,8 +158,20 @@ async def test_query(gql_query, dummy_workflow):
 
     # Test a bad query
     with pytest.raises(HTTPClientError) as exc:
-        await gql_query(*('cylc', 'graphql'), query='not a query')
-    assert 'Bad Request' in str(exc)
+        await gql_query(*('cylc', 'graphql'), query='this is not a query')
+    assert r"Syntax Error: Unexpected Name 'this" in str(exc)
+
+    # Test bad graphql query
+    bad_query = '''
+        query {
+            workflows {
+                notAField
+            }
+        }
+    '''
+    result = await gql_query(
+        *('cylc', 'graphql'), query=bad_query, raise_error=False)
+    assert r"Cannot query field 'not" in result.reason
 
     # Test 'application/graphql'
     response_gql = await gql_query(
@@ -203,7 +215,7 @@ async def test_batch_query(gql_query, dummy_workflow):
     )
     assert response.code == 200
 
-    # we should find the two dummy workflows in the response
+    # we should find the 'fooFlow' query result in the response
     body = json.loads(response.body)
     assert body == [
         {

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -250,6 +250,44 @@ async def test_batch_query(gql_query, dummy_workflow):
     assert 'Bad Request' in str(exc)
 
 
+async def test_mutation(gql_query, dummy_workflow):
+    """Test simple mutation scenarios."""
+
+    # start a workflow
+    await dummy_workflow('foo')
+
+    # make a simple mutation
+    response = await gql_query(
+        *('cylc', 'graphql'),
+        query='''
+            mutation {
+                pause(workflows: ["*"]) {
+                    result
+                }
+            }
+        ''',
+    )
+    assert response.code == 200
+
+    # try a mutation with GET method
+    response = await gql_query(
+        *('cylc', 'graphql'),
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        query='''
+            mutation {
+                stop(workflows: ["*"]) {
+                    result
+                }
+            }
+        ''',
+        method='GET',
+        raise_error=False
+    )
+    # Should be rejected for incorrect method.
+    assert response.code == 405
+    assert response.reason == 'Method Not Allowed'
+
+
 async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
     """Ensure multi-mutation requests are properly forwarded.
 
@@ -260,7 +298,7 @@ async def test_multi(gql_query, monkeypatch, cylc_uis, dummy_workflow):
       query must be altered so it only contains the single mutation.
 
     """
-    # need at leat one workflow for the request to be forwarded
+    # need at least one workflow for the request to be forwarded
     await dummy_workflow('foo')
     await dummy_workflow('bar')
 

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -249,6 +249,11 @@ async def test_batch_query(gql_query, dummy_workflow):
             *('cylc', 'graphql', 'batch'), body=json.dumps([]))
     assert 'Bad Request' in str(exc)
 
+    # Test a non-list "batch"
+    response = await gql_query(
+        *('cylc', 'graphql', 'batch'), body=json.dumps({}), raise_error=False)
+    assert response.reason == 'Bad Request'
+
 
 async def test_mutation(gql_query, dummy_workflow):
     """Test simple mutation scenarios."""

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -52,11 +52,16 @@ def gql_query(jp_fetch):
         }
         if not kwargs.get('method'):
             kwargs['method'] = 'POST'
+        params = {}
         if 'body' not in kwargs:
-            kwargs['body'] = json.dumps({'query': query}, indent=4)
+            if kwargs['method'] in ("POST", "PATCH", "PUT"):
+                kwargs['body'] = json.dumps({'query': query}, indent=4)
+            else:
+                params = {'query': query}
         return await jp_fetch(
             *endpoint,
             headers=headers,
+            params=params,
             **kwargs
         )
 
@@ -128,21 +133,27 @@ async def test_query(gql_query, dummy_workflow):
     await dummy_workflow('foo')
     await dummy_workflow('bar')
 
-    query = '''
-        query {
-            workflows {
-                id
-                status
-            }
-        }
-    '''
+    query = '''query {workflows {id status}}'''
 
     # perform the request
-    response = await gql_query(*('cylc', 'graphql'), query=query)
-    assert response.code == 200
+    get_response = await gql_query(
+        *('cylc', 'graphql'),
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        query=query,
+        method='GET'
+    )
+    assert get_response.code == 200
+
+    # test against same query different method
+    post_response = await gql_query(
+        *('cylc', 'graphql'),
+        query=query,
+        method='POST'
+    )
+    assert get_response.body == post_response.body
 
     # we should find the two dummy workflows in the response
-    body = json.loads(response.body)
+    body = json.loads(get_response.body)
     assert body['data'] == {
         'workflows': [
             {
@@ -191,7 +202,7 @@ async def test_query(gql_query, dummy_workflow):
     assert response_form.code == 200
     assert json.loads(response_form.body) == body
     # should be pretty
-    assert response_form.body != response.body
+    assert response_form.body != get_response.body
 
 
 async def test_batch_query(gql_query, dummy_workflow):

--- a/cylc/uiserver/tests/test_handlers.py
+++ b/cylc/uiserver/tests/test_handlers.py
@@ -20,16 +20,272 @@ from unittest import mock
 from unittest.mock import MagicMock
 import pytest
 
+from graphql import ExecutionResult, GraphQLError
+from graphql.execution.middleware import MiddlewareManager
 from tornado.httputil import HTTPServerRequest
-from tornado.testing import AsyncHTTPTestCase, get_async_test_timeout
+from tornado.testing import AsyncHTTPTestCase, get_async_test_timeout, gen_test
 from tornado.web import Application
+from tornado.web import HTTPError
 
+from cylc.flow.network.graphql import (
+    CylcExecutionContext, IgnoreFieldMiddleware
+)
+from cylc.uiserver.authorise import AuthorizationMiddleware
+from cylc.uiserver.graphql.tornado import TornadoGraphQLHandler, ExecutionError
 from cylc.uiserver.graphql.tornado_ws import GRAPHQL_WS
-from cylc.uiserver.handlers import SubscriptionHandler
+from cylc.uiserver.handlers import (
+    SubscriptionHandler,
+    UIServerGraphQLHandler,
+)
+from cylc.uiserver.schema import schema
 
 
 class MyApplication(Application):
     ...
+
+class GraphQLHandlersTest(AsyncHTTPTestCase):
+    """Test for TornadoGraphQLHandler/UIServerGraphQLHandler"""
+
+    def get_app(self, handler_class=UIServerGraphQLHandler) -> Application:
+        return MyApplication(
+            handlers=[
+                (
+                    'graphql',
+                    handler_class,
+                    {
+                        'schema': schema,
+                        'middleware': [
+                            AuthorizationMiddleware,
+                            IgnoreFieldMiddleware
+                        ],
+                        'execution_context_class': CylcExecutionContext,
+                    }
+                ),
+            ]
+        )
+
+    def _create_handler(
+        self,
+        handler_class=UIServerGraphQLHandler,
+        r_kwargs={},
+        h_kwargs={},
+        logged_in=True,
+    ):
+        app = self.get_app(handler_class)
+        r_params = {
+            'uri': '/graphql',
+            'method': 'GET',
+            **r_kwargs,
+        }
+        request = HTTPServerRequest(**r_params)
+        request.connection = MagicMock()
+        h_params = {
+            'middleware': [
+                AuthorizationMiddleware,
+                IgnoreFieldMiddleware
+            ],
+            'execution_context_class': CylcExecutionContext,
+            **h_kwargs,
+        }
+        handler = handler_class(
+            application=app,
+            request=request,
+            schema=schema,
+            **h_params,
+        )
+
+        if logged_in:
+            handler.get
+            _current_user = lambda: {'name': getuser()}
+        else:
+            handler.current_user = None
+        return handler
+
+    def test_setup(self):
+        """Test setup, attributes, and properties."""
+        mid_manager = MiddlewareManager()
+        handler = self._create_handler(
+            handler_class=TornadoGraphQLHandler,
+            h_kwargs={'middleware': mid_manager}
+        )
+        assert handler.middleware == mid_manager
+
+        handler = self._create_handler(
+            handler_class=TornadoGraphQLHandler,
+            h_kwargs={'middleware': None},
+        )
+        assert not handler.middleware
+        assert handler.get_context().method == "GET"
+
+    def test_parse_body(self):
+        """Test parse_body for query doc."""
+        handler = self._create_handler(
+            r_kwargs={
+                'headers': {'Content-Type': "application/json"},
+                'method': "POST",
+            }
+        )
+        assert not handler.get_parsed_body()
+
+        class FakeRequest:
+            headers = {'Content-Type': "Application/json"}
+            errors = None
+
+        # test request without body.
+        orig_request = handler.request
+        handler.request = FakeRequest()
+        with pytest.raises(ExecutionError) as exc:
+            handler.parse_body()
+        assert 'FakeRequest' in str(exc)
+
+        ex_error = ExecutionError(123, None)
+        assert ex_error.status_code == 123
+        assert ex_error.message == ''
+
+        # test invalid JSON string
+        handler.request = orig_request
+        handler.request.body = '%&^ds:ea43#'
+        with pytest.raises(HTTPError) as exc:
+            handler.parse_body()
+        assert 'invalid JSON' in str(exc.value)
+
+        # test invalid query
+        handler.request.body = json.dumps([{'this': "that"}])
+        with pytest.raises(HTTPError) as exc:
+            handler.parse_body()
+        assert 'not a valid JSON query.' in str(exc.value)
+
+    @gen_test
+    @pytest.mark.usefixtures("mock_authentication_yossarian")
+    async def test_get_response(self):
+        """Test get_response."""
+        r_kwargs = {
+            'headers': {'Content-Type': "application/json"},
+            'method': "POST",
+            'body': json.dumps({'query': "curry { massaman }"})
+        }
+        h_kwargs = {
+            'execution_context_class': None,
+            'parsed_body': 'cake',
+        }
+        handler = self._create_handler(r_kwargs=r_kwargs, h_kwargs=h_kwargs)
+        assert handler.parsed_body == 'cake'
+
+        # Test bad query
+        data = handler.parse_body()
+        result, status_code = await handler.get_response(data)
+        assert status_code == 400
+        assert 'curry' in result
+
+        # Test good query
+        doc = {
+            'query': '''
+                query stoke ($wFlows: [ID]){
+                  workflows (ids: $wFlows) { id status }
+                }
+            ''',
+            'variables': {'wFlows': ["*/run1"]},
+            'operationName': 'stoke',
+        }
+
+        handler.request.body = json.dumps(doc)
+        data = handler.parse_body()
+        handler.graphql_params = {}
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        # caught by auth
+        assert 'Forbidden' in str(result)
+        assert handler.graphql_params[2] == 'stoke'
+        # test the graphql params bypass
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        assert 'Forbidden' in str(result)
+
+        # test bad schema
+        orig_type = handler.schema.graphql_schema.query_type
+        handler.schema.graphql_schema.query_type = None
+        result, status_code = await handler.get_response(data)
+        assert 'not configured to execute query' in result
+        assert status_code == 400
+        handler.schema.graphql_schema.query_type = orig_type
+        handler.schema.graphql_schema._validation_errors = ['nasty one']
+        result, status_code = await handler.get_response(data)
+        assert 'nasty one' in result
+        assert status_code == 400
+        handler.schema.graphql_schema._validation_errors = []
+
+        # by-pass auth middleware
+        h_kwargs['middleware'] = []
+        doc['operationName'] = 'null'
+        handler = self._create_handler(r_kwargs=r_kwargs, h_kwargs=h_kwargs)
+        handler.request.body = json.dumps(doc)
+        data = handler.parse_body()
+        handler.graphql_params = {}
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        # because no resolvers set:
+        assert "object has no attribute 'get_workflows'" in str(result)
+        # operationName should be None
+        assert handler.graphql_params[2] is None
+
+        # test invalid variable
+        doc['variables'] = 'Nope'
+        handler.request.body = json.dumps(doc)
+        data = handler.parse_body()
+        handler.graphql_params = {}
+        with pytest.raises(HTTPError) as exc:
+            await handler.get_response(data)
+        assert 'Variables are invalid JSON' in str(exc.value)
+
+        doc['variables'] = {'wFlows': ["*/run1"]},
+        doc['operationName'] = 'stoke'
+        handler.request.body = json.dumps(doc)
+        data = handler.parse_body()
+        handler.graphql_params = {}
+
+        # test execution error
+        async def exec_error(schema, doc, **kwargs):
+            raise ExecutionError(400, ['problems'])
+        orig_exec = handler.execute
+        handler.execute = exec_error
+        result, status_code = await handler.get_response(data)
+        assert status_code == 400
+        handler.execute = orig_exec
+
+        # replicate the None result
+        async def exe_gql_req(data, query, variables, operation_name):
+            return None
+        handler.execute_graphql_request = exe_gql_req
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        assert result is None
+
+        # test an execution result with get method (i.e. other api link)
+        async def exe_gql_req2(data, query, variables, operation_name):
+            class FakeResult:
+                def get(self):
+                    return ExecutionResult(data='other-api-response')
+            return FakeResult()
+        handler.execute_graphql_request = exe_gql_req2
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        assert 'other-api-response' in result
+
+        # test an execution result with errors
+        async def exe_gql_req3(data, query, variables, operation_name):
+            return ExecutionResult(
+                errors = [
+                    GraphQLError('GQL error'),
+                    ExecutionError(400, ['Some Exc error']),
+                    Exception('random other error')
+                ]
+            )
+        handler.execute_graphql_request = exe_gql_req3
+        result, status_code = await handler.get_response(data)
+        assert status_code == 400
+        assert 'GQL error' in result
+        assert 'Some Exc error' in result
+        assert 'random other error' in result
 
 
 class SubscriptionHandlerTest(AsyncHTTPTestCase):

--- a/cylc/uiserver/tests/test_handlers.py
+++ b/cylc/uiserver/tests/test_handlers.py
@@ -19,16 +19,276 @@ import json
 from unittest.mock import MagicMock
 import pytest
 
+from graphql import ExecutionResult, GraphQLError
+from graphql.execution.middleware import MiddlewareManager
 from tornado.httputil import HTTPServerRequest
-from tornado.testing import AsyncHTTPTestCase, get_async_test_timeout
+from tornado.testing import AsyncHTTPTestCase, get_async_test_timeout, gen_test
 from tornado.web import Application
+from tornado.web import HTTPError
 
+from cylc.flow.network.graphql import (
+    CylcExecutionContext, IgnoreFieldMiddleware
+)
+from cylc.uiserver.authorise import AuthorizationMiddleware
+from cylc.uiserver.graphql.tornado import TornadoGraphQLHandler, ExecutionError
 from cylc.uiserver.graphql.tornado_ws import GRAPHQL_WS
-from cylc.uiserver.handlers import SubscriptionHandler
+from cylc.uiserver.handlers import (
+    SubscriptionHandler,
+    UIServerGraphQLHandler,
+)
+from cylc.uiserver.schema import schema
 
 
 class MyApplication(Application):
     ...
+
+class GraphQLHandlersTest(AsyncHTTPTestCase):
+    """Test for TornadoGraphQLHandler/UIServerGraphQLHandler"""
+
+    def get_app(self, handler_class=UIServerGraphQLHandler) -> Application:
+        return MyApplication(
+            handlers=[
+                (
+                    'graphql',
+                    handler_class,
+                    {
+                        'schema': schema,
+                        'middleware': [
+                            AuthorizationMiddleware,
+                            IgnoreFieldMiddleware
+                        ],
+                        'execution_context_class': CylcExecutionContext,
+                    }
+                ),
+            ]
+        )
+
+    def _create_handler(
+        self,
+        handler_class=UIServerGraphQLHandler,
+        r_kwargs=None,
+        h_kwargs=None,
+        logged_in=True,
+    ):
+        if r_kwargs is None:
+            r_kwargs = {}
+        if h_kwargs is None:
+            h_kwargs = {}
+        app = self.get_app(handler_class)
+        r_params = {
+            'uri': '/graphql',
+            'method': 'GET',
+            **r_kwargs,
+        }
+        request = HTTPServerRequest(**r_params)
+        request.connection = MagicMock()
+        h_params = {
+            'middleware': [
+                AuthorizationMiddleware,
+                IgnoreFieldMiddleware
+            ],
+            'execution_context_class': CylcExecutionContext,
+            **h_kwargs,
+        }
+        handler = handler_class(
+            application=app,
+            request=request,
+            schema=schema,
+            **h_params,
+        )
+
+        if logged_in:
+            handler.get
+            _current_user = lambda: {'name': getuser()}
+        else:
+            handler.current_user = None
+        return handler
+
+    def test_setup(self):
+        """Test setup, attributes, and properties."""
+        mid_manager = MiddlewareManager()
+        handler = self._create_handler(
+            handler_class=TornadoGraphQLHandler,
+            h_kwargs={'middleware': mid_manager}
+        )
+        assert handler.middleware == mid_manager
+
+        handler = self._create_handler(
+            handler_class=TornadoGraphQLHandler,
+            h_kwargs={'middleware': None},
+        )
+        assert not handler.middleware
+        assert handler.get_context().method == "GET"
+
+    def test_parse_body(self):
+        """Test parse_body for query doc."""
+        handler = self._create_handler(
+            r_kwargs={
+                'headers': {'Content-Type': "application/json"},
+                'method': "POST",
+            }
+        )
+        assert not handler.get_parsed_body()
+
+        class FakeRequest:
+            headers = {'Content-Type': "Application/json"}
+            errors = None
+
+        # test request without body.
+        orig_request = handler.request
+        handler.request = FakeRequest()
+        with pytest.raises(ExecutionError) as exc:
+            handler.parse_body()
+        assert 'FakeRequest' in str(exc)
+
+        ex_error = ExecutionError(123, None)
+        assert ex_error.status_code == 123
+        assert ex_error.message == ''
+
+        # test invalid JSON string
+        handler.request = orig_request
+        handler.request.body = '%&^ds:ea43#'
+        with pytest.raises(HTTPError) as exc:
+            handler.parse_body()
+        assert 'invalid JSON' in str(exc.value)
+
+        # test invalid query
+        handler.request.body = json.dumps([{'this': "that"}])
+        with pytest.raises(HTTPError) as exc:
+            handler.parse_body()
+        assert 'not a valid JSON query.' in str(exc.value)
+
+    @gen_test
+    @pytest.mark.usefixtures("mock_authentication_yossarian")
+    async def test_get_response(self):
+        """Test get_response."""
+        r_kwargs = {
+            'headers': {'Content-Type': "application/json"},
+            'method': "POST",
+            'body': json.dumps({'query': "curry { massaman }"})
+        }
+        h_kwargs = {
+            'execution_context_class': None,
+            'parsed_body': 'cake',
+        }
+        handler = self._create_handler(r_kwargs=r_kwargs, h_kwargs=h_kwargs)
+        assert handler.parsed_body == 'cake'
+
+        # Test bad query
+        data = handler.parse_body()
+        result, status_code = await handler.get_response(data)
+        assert status_code == 400
+        assert 'curry' in result
+
+        # Test good query
+        doc = {
+            'query': '''
+                query stoke ($wFlows: [ID]){
+                  workflows (ids: $wFlows) { id status }
+                }
+            ''',
+            'variables': {'wFlows': ["*/run1"]},
+            'operationName': 'stoke',
+        }
+
+        handler.request.body = json.dumps(doc)
+        data = handler.parse_body()
+        handler.graphql_params = {}
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        # caught by auth
+        assert 'Forbidden' in str(result)
+        assert handler.graphql_params[2] == 'stoke'
+        # test the graphql params bypass
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        assert 'Forbidden' in str(result)
+
+        # test bad schema
+        orig_type = handler.schema.graphql_schema.query_type
+        handler.schema.graphql_schema.query_type = None
+        result, status_code = await handler.get_response(data)
+        assert 'not configured to execute query' in result
+        assert status_code == 400
+        handler.schema.graphql_schema.query_type = orig_type
+        handler.schema.graphql_schema._validation_errors = ['nasty one']
+        result, status_code = await handler.get_response(data)
+        assert 'nasty one' in result
+        assert status_code == 400
+        handler.schema.graphql_schema._validation_errors = []
+
+        # by-pass auth middleware
+        h_kwargs['middleware'] = []
+        doc['operationName'] = 'null'
+        handler = self._create_handler(r_kwargs=r_kwargs, h_kwargs=h_kwargs)
+        handler.request.body = json.dumps(doc)
+        data = handler.parse_body()
+        handler.graphql_params = {}
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        # because no resolvers set:
+        assert "object has no attribute 'get_workflows'" in str(result)
+        # operationName should be None
+        assert handler.graphql_params[2] is None
+
+        # test invalid variable
+        doc['variables'] = 'Nope'
+        handler.request.body = json.dumps(doc)
+        data = handler.parse_body()
+        handler.graphql_params = {}
+        with pytest.raises(HTTPError) as exc:
+            await handler.get_response(data)
+        assert 'Variables are invalid JSON' in str(exc.value)
+
+        doc['variables'] = {'wFlows': ["*/run1"]},
+        doc['operationName'] = 'stoke'
+        handler.request.body = json.dumps(doc)
+        data = handler.parse_body()
+        handler.graphql_params = {}
+
+        # test execution error
+        async def exec_error(schema, doc, **kwargs):
+            raise ExecutionError(400, ['problems'])
+        orig_exec = handler.execute
+        handler.execute = exec_error
+        result, status_code = await handler.get_response(data)
+        assert status_code == 400
+        handler.execute = orig_exec
+
+        # replicate the None result
+        async def exe_gql_req(data, query, variables, operation_name):
+            return None
+        handler.execute_graphql_request = exe_gql_req
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        assert result is None
+
+        # test an execution result with get method (i.e. other api link)
+        async def exe_gql_req2(data, query, variables, operation_name):
+            class FakeResult:
+                def get(self):
+                    return ExecutionResult(data='other-api-response')
+            return FakeResult()
+        handler.execute_graphql_request = exe_gql_req2
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        assert 'other-api-response' in result
+
+        # test an execution result with errors
+        async def exe_gql_req3(data, query, variables, operation_name):
+            return ExecutionResult(
+                errors = [
+                    GraphQLError('GQL error'),
+                    ExecutionError(400, ['Some Exc error']),
+                    Exception('random other error')
+                ]
+            )
+        handler.execute_graphql_request = exe_gql_req3
+        result, status_code = await handler.get_response(data)
+        assert status_code == 400
+        assert 'GQL error' in result
+        assert 'Some Exc error' in result
+        assert 'random other error' in result
 
 
 class SubscriptionHandlerTest(AsyncHTTPTestCase):

--- a/cylc/uiserver/tests/test_handlers.py
+++ b/cylc/uiserver/tests/test_handlers.py
@@ -98,8 +98,7 @@ class GraphQLHandlersTest(AsyncHTTPTestCase):
         )
 
         if logged_in:
-            handler.get
-            _current_user = lambda: {'name': getuser()}
+            handler.get_current_user = lambda: {'name': getuser()}
         else:
             handler.current_user = None
         return handler

--- a/cylc/uiserver/tests/test_handlers.py
+++ b/cylc/uiserver/tests/test_handlers.py
@@ -42,6 +42,7 @@ from cylc.uiserver.schema import schema
 class MyApplication(Application):
     ...
 
+
 class GraphQLHandlersTest(AsyncHTTPTestCase):
     """Test for TornadoGraphQLHandler/UIServerGraphQLHandler"""
 
@@ -276,7 +277,7 @@ class GraphQLHandlersTest(AsyncHTTPTestCase):
         # test an execution result with errors
         async def exe_gql_req3(data, query, variables, operation_name):
             return ExecutionResult(
-                errors = [
+                errors=[
                     GraphQLError('GQL error'),
                     ExecutionError(400, ['Some Exc error']),
                     Exception('random other error')

--- a/cylc/uiserver/tests/test_handlers.py
+++ b/cylc/uiserver/tests/test_handlers.py
@@ -43,6 +43,7 @@ from cylc.uiserver.schema import schema
 class MyApplication(Application):
     ...
 
+
 class GraphQLHandlersTest(AsyncHTTPTestCase):
     """Test for TornadoGraphQLHandler/UIServerGraphQLHandler"""
 
@@ -99,8 +100,9 @@ class GraphQLHandlersTest(AsyncHTTPTestCase):
         )
 
         if logged_in:
-            handler.get
-            _current_user = lambda: {'name': getuser()}
+            def _current_user():
+                return {'name': getuser()}
+            handler.get_current_user = _current_user
         else:
             handler.current_user = None
         return handler
@@ -278,7 +280,7 @@ class GraphQLHandlersTest(AsyncHTTPTestCase):
         # test an execution result with errors
         async def exe_gql_req3(data, query, variables, operation_name):
             return ExecutionResult(
-                errors = [
+                errors=[
                     GraphQLError('GQL error'),
                     ExecutionError(400, ['Some Exc error']),
                     Exception('random other error')

--- a/cylc/uiserver/tests/test_handlers.py
+++ b/cylc/uiserver/tests/test_handlers.py
@@ -20,16 +20,276 @@ import json
 from unittest.mock import MagicMock
 import pytest
 
+from graphql import ExecutionResult, GraphQLError
+from graphql.execution.middleware import MiddlewareManager
 from tornado.httputil import HTTPServerRequest
-from tornado.testing import AsyncHTTPTestCase, get_async_test_timeout
+from tornado.testing import AsyncHTTPTestCase, get_async_test_timeout, gen_test
 from tornado.web import Application
+from tornado.web import HTTPError
 
+from cylc.flow.network.graphql import (
+    CylcExecutionContext, IgnoreFieldMiddleware
+)
+from cylc.uiserver.authorise import AuthorizationMiddleware
+from cylc.uiserver.graphql.tornado import TornadoGraphQLHandler, ExecutionError
 from cylc.uiserver.graphql.tornado_ws import GRAPHQL_WS
-from cylc.uiserver.handlers import SubscriptionHandler
+from cylc.uiserver.handlers import (
+    SubscriptionHandler,
+    UIServerGraphQLHandler,
+)
+from cylc.uiserver.schema import schema
 
 
 class MyApplication(Application):
     ...
+
+class GraphQLHandlersTest(AsyncHTTPTestCase):
+    """Test for TornadoGraphQLHandler/UIServerGraphQLHandler"""
+
+    def get_app(self, handler_class=UIServerGraphQLHandler) -> Application:
+        return MyApplication(
+            handlers=[
+                (
+                    'graphql',
+                    handler_class,
+                    {
+                        'schema': schema,
+                        'middleware': [
+                            AuthorizationMiddleware,
+                            IgnoreFieldMiddleware
+                        ],
+                        'execution_context_class': CylcExecutionContext,
+                    }
+                ),
+            ]
+        )
+
+    def _create_handler(
+        self,
+        handler_class=UIServerGraphQLHandler,
+        r_kwargs=None,
+        h_kwargs=None,
+        logged_in=True,
+    ):
+        if r_kwargs is None:
+            r_kwargs = {}
+        if h_kwargs is None:
+            h_kwargs = {}
+        app = self.get_app(handler_class)
+        r_params = {
+            'uri': '/graphql',
+            'method': 'GET',
+            **r_kwargs,
+        }
+        request = HTTPServerRequest(**r_params)
+        request.connection = MagicMock()
+        h_params = {
+            'middleware': [
+                AuthorizationMiddleware,
+                IgnoreFieldMiddleware
+            ],
+            'execution_context_class': CylcExecutionContext,
+            **h_kwargs,
+        }
+        handler = handler_class(
+            application=app,
+            request=request,
+            schema=schema,
+            **h_params,
+        )
+
+        if logged_in:
+            handler.get
+            _current_user = lambda: {'name': getuser()}
+        else:
+            handler.current_user = None
+        return handler
+
+    def test_setup(self):
+        """Test setup, attributes, and properties."""
+        mid_manager = MiddlewareManager()
+        handler = self._create_handler(
+            handler_class=TornadoGraphQLHandler,
+            h_kwargs={'middleware': mid_manager}
+        )
+        assert handler.middleware == mid_manager
+
+        handler = self._create_handler(
+            handler_class=TornadoGraphQLHandler,
+            h_kwargs={'middleware': None},
+        )
+        assert not handler.middleware
+        assert handler.get_context().method == "GET"
+
+    def test_parse_body(self):
+        """Test parse_body for query doc."""
+        handler = self._create_handler(
+            r_kwargs={
+                'headers': {'Content-Type': "application/json"},
+                'method': "POST",
+            }
+        )
+        assert not handler.get_parsed_body()
+
+        class FakeRequest:
+            headers = {'Content-Type': "Application/json"}
+            errors = None
+
+        # test request without body.
+        orig_request = handler.request
+        handler.request = FakeRequest()
+        with pytest.raises(ExecutionError) as exc:
+            handler.parse_body()
+        assert 'FakeRequest' in str(exc)
+
+        ex_error = ExecutionError(123, None)
+        assert ex_error.status_code == 123
+        assert ex_error.message == ''
+
+        # test invalid JSON string
+        handler.request = orig_request
+        handler.request.body = '%&^ds:ea43#'
+        with pytest.raises(HTTPError) as exc:
+            handler.parse_body()
+        assert 'invalid JSON' in str(exc.value)
+
+        # test invalid query
+        handler.request.body = json.dumps([{'this': "that"}])
+        with pytest.raises(HTTPError) as exc:
+            handler.parse_body()
+        assert 'not a valid JSON query.' in str(exc.value)
+
+    @gen_test
+    @pytest.mark.usefixtures("mock_authentication_yossarian")
+    async def test_get_response(self):
+        """Test get_response."""
+        r_kwargs = {
+            'headers': {'Content-Type': "application/json"},
+            'method': "POST",
+            'body': json.dumps({'query': "curry { massaman }"})
+        }
+        h_kwargs = {
+            'execution_context_class': None,
+            'parsed_body': 'cake',
+        }
+        handler = self._create_handler(r_kwargs=r_kwargs, h_kwargs=h_kwargs)
+        assert handler.parsed_body == 'cake'
+
+        # Test bad query
+        data = handler.parse_body()
+        result, status_code = await handler.get_response(data)
+        assert status_code == 400
+        assert 'curry' in result
+
+        # Test good query
+        doc = {
+            'query': '''
+                query stoke ($wFlows: [ID]){
+                  workflows (ids: $wFlows) { id status }
+                }
+            ''',
+            'variables': {'wFlows': ["*/run1"]},
+            'operationName': 'stoke',
+        }
+
+        handler.request.body = json.dumps(doc)
+        data = handler.parse_body()
+        handler.graphql_params = {}
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        # caught by auth
+        assert 'Forbidden' in str(result)
+        assert handler.graphql_params[2] == 'stoke'
+        # test the graphql params bypass
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        assert 'Forbidden' in str(result)
+
+        # test bad schema
+        orig_type = handler.schema.graphql_schema.query_type
+        handler.schema.graphql_schema.query_type = None
+        result, status_code = await handler.get_response(data)
+        assert 'not configured to execute query' in result
+        assert status_code == 400
+        handler.schema.graphql_schema.query_type = orig_type
+        handler.schema.graphql_schema._validation_errors = ['nasty one']
+        result, status_code = await handler.get_response(data)
+        assert 'nasty one' in result
+        assert status_code == 400
+        handler.schema.graphql_schema._validation_errors = []
+
+        # by-pass auth middleware
+        h_kwargs['middleware'] = []
+        doc['operationName'] = 'null'
+        handler = self._create_handler(r_kwargs=r_kwargs, h_kwargs=h_kwargs)
+        handler.request.body = json.dumps(doc)
+        data = handler.parse_body()
+        handler.graphql_params = {}
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        # because no resolvers set:
+        assert "object has no attribute 'get_workflows'" in str(result)
+        # operationName should be None
+        assert handler.graphql_params[2] is None
+
+        # test invalid variable
+        doc['variables'] = 'Nope'
+        handler.request.body = json.dumps(doc)
+        data = handler.parse_body()
+        handler.graphql_params = {}
+        with pytest.raises(HTTPError) as exc:
+            await handler.get_response(data)
+        assert 'Variables are invalid JSON' in str(exc.value)
+
+        doc['variables'] = {'wFlows': ["*/run1"]},
+        doc['operationName'] = 'stoke'
+        handler.request.body = json.dumps(doc)
+        data = handler.parse_body()
+        handler.graphql_params = {}
+
+        # test execution error
+        async def exec_error(schema, doc, **kwargs):
+            raise ExecutionError(400, ['problems'])
+        orig_exec = handler.execute
+        handler.execute = exec_error
+        result, status_code = await handler.get_response(data)
+        assert status_code == 400
+        handler.execute = orig_exec
+
+        # replicate the None result
+        async def exe_gql_req(data, query, variables, operation_name):
+            return None
+        handler.execute_graphql_request = exe_gql_req
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        assert result is None
+
+        # test an execution result with get method (i.e. other api link)
+        async def exe_gql_req2(data, query, variables, operation_name):
+            class FakeResult:
+                def get(self):
+                    return ExecutionResult(data='other-api-response')
+            return FakeResult()
+        handler.execute_graphql_request = exe_gql_req2
+        result, status_code = await handler.get_response(data)
+        assert status_code == 200
+        assert 'other-api-response' in result
+
+        # test an execution result with errors
+        async def exe_gql_req3(data, query, variables, operation_name):
+            return ExecutionResult(
+                errors = [
+                    GraphQLError('GQL error'),
+                    ExecutionError(400, ['Some Exc error']),
+                    Exception('random other error')
+                ]
+            )
+        handler.execute_graphql_request = exe_gql_req3
+        result, status_code = await handler.get_response(data)
+        assert status_code == 400
+        assert 'GQL error' in result
+        assert 'Some Exc error' in result
+        assert 'random other error' in result
 
 
 class SubscriptionHandlerTest(AsyncHTTPTestCase):


### PR DESCRIPTION
Adds an integration test for testing the graphql subscriptions via websocket connection.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
