### PR TITLE
fix RST

### DIFF
--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -57,7 +57,7 @@ Cylc Review Service
 
 Cylc hub can be configured to automatically serve the Cylc Review static
 log-file viewer. To enable Cylc Review, add the following to your
-`jupyterhub_config.py`:
+``jupyterhub_config.py``:
 
 .. code-block:: python
 


### PR DESCRIPTION
This documentation is in ReStructuredText format, but has been written like Markdown, whoops.

This has caused the nightly builds of cylc-doc to fail.

These failures are visible from the status page: https://cylc.github.io/cylc-admin/status/status.html

The line which identifies this as the failure is here: https://github.com/cylc/cylc-doc/actions/runs/24435356597/job/71388336103#step:12:350

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.