### PR TITLE
Fix linting config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,19 +25,15 @@ per-file-ignores=
     ; B904 needs explicitly excepting because it's added in extend-select
     tests/*: A, B, B904, C, E731, TC, ISC, N, SIM
 
-    tests/unit/parsec/*: B, B904, C, SIM, TC
-
 exclude=
     build,
     dist,
-    tests,
     .git,
     __pycache__,
     .tox,
     .eggs,
     cylc/uiserver/jupyter_config.py,
-    *.svg,
     ./src
 paths =
     ./cylc/uiserver
-    ./tests/integration
+    ./tests


### PR DESCRIPTION
https://github.com/cylc/cylc-uiserver/pull/831 was rejected on 1.9.x but we still need the linting config fix from it

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests, docs, etc not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
