### PR TITLE
Include cylc/review/static via MANIFEST.in

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,3 +59,4 @@ jobs:
           grep 'cylc/uiserver/py.typed' files
           grep 'cylc/uiserver/ui' files
           grep 'cylc/review/static/css/bootstrap.min.css' files
+          grep 'cylc/review/template/index.html' files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,5 +58,6 @@ jobs:
           grep -E 'cylc_uiserver.*.dist-info/.*COPYING' files
           grep 'cylc/uiserver/py.typed' files
           grep 'cylc/uiserver/ui' files
-          grep 'cylc/review/static/css/bootstrap.min.css' files
+          grep 'cylc/review/static/css/.*\.css' files
+          grep 'cylc/review/static/js/.*\.js' files
           grep 'cylc/review/template/index.html' files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,4 @@ jobs:
           grep -E 'cylc_uiserver.*.dist-info/.*COPYING' files
           grep 'cylc/uiserver/py.typed' files
           grep 'cylc/uiserver/ui' files
+          grep 'cylc/review/static/css/bootstrap.min.css' files

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include cylc/uiserver/logo.svg
 include cylc/uiserver/py.typed
 recursive-include cylc/uiserver/ui/ *
 recursive-include cylc/review/static/ *
+recursive-include cylc/review/template/ *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include cylc/uiserver/logo.svg
 include cylc/uiserver/py.typed
 recursive-include cylc/uiserver/ui/ *
+recursive-include cylc/review/static/ *

--- a/changes.d/824.fix.md
+++ b/changes.d/824.fix.md
@@ -1,0 +1,1 @@
+Fixed files missing from the package, needed for Cylc Review.


### PR DESCRIPTION
The published package (pypi -> conda) doesn't include the Cylc Review static files.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
