### PR TITLE
Switch to `graphql-transport-ws` subprotocol

### DIFF
--- a/changes.d/821.feat.md
+++ b/changes.d/821.feat.md
@@ -1,0 +1,1 @@
+Changed to `graphql-transport-ws` subprotocol for WebSocket connections to the UI.

--- a/cylc/uiserver/__init__.py
+++ b/cylc/uiserver/__init__.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "1.10.0.dev"
+__version__ = "1.10.0.dev1"
 
 import os
 from typing import Dict

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -468,8 +468,6 @@ class CylcUIServer(ExtensionApp):
             self.log,
             self.max_threads,
         )
-        # sub_status dictionary storing status of subscriptions
-        self.sub_statuses = {}
         self.resolvers = Resolvers(
             self,
             self.data_store_mgr,
@@ -576,7 +574,6 @@ class CylcUIServer(ExtensionApp):
                 {
                     'sub_server': self.subscription_server,
                     'resolvers': self.resolvers,
-                    'sub_statuses': self.sub_statuses
                 }
             ),
             (

--- a/cylc/uiserver/authorise.py
+++ b/cylc/uiserver/authorise.py
@@ -505,7 +505,7 @@ class AuthorizationMiddleware:
 
     """
 
-    auth = None
+    auth: Authorization
 
     def resolve(self, next_, root, info, **args):
         current_user = info.context["current_user"]

--- a/cylc/uiserver/graphql/tornado_ws.py
+++ b/cylc/uiserver/graphql/tornado_ws.py
@@ -52,18 +52,14 @@ if TYPE_CHECKING:
 
 NO_MSG_DELAY = 1.0
 
-GRAPHQL_WS = "graphql-ws"
-WS_PROTOCOL = GRAPHQL_WS
-GQL_CONNECTION_INIT = "connection_init"  # Client -> Server
-GQL_CONNECTION_ACK = "connection_ack"  # Server -> Client
-GQL_CONNECTION_ERROR = "connection_error"  # Server -> Client
-GQL_CONNECTION_TERMINATE = "connection_terminate"  # Client -> Server
-GQL_CONNECTION_KEEP_ALIVE = "ka"  # Server -> Client
-GQL_START = "start"  # Client -> Server
-GQL_DATA = "data"  # Server -> Client
-GQL_ERROR = "error"  # Server -> Client
-GQL_COMPLETE = "complete"  # Server -> Client
-GQL_STOP = "stop"  # Client -> Server
+# See https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
+WS_PROTOCOL = 'graphql-transport-ws'
+GQL_CONNECTION_INIT = 'connection_init'  # Client -> Server
+GQL_CONNECTION_ACK = 'connection_ack'  # Server -> Client
+GQL_SUBSCRIBE = 'subscribe'  # Client -> Server
+GQL_NEXT = 'next'  # Server -> Client
+GQL_ERROR = 'error'  # Server -> Client
+GQL_COMPLETE = 'complete'  # Bidrectional
 
 REQ_HEADER_INFO = {
     'Host',
@@ -189,40 +185,32 @@ class TornadoSubscriptionServer:
                 connection_context, op_id, payload
             )
 
-        elif op_type == GQL_CONNECTION_TERMINATE:
-            return self.on_connection_terminate(connection_context, op_id)
-
-        elif op_type == GQL_START:
+        elif op_type == GQL_SUBSCRIBE:
             if not isinstance(payload, dict):
                 raise AssertionError("The payload must be a dict")
             params = self.get_graphql_params(connection_context, payload)
             return await self.on_start(connection_context, op_id, params)
 
-        elif op_type == GQL_STOP:
+        elif op_type == GQL_COMPLETE:
             return await self.on_stop(connection_context, op_id)
 
         else:
-            return await self.send_error(
-                connection_context,
-                op_id,
-                Exception("Invalid message type: {}.".format(op_type)),
+            connection_context.ws.close(
+                4400, f"Invalid message type: {op_type}"
             )
 
     async def on_connection_init(self, connection_context, op_id, payload):
         try:
             await self.on_connect(connection_context, payload)
             await self.send_message(
-                connection_context, op_type=GQL_CONNECTION_ACK)
+                connection_context, op_type=GQL_CONNECTION_ACK
+            )
         except Exception as e:
-            await self.send_error(
-                connection_context, op_id, e, GQL_CONNECTION_ERROR)
+            await self.send_error(connection_context, op_id, e, GQL_ERROR)
             await connection_context.ws.close(1011)
 
     async def on_connect(self, connection_context, payload):
         pass
-
-    def on_connection_terminate(self, connection_context, op_id):
-        return connection_context.ws.close(1011)
 
     def get_graphql_params(self, connection_context, payload):
         # Create a new context object for each subscription,
@@ -262,6 +250,7 @@ class TornadoSubscriptionServer:
 
     async def on_stop(self, connection_context, op_id):
         return await connection_context.unsubscribe(op_id)
+        connection_context.request_context['sub_statuses'][op_id] = 'stop'
 
     async def on_close(self, connection_context):
         return await connection_context.unsubscribe_all()
@@ -286,6 +275,8 @@ class TornadoSubscriptionServer:
         # Attempt to unsubscribe first in case we already have a subscription
         # with this id.
         await connection_context.unsubscribe(op_id)
+
+        connection_context.request_context['sub_statuses'][op_id] = 'start'
 
         params['kwargs']['root_value'] = op_id
         execution_result = await self.execute(params)
@@ -370,7 +361,7 @@ class TornadoSubscriptionServer:
 
         result = execution_result.formatted
         return await self.send_message(
-            connection_context, op_id, GQL_DATA, result
+            connection_context, op_id, GQL_NEXT, result
         )
 
     async def on_operation_complete(self, connection_context, op_id):
@@ -384,13 +375,9 @@ class TornadoSubscriptionServer:
         if error_type is None:
             error_type = GQL_ERROR
 
-        if error_type not in {GQL_CONNECTION_ERROR, GQL_ERROR}:
-            raise AssertionError(
-                "error_type should be one of the allowed error messages"
-                " GQL_CONNECTION_ERROR or GQL_ERROR"
-            )
+        assert error_type == GQL_ERROR, "error_type should be GQL_ERROR"
 
-        error_payload = {"message": str(error)}
+        error_payload = [{"message": str(error)}]
 
         with suppress(WebSocketClosedError):
             return await self.send_message(
@@ -405,6 +392,7 @@ class TornadoSubscriptionServer:
             else:
                 parsed_message = message
         except Exception as e:
-            return await self.send_error(connection_context, None, e)
+            connection_context.ws.close(4400, str(e))
+            return None
 
         return self.process_message(connection_context, parsed_message)

--- a/cylc/uiserver/graphql/tornado_ws.py
+++ b/cylc/uiserver/graphql/tornado_ws.py
@@ -28,7 +28,13 @@ from asyncio.queues import QueueEmpty
 from contextlib import suppress
 from inspect import isawaitable
 import json
-from typing import TYPE_CHECKING
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Iterable,
+    Literal,
+    Type,
+)
 
 from graphql import (
     ExecutionResult,
@@ -47,19 +53,35 @@ from cylc.uiserver.schema import SUB_RESOLVER_MAPPING
 
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from graphene import Schema
+    from graphql import ExecutionContext
+    from tornado.httputil import HTTPServerRequest
+
+    from cylc.uiserver.authorise import Authorization
     from cylc.uiserver.handlers import SubscriptionHandler
 
+    SendOperationType = Literal[
+        "connection_ack", "ping", "pong", "next", "error", "complete"
+    ]
 
 NO_MSG_DELAY = 1.0
 
 # See https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
 WS_PROTOCOL = 'graphql-transport-ws'
-GQL_CONNECTION_INIT = 'connection_init'  # Client -> Server
-GQL_CONNECTION_ACK = 'connection_ack'  # Server -> Client
-GQL_SUBSCRIBE = 'subscribe'  # Client -> Server
-GQL_NEXT = 'next'  # Server -> Client
-GQL_ERROR = 'error'  # Server -> Client
-GQL_COMPLETE = 'complete'  # Bidrectional
+GQL_CONNECTION_INIT: Literal["connection_init"] = (
+    'connection_init'  # Client -> Server
+)
+GQL_CONNECTION_ACK: Literal["connection_ack"] = (
+    'connection_ack'  # Server -> Client
+)
+GQL_PING: Literal["ping"] = 'ping'  # Bidirectional
+GQL_PONG: Literal["pong"] = 'pong'  # Bidirectional
+GQL_SUBSCRIBE: Literal["subscribe"] = 'subscribe'  # Client -> Server
+GQL_NEXT: Literal["next"] = 'next'  # Server -> Client
+GQL_ERROR: Literal["error"] = 'error'  # Server -> Client
+GQL_COMPLETE: Literal["complete"] = 'complete'  # Bidrectional
 
 REQ_HEADER_INFO = {
     'Host',
@@ -72,40 +94,33 @@ REQ_HEADER_INFO = {
 
 
 class TornadoConnectionContext:
-
-    def __init__(self, ws, request_context=None):
-        self.ws: SubscriptionHandler = ws
-        self.operations = {}
+    def __init__(self, ws: 'SubscriptionHandler', request_context: dict):
+        self.ws = ws
+        self.operations: dict[str, 'AsyncIterator'] = {}
         self.request_context = request_context
         self.pending_tasks: set[asyncio.Task] = set()
 
-    def has_operation(self, op_id):
+    def has_operation(self, op_id: str):
         return op_id in self.operations
 
-    def register_operation(self, op_id, async_iterator):
+    def register_operation(self, op_id: str, async_iterator: 'AsyncIterator'):
         self.operations[op_id] = async_iterator
 
-    def get_operation(self, op_id):
+    def get_operation(self, op_id: str):
         return self.operations[op_id]
 
-    def remove_operation(self, op_id):
-        try:
-            return self.operations.pop(op_id)
-        except KeyError:
-            return
-
-    async def receive(self):
-        return self.ws.recv_nowait()
+    def remove_operation(self, op_id: str):
+        return self.operations.pop(op_id, None)
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         return self.ws.close_code is not None
 
     def remember_task(self, task: asyncio.Task) -> None:
         self.pending_tasks.add(task)
         task.add_done_callback(self.pending_tasks.discard)
 
-    async def unsubscribe(self, op_id):
+    async def unsubscribe(self, op_id: str) -> None:
         async_iterator = self._unsubscribe(op_id)
         if (
             getattr(async_iterator, "future", None)
@@ -113,7 +128,7 @@ class TornadoConnectionContext:
         ):
             await async_iterator.future
 
-    def _unsubscribe(self, op_id):
+    def _unsubscribe(self, op_id: str):
         async_iterator = self.remove_operation(op_id)
         if hasattr(async_iterator, "dispose"):
             async_iterator.dispose()
@@ -136,14 +151,12 @@ class TornadoSubscriptionServer:
 
     def __init__(
         self,
-        schema,
-        loop=None,
-        middleware=None,
-        execution_context_class=None,
-        auth=None
+        schema: 'Schema',
+        middleware: Iterable[Type],
+        execution_context_class: 'Type[ExecutionContext]',
+        auth: 'Authorization',
     ):
         self.schema = schema
-        self.loop = loop
         self.middleware = middleware
         self.execution_context_class = execution_context_class
         self.auth = auth
@@ -167,52 +180,67 @@ class TornadoSubscriptionServer:
             **params['kwargs']
         )
 
-    def process_message(self, connection_context, parsed_message):
-        task = asyncio.ensure_future(
-            self._process_message(connection_context, parsed_message),
-            loop=self.loop
+    def process_message(
+        self,
+        connection_context: TornadoConnectionContext,
+        parsed_message: dict,
+    ) -> asyncio.Task[None]:
+        """Process a message from the client"""
+        task = asyncio.create_task(
+            self._process_message(connection_context, parsed_message)
         )
         connection_context.remember_task(task)
         return task
 
-    async def _process_message(self, connection_context, parsed_message):
+    async def _process_message(
+        self,
+        connection_context: TornadoConnectionContext,
+        parsed_message: dict,
+    ) -> None:
         op_id = parsed_message.get("id")
         op_type = parsed_message.get("type")
         payload = parsed_message.get("payload")
 
         if op_type == GQL_CONNECTION_INIT:
-            return await self.on_connection_init(
-                connection_context, op_id, payload
-            )
+            return await self.on_connection_init(connection_context)
 
         elif op_type == GQL_SUBSCRIBE:
             if not isinstance(payload, dict):
                 raise AssertionError("The payload must be a dict")
+            assert op_id, "The message must have an operation ID"
             params = self.get_graphql_params(connection_context, payload)
-            return await self.on_start(connection_context, op_id, params)
+            return await self.on_subscribe(connection_context, op_id, params)
 
         elif op_type == GQL_COMPLETE:
-            return await self.on_stop(connection_context, op_id)
+            assert op_id, "The message must have an operation ID"
+            await connection_context.unsubscribe(op_id)
+            connection_context.request_context['sub_statuses'][op_id] = 'stop'
+            return
+
+        elif op_type == GQL_PING:
+            return await self.send_message(connection_context, GQL_PONG)
+
+        elif op_type == GQL_PONG:
+            return
 
         else:
             connection_context.ws.close(
                 4400, f"Invalid message type: {op_type}"
             )
 
-    async def on_connection_init(self, connection_context, op_id, payload):
+    async def on_connection_init(
+        self, connection_context: TornadoConnectionContext
+    ) -> None:
         try:
-            await self.on_connect(connection_context, payload)
             await self.send_message(
                 connection_context, op_type=GQL_CONNECTION_ACK
             )
         except Exception as e:
-            await self.send_error(connection_context, op_id, e, GQL_ERROR)
-            await connection_context.ws.close(1011)
+            connection_context.ws.close(1011, str(e))
 
-    async def on_connect(self, connection_context, payload):
-        pass
-
-    def get_graphql_params(self, connection_context, payload):
+    def get_graphql_params(
+        self, connection_context: TornadoConnectionContext, payload: dict
+    ):
         # Create a new context object for each subscription,
         # which allows it to carry a unique subscription id.
         params = {
@@ -225,14 +253,11 @@ class TornadoSubscriptionServer:
         }
         # If middleware get instantiated here (optional), they will
         # be local/private to each subscription.
-        if self.middleware is not None:
-            middleware = list(
-                instantiate_middleware(self.middleware)
-            )
-        else:
-            middleware = self.middleware
-        for mw in self.middleware:
-            if mw == AuthorizationMiddleware:
+        middleware = list(
+            instantiate_middleware(self.middleware)
+        )
+        for mw in middleware:
+            if isinstance(mw, AuthorizationMiddleware):
                 mw.auth = self.auth
         return {
             'query': payload.get("query"),
@@ -245,33 +270,36 @@ class TornadoSubscriptionServer:
             )
         }
 
-    async def on_open(self, connection_context):
-        pass
-
-    async def on_stop(self, connection_context, op_id):
-        return await connection_context.unsubscribe(op_id)
-        connection_context.request_context['sub_statuses'][op_id] = 'stop'
-
-    async def on_close(self, connection_context):
-        return await connection_context.unsubscribe_all()
-
-    async def handle(self, ws, request_context=None):
+    async def handle(self, ws: 'SubscriptionHandler', request_context: dict):
         await asyncio.shield(self._handle(ws, request_context))
 
-    async def _handle(self, ws, request_context=None):
+    async def _handle(self, ws: 'SubscriptionHandler', request_context: dict):
         connection_context = TornadoConnectionContext(ws, request_context)
-        await self.on_open(connection_context)
         while not connection_context.closed:
             try:
-                message = await connection_context.receive()
+                message = connection_context.ws.recv_nowait()
             except QueueEmpty:
                 await asyncio.sleep(NO_MSG_DELAY)
             else:
-                await self.on_message(connection_context, message)
+                self.on_message(connection_context, message)
 
-        await self.on_close(connection_context)
+        await connection_context.unsubscribe_all()
 
-    async def on_start(self, connection_context, op_id, params):
+    async def on_subscribe(
+        self,
+        connection_context: TornadoConnectionContext,
+        op_id: str,
+        params: dict,
+    ) -> None:
+        """Run when the client starts a subscription.
+
+        Execute the GraphQL subscription and send to the client each resulting
+        delta in turn.
+
+        This will not return until the subscription ends (e.g. workflow stops),
+        at which point it will send a complete message to the client and
+        clean up.
+        """
         # Attempt to unsubscribe first in case we already have a subscription
         # with this id.
         await connection_context.unsubscribe(op_id)
@@ -298,26 +326,40 @@ class TornadoSubscriptionServer:
         except (GeneratorExit, asyncio.CancelledError):
             raise
         except Exception as e:
-            await self.send_error(connection_context, op_id, e)
+            with suppress(WebSocketClosedError):
+                await self.send_message(
+                    connection_context,
+                    GQL_ERROR,
+                    op_id,
+                    payload=[{"message": str(e)}],
+                )
         finally:
             if iterator:
                 await iterator.aclose()
+
+        # Complete the subscription from the server side:
         with suppress(WebSocketClosedError):
-            await self.send_message(connection_context, op_id, GQL_COMPLETE)
+            await self.send_message(connection_context, GQL_COMPLETE, op_id)
         await connection_context.unsubscribe(op_id)
-        await self.on_operation_complete(connection_context, op_id)
+        connection_context.request_context['sub_statuses'].pop(op_id, None)
 
     async def send_message(
-        self, connection_context, op_id=None, op_type=None, payload=None
-    ):
-        message = self.build_message(op_id, op_type, payload)
+        self,
+        connection_context: TornadoConnectionContext,
+        op_type: 'SendOperationType',
+        op_id: str | None = None,
+        payload=None,
+    ) -> None:
+        message = self.build_message(op_type, op_id, payload)
         try:
             return await connection_context.ws.write_message(message)
         except WebSocketClosedError:
             resolvers = connection_context.request_context.get('resolvers')
             if resolvers is not None:
-                request = connection_context.request_context.get('request')
-                headers = {}
+                request: HTTPServerRequest = (
+                    connection_context.request_context['request']
+                )
+                headers: dict[str, Any] = {}
                 headers.update(getattr(request, 'headers', {}))
                 resolvers.log.warning(
                     '[GraphQL WS] Websocket closed on send'
@@ -337,23 +379,28 @@ class TornadoSubscriptionServer:
             # Raise exception, in order to exit the on_start subscription loop.
             raise
 
-    def build_message(self, _id, op_type, payload):
-        message = {}
-        if _id is not None:
-            message["id"] = _id
-        if op_type is not None:
-            message["type"] = op_type
+    @staticmethod
+    def build_message(
+        op_type: 'SendOperationType', op_id: str | None, payload
+    ):
+        assert op_type, "Message must have a type"
+        message: dict[str, Any] = {"type": op_type}
+        if op_id is not None:
+            message["id"] = op_id
         if payload is not None:
             message["payload"] = payload
-        if not message:
-            raise AssertionError("You need to send at least one thing")
         return message
 
     async def send_execution_result(
-            self, connection_context, op_id, execution_result):
+        self,
+        connection_context: TornadoConnectionContext,
+        op_id: str,
+        execution_result: ExecutionResult,
+    ):
         # Resolve any pending promises
         if is_awaitable(execution_result.data):
-            await execution_result.data
+            # TODO: never hit?
+            await execution_result.data  # type: ignore[misc]
         if execution_result.data and 'logs' not in execution_result.data:
             request_context = connection_context.request_context
             await request_context['resolvers'].flow_delta_processed(
@@ -361,38 +408,18 @@ class TornadoSubscriptionServer:
 
         result = execution_result.formatted
         return await self.send_message(
-            connection_context, op_id, GQL_NEXT, result
+            connection_context, GQL_NEXT, op_id, result
         )
 
-    async def on_operation_complete(self, connection_context, op_id):
-        # remove the subscription from the sub_statuses dict
-        with suppress(KeyError):
-            connection_context.request_context['sub_statuses'].pop(op_id)
-
-    async def send_error(
-        self, connection_context, op_id, error, error_type=None
-    ):
-        if error_type is None:
-            error_type = GQL_ERROR
-
-        assert error_type == GQL_ERROR, "error_type should be GQL_ERROR"
-
-        error_payload = [{"message": str(error)}]
-
-        with suppress(WebSocketClosedError):
-            return await self.send_message(
-                connection_context, op_id, error_type, error_payload)
-
-    async def on_message(self, connection_context, message):
+    def on_message(
+        self, connection_context: TornadoConnectionContext, message
+    ) -> None:
         try:
-            if not isinstance(message, dict):
-                parsed_message = json.loads(message)
-                if not isinstance(parsed_message, dict):
-                    raise AssertionError("Payload must be an object.")
-            else:
-                parsed_message = message
+            parsed_message = json.loads(message)
+            if not isinstance(parsed_message, dict):
+                raise AssertionError("Message must be an object")
         except Exception as e:
             connection_context.ws.close(4400, str(e))
             return None
 
-        return self.process_message(connection_context, parsed_message)
+        self.process_message(connection_context, parsed_message)

--- a/cylc/uiserver/graphql/tornado_ws.py
+++ b/cylc/uiserver/graphql/tornado_ws.py
@@ -26,6 +26,10 @@
 import asyncio
 from asyncio.queues import QueueEmpty
 from contextlib import suppress
+from enum import (
+    StrEnum,
+    auto,
+)
 from inspect import isawaitable
 import json
 from typing import (
@@ -62,26 +66,35 @@ if TYPE_CHECKING:
     from cylc.uiserver.authorise import Authorization
     from cylc.uiserver.handlers import SubscriptionHandler
 
-    SendOperationType = Literal[
-        "connection_ack", "ping", "pong", "next", "error", "complete"
-    ]
 
 NO_MSG_DELAY = 1.0
 
-# See https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
 WS_PROTOCOL = 'graphql-transport-ws'
-GQL_CONNECTION_INIT: Literal["connection_init"] = (
-    'connection_init'  # Client -> Server
-)
-GQL_CONNECTION_ACK: Literal["connection_ack"] = (
-    'connection_ack'  # Server -> Client
-)
-GQL_PING: Literal["ping"] = 'ping'  # Bidirectional
-GQL_PONG: Literal["pong"] = 'pong'  # Bidirectional
-GQL_SUBSCRIBE: Literal["subscribe"] = 'subscribe'  # Client -> Server
-GQL_NEXT: Literal["next"] = 'next'  # Server -> Client
-GQL_ERROR: Literal["error"] = 'error'  # Server -> Client
-GQL_COMPLETE: Literal["complete"] = 'complete'  # Bidrectional
+
+
+class OperationType(StrEnum):
+    """graphql-transport-ws message types.
+
+    See https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
+    """
+    CONNECTION_INIT = auto()  # Client -> Server
+    CONNECTION_ACK = auto()  # Server -> Client
+    PING = auto()  # Bidirectional
+    PONG = auto()  # Bidirectional
+    SUBSCRIBE = auto()  # Client -> Server
+    NEXT = auto()  # Server -> Client
+    ERROR = auto()  # Server -> Client
+    COMPLETE = auto()  # Bidirectional
+
+
+SendOperationType = Literal[
+    OperationType.CONNECTION_ACK,
+    OperationType.PING,
+    OperationType.PONG,
+    OperationType.NEXT,
+    OperationType.ERROR,
+    OperationType.COMPLETE,
+]
 
 REQ_HEADER_INFO = {
     'Host',
@@ -201,39 +214,41 @@ class TornadoSubscriptionServer:
         op_type = parsed_message.get("type")
         payload = parsed_message.get("payload")
 
-        if op_type == GQL_CONNECTION_INIT:
-            return await self.on_connection_init(connection_context)
+        match op_type:
+            case OperationType.CONNECTION_INIT.value:
+                await self.on_connection_init(connection_context)
 
-        elif op_type == GQL_SUBSCRIBE:
-            if not isinstance(payload, dict):
-                raise AssertionError("The payload must be a dict")
-            assert op_id, "The message must have an operation ID"
-            params = self.get_graphql_params(connection_context, payload)
-            return await self.on_subscribe(connection_context, op_id, params)
+            case OperationType.SUBSCRIBE.value:
+                if not isinstance(payload, dict):
+                    raise AssertionError("The payload must be a dict")
+                assert op_id, "The message must have an operation ID"
+                params = self.get_graphql_params(connection_context, payload)
+                await self.on_subscribe(connection_context, op_id, params)
 
-        elif op_type == GQL_COMPLETE:
-            assert op_id, "The message must have an operation ID"
-            await connection_context.unsubscribe(op_id)
-            connection_context.request_context['sub_statuses'][op_id] = 'stop'
-            return
+            case OperationType.COMPLETE.value:
+                assert op_id, "The message must have an operation ID"
+                await connection_context.unsubscribe(op_id)
+                connection_context.request_context['sub_statuses'][op_id] = (
+                    'stop'
+                )
 
-        elif op_type == GQL_PING:
-            return await self.send_message(connection_context, GQL_PONG)
+            case OperationType.PING.value:
+                await self.send_message(connection_context, OperationType.PONG)
 
-        elif op_type == GQL_PONG:
-            return
+            case OperationType.PONG.value:
+                pass
 
-        else:
-            connection_context.ws.close(
-                4400, f"Invalid message type: {op_type}"
-            )
+            case _:
+                connection_context.ws.close(
+                    4400, f"Invalid message type: {op_type}"
+                )
 
     async def on_connection_init(
         self, connection_context: TornadoConnectionContext
     ) -> None:
         try:
             await self.send_message(
-                connection_context, op_type=GQL_CONNECTION_ACK
+                connection_context, op_type=OperationType.CONNECTION_ACK
             )
         except Exception as e:
             connection_context.ws.close(1011, str(e))
@@ -329,7 +344,7 @@ class TornadoSubscriptionServer:
             with suppress(WebSocketClosedError):
                 await self.send_message(
                     connection_context,
-                    GQL_ERROR,
+                    OperationType.ERROR,
                     op_id,
                     payload=[{"message": str(e)}],
                 )
@@ -339,14 +354,16 @@ class TornadoSubscriptionServer:
 
         # Complete the subscription from the server side:
         with suppress(WebSocketClosedError):
-            await self.send_message(connection_context, GQL_COMPLETE, op_id)
+            await self.send_message(
+                connection_context, OperationType.COMPLETE, op_id
+            )
         await connection_context.unsubscribe(op_id)
         connection_context.request_context['sub_statuses'].pop(op_id, None)
 
     async def send_message(
         self,
         connection_context: TornadoConnectionContext,
-        op_type: 'SendOperationType',
+        op_type: SendOperationType,
         op_id: str | None = None,
         payload=None,
     ) -> None:
@@ -381,10 +398,10 @@ class TornadoSubscriptionServer:
 
     @staticmethod
     def build_message(
-        op_type: 'SendOperationType', op_id: str | None, payload
+        op_type: SendOperationType, op_id: str | None, payload
     ):
         assert op_type, "Message must have a type"
-        message: dict[str, Any] = {"type": op_type}
+        message: dict[str, Any] = {"type": str(op_type)}
         if op_id is not None:
             message["id"] = op_id
         if payload is not None:
@@ -408,7 +425,7 @@ class TornadoSubscriptionServer:
 
         result = execution_result.formatted
         return await self.send_message(
-            connection_context, GQL_NEXT, op_id, result
+            connection_context, OperationType.NEXT, op_id, result
         )
 
     def on_message(

--- a/cylc/uiserver/handlers.py
+++ b/cylc/uiserver/handlers.py
@@ -23,7 +23,7 @@ import re
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Dict,
+    Literal,
 )
 
 from jupyter_server.base.handlers import JupyterHandler
@@ -41,7 +41,7 @@ from cylc.uiserver.authorise import (
 )
 from cylc.uiserver.graphql import authenticated as websockets_authenticated
 from cylc.uiserver.graphql.tornado import TornadoGraphQLHandler
-from cylc.uiserver.graphql.tornado_ws import GRAPHQL_WS
+from cylc.uiserver.graphql.tornado_ws import WS_PROTOCOL
 from cylc.uiserver.utils import is_bearer_token_authenticated
 
 
@@ -376,14 +376,15 @@ class UIServerGraphQLHandler(CylcAppHandler, TornadoGraphQLHandler):
 class SubscriptionHandler(CylcAppHandler, websocket.WebSocketHandler):
     """Endpoint for performing GraphQL subscriptions."""
     # No authorization decorators here, auth handled in AuthorizationMiddleware
-    def initialize(self, sub_server, resolvers, sub_statuses=None):
+    def initialize(self, sub_server, resolvers):
         self.queue: Queue = Queue(100)
         self.subscription_server: TornadoSubscriptionServer = sub_server
         self.resolvers: Resolvers = resolvers
-        self.sub_statuses: Dict = sub_statuses
+        # sub_status dictionary storing status of subscriptions
+        self.sub_statuses: dict[str, Literal["start", "stop"]] = {}
 
     def select_subprotocol(self, subprotocols):
-        return GRAPHQL_WS
+        return WS_PROTOCOL
 
     @websockets_authenticated
     def get(self, *args, **kwargs):
@@ -399,15 +400,6 @@ class SubscriptionHandler(CylcAppHandler, websocket.WebSocketHandler):
         )
 
     async def on_message(self, message):
-        try:
-            message_dict = json.loads(message)
-            op_id = message_dict.get("id", None)
-            if (message_dict['type'] == 'start'):
-                self.sub_statuses[op_id] = 'start'
-            if (message_dict['type'] == 'stop'):
-                self.sub_statuses[op_id] = 'stop'
-        except (KeyError, ValueError):
-            pass
         await self.queue.put(message)
 
     async def recv(self):

--- a/cylc/uiserver/tests/test_graphql.py
+++ b/cylc/uiserver/tests/test_graphql.py
@@ -24,6 +24,7 @@ from tornado.httpclient import HTTPClientError
 
 from cylc.flow.id import Tokens
 from cylc.uiserver.data_store_mgr import ALL_DELTAS
+from cylc.uiserver.graphql.tornado_ws import WS_PROTOCOL
 
 
 @pytest.fixture
@@ -80,7 +81,7 @@ def gql_subscription(jp_ws_fetch):
         *('cylc', 'subscriptions'),
         sub={
             'id': '1',
-            'type': 'start',
+            'type': 'subscribe',
             'payload': {
                 'query': '''
                     subscription {
@@ -104,7 +105,7 @@ def gql_subscription(jp_ws_fetch):
         headers = headers or {}
         headers = {
             'Content-Type': 'application/json',
-            'Sec-Websocket-Protocol': 'graphql-ws',
+            'Sec-Websocket-Protocol': WS_PROTOCOL,
             **headers,
         }
         ws = await jp_ws_fetch(
@@ -113,7 +114,6 @@ def gql_subscription(jp_ws_fetch):
             **kwargs
         )
 
-        # Using graphql-ws protocol, so send connection_init
         await ws.write_message(
             json.dumps({"type": "connection_init", "payload": {}})
         )
@@ -392,7 +392,7 @@ async def test_subscription(gql_subscription, dummy_workflow):
         *('cylc', 'subscriptions'),
         sub={
             "id": sub_id,
-            "type": "start",
+            "type": "subscribe",
             "payload": {
                 "query": """
                     subscription {
@@ -411,7 +411,7 @@ async def test_subscription(gql_subscription, dummy_workflow):
 
     assert response == {
         'id': sub_id,
-        'type': 'data',
+        'type': 'next',
         'payload': {
             'data': {
                 'workflows': [
@@ -425,7 +425,7 @@ async def test_subscription(gql_subscription, dummy_workflow):
     }
 
     # Run the stop/cleanup code
-    await ws.write_message(json.dumps({"id": sub_id, "type": "stop"}))
+    await ws.write_message(json.dumps({"id": sub_id, "type": "complete"}))
 
     ws.close()
 
@@ -443,7 +443,7 @@ async def test_subscription_deltas(
         *('cylc', 'subscriptions'),
         sub={
             "id": sub_id,
-            "type": "start",
+            "type": "subscribe",
             "payload": {
                 "query": """
                     subscription {
@@ -487,7 +487,7 @@ async def test_subscription_deltas(
     response = json.loads(await ws.read_message())
     assert response == {
         'id': sub_id,
-        'type': 'data',
+        'type': 'next',
         'payload': {
             'data': {
                 'deltas': {
@@ -515,7 +515,7 @@ async def test_subscription_deltas(
     response = json.loads(await ws.read_message())
     assert response == {
         'id': sub_id,
-        'type': 'data',
+        'type': 'next',
         'payload': {
             'data': {
                 'deltas': {
@@ -571,6 +571,6 @@ async def test_subscription_deltas(
     ]['status'] == 'stopped'
 
     # Run the stop/cleanup code
-    await ws.write_message(json.dumps({"id": sub_id, "type": "stop"}))
+    await ws.write_message(json.dumps({"id": sub_id, "type": "complete"}))
 
     ws.close()

--- a/cylc/uiserver/tests/test_handlers.py
+++ b/cylc/uiserver/tests/test_handlers.py
@@ -32,7 +32,6 @@ from cylc.flow.network.graphql import (
 )
 from cylc.uiserver.authorise import AuthorizationMiddleware
 from cylc.uiserver.graphql.tornado import TornadoGraphQLHandler, ExecutionError
-from cylc.uiserver.graphql.tornado_ws import GRAPHQL_WS
 from cylc.uiserver.handlers import (
     SubscriptionHandler,
     UIServerGraphQLHandler,
@@ -327,7 +326,7 @@ class SubscriptionHandlerTest(AsyncHTTPTestCase):
     @pytest.mark.usefixtures("mock_authentication_yossarian")
     def test_websockets_subprotocol(self):
         handler = self._create_handler()
-        assert handler.select_subprotocol(subprotocols=[]) == GRAPHQL_WS
+        assert handler.select_subprotocol([]) == 'graphql-transport-ws'
 
     @pytest.mark.usefixtures("mock_authentication_yossarian")
     def test_websockets_check_origin_accepts_same_origin(self):


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-uiserver/issues/690

Implements the `graphql-transport-ws` subprotocol as defined in https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md

Sibling: https://github.com/cylc/cylc-ui/pull/2548

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
