### PR TITLE
lower cylc-flow dep

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     # dependencies first. This way, if other dependencies (e.g. jupyterhub)
     # don't pin versions, we will get whatever cylc-flow needs, and not the
     # bleeding-edge version.
-    cylc-flow==8.7.*
+    cylc-flow>=8.6.4.dev,<8.7
 
     ansimarkup>=1.0.0
     jupyter_server>=2.13.0


### PR DESCRIPTION
cylc-uis 1.9 is moving from the 8.7 meta-release to 8.6.

This goes with:
* https://github.com/cylc/cylc-admin/pull/226 - changes the meta-release.
* https://github.com/cylc/cylc-flow/pull/7294 - backports minor cylc-flow changes required to permit this for release in 8.6.4, hence the lower pin.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
