### PR TITLE
review: make robust to late arrival of DB file.

### DIFF
--- a/changes.d/847.fix.md
+++ b/changes.d/847.fix.md
@@ -1,0 +1,1 @@
+Cylc Review: fixed a bug where a newly-installed workflow would be stuck with an error banner incorrectly mentioning Cylc 8.0.x.

--- a/cylc/review/review_dao.py
+++ b/cylc/review/review_dao.py
@@ -123,7 +123,13 @@ class CylcReviewDAO:
         self.daos = {}
 
     def _db_init(self, user_name, suite_name):
-        """Initialise a named CylcWorkflowDAO database connection."""
+        """Initialise a named CylcWorkflowDAO database connection.
+
+        Returns:
+            CylcWorkflowDAO for the "log/db" or "cylc-suite.db" file as
+            appropriate, or "None" if there is no DB.
+
+        """
         key = (user_name, suite_name)
         if key not in self.daos:
             prefix = "~"
@@ -133,11 +139,11 @@ class CylcReviewDAO:
                 db_f_name = os.path.expanduser(
                     os.path.join(
                         prefix, os.path.join("cylc-run", suite_name, name)))
-                self.daos[key] = CylcWorkflowDAO(db_f_name, is_public=True)
                 if os.path.exists(db_f_name):
+                    self.daos[key] = CylcWorkflowDAO(db_f_name, is_public=True)
                     break
         self.is_cylc8 = self.set_is_cylc8(user_name, suite_name)
-        return self.daos[key]
+        return self.daos.get(key, None)
 
     def _db_close(self, user_name, suite_name):
         """Close a named CylcWorkflowDAO database connection."""
@@ -147,15 +153,16 @@ class CylcReviewDAO:
 
     def _db_exec(self, user_name, suite_name, stmt, stmt_args=None):
         """Execute a query on a named CylcWorkflowDAO database connection."""
-        daos = self._db_init(user_name, suite_name)
-        if stmt_args is None:
-            stmt_args = []
+        dao = self._db_init(user_name, suite_name)
+
         # only connect if db exists to avoid creating db if none there
-        if not os.path.exists(daos.db_file_name):
+        if dao is None or not os.path.exists(dao.db_file_name):
             return []
         else:
+            if stmt_args is None:
+                stmt_args = []
             try:
-                return daos.connect().execute(stmt, stmt_args)
+                return dao.connect().execute(stmt, stmt_args)
             except sqlite3.OperationalError as exc:
                 # At Cylc 8.0.1+ Workflows installed but not run will not yet
                 # have a database.
@@ -691,7 +698,7 @@ class CylcReviewDAO:
             "is_failed": False,
             "server": None}
         dao = self._db_init(user_name, suite_name)
-        if not os.access(dao.db_file_name, os.F_OK | os.R_OK):
+        if dao is None or not os.access(dao.db_file_name, os.F_OK | os.R_OK):
             self._db_close(user_name, suite_name)
             return ret
 


### PR DESCRIPTION
* If Cylc Review attempted to connect to a DB before it appeared on the filesystem, it would fall back to the Cylc 7 DB path.
* This would not self-rectify as the decision would be remembered for future requests.
* This changes the logic so the DB file location is only cached once it has been determined to exist.

Note, this is just a quick patch to allow Cylc Review to recover. The situation should be handled better!

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.