### PR TITLE
Fix flaky coverage failures

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -32,7 +32,6 @@ omit =
 parallel = True
 timid = False
 source = ./cylc
-relative_files=True
 
 
 [report]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,8 +117,7 @@ jobs:
 
       - name: Coverage report
         run: |
-          coverage combine --append
-          coverage xml --ignore-errors
+          coverage xml
           coverage report
 
       - name: Upload coverage artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ concurrency:
 
 env:
   FORCE_COLOR: 2
+  PIP_PROGRESS_BAR: 'off'
 
 defaults:
   run:
@@ -74,6 +75,7 @@ jobs:
         run: mypy
 
       - name: Check changelog
+        if: startsWith(matrix.os, 'ubuntu')
         uses: cylc/release-actions/towncrier-draft@v1
 
       - name: Test


### PR DESCRIPTION
Something about the relative paths coverage setting was causing flaky failures of `coverage combine`. See https://github.com/coveragepy/coveragepy/issues/2195

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Nothing else applicable
