### PR TITLE
Include active broken-connection/irresponsive-workflow checks

### DIFF
--- a/changes.d/851.fix.md
+++ b/changes.d/851.fix.md
@@ -1,0 +1,1 @@
+Fixed an issue identifying closed connections between the UI Server and workflows.

--- a/cylc/uiserver/app.py
+++ b/cylc/uiserver/app.py
@@ -336,6 +336,20 @@ class CylcUIServer(ExtensionApp):
         ''',
         default_value=5.0  # default values as kwargs correctly display in docs
     )
+    connections_check_interval = Float(
+        config=False,
+        help='''
+            Set the interval between REQ/RES/PUB/SUB connnection checks in
+            seconds.
+
+            This allows connections that may have broken for whatever reason
+            to be reset.
+
+            This involves sending workflows a REQ/RES request which prompts
+            a PUB response captured by our SUB.
+        ''',
+        default_value=180.0
+    )
     max_workers = Int(
         config=True,
         help='''
@@ -528,6 +542,11 @@ class CylcUIServer(ExtensionApp):
         ioloop.PeriodicCallback(
             self.workflows_mgr.scan,
             self.scan_interval * 1000
+        ).start()
+        # configure the connections checking
+        ioloop.PeriodicCallback(
+            self.data_store_mgr.connections_checker,
+            self.connections_check_interval * 1000
         ).start()
 
     def initialize_handlers(self):

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -34,6 +34,7 @@ Subscriptions are currently run in a different thread (via ThreadPoolExecutor).
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
+import json
 from pathlib import Path
 import time
 from typing import (
@@ -312,10 +313,19 @@ class DataStoreMgr:
             return
         elif (
             topic == 'ping'
-            and delta == b'pong'
             and w_id in self.workflows_mgr.workflows
         ):
             self.workflows_mgr.workflows[w_id]['pubsub_time'] = time.time()
+            # workflow is now clearly responsive
+            if w_id in self.workflows_mgr.irresponsive:
+                # Bring status up to date
+                status_data = json.loads(delta.decode('utf-8'))
+                self.create_status_delta(
+                    w_id,
+                    status=status_data['status'],
+                    status_msg=status_data['status_msg'],
+                )
+                self.workflows_mgr.irresponsive.remove(w_id)
             return
         self._apply_all_delta(w_id, delta)
         self._delta_store_to_queues(w_id, topic, delta)
@@ -486,11 +496,16 @@ class DataStoreMgr:
             # workflow has been removed - do nothing
             return False
 
-        delta = DELTAS_MAP[ALL_DELTAS]()
-        delta.workflow.time = time.time()
+        delta = self.create_status_delta(
+            w_id,
+            status=status,
+            status_msg=status_msg,
+            apply=False,
+            send=False,
+        )
+
         flow = delta.workflow.updated
-        flow.id = w_id
-        flow.stamp = f'{w_id}@{delta.workflow.time}'
+
         if contact_data:
             # update with contact file data
             flow.name = contact_data['name']
@@ -507,10 +522,6 @@ class DataStoreMgr:
             flow.port = 0
             flow.api_version = 0
 
-        if status is not None:
-            flow.status = status
-        if status_msg is not None:
-            flow.status_msg = status_msg
         if pruned:
             flow.pruned = True
             delta.workflow.pruned = w_id
@@ -523,6 +534,48 @@ class DataStoreMgr:
         self._delta_store_to_queues(w_id, ALL_DELTAS, delta)
 
         return True
+
+    def create_status_delta(
+        self,
+        w_id,
+        status=None,
+        status_msg=None,
+        apply=True,
+        send=True,
+    ):
+        """Create status delta for application and/or distribution.
+
+        Args:
+            w_id: Workflow ID.
+            status: Workflow status (e.g. "running").
+            status_msg: Workflow status message (e.g. "will stop at 2000").
+            apply: Apply delta to data-store.
+            send: Add delta to subscription queue.
+
+        Returns:
+            An ALL_DELTAS with updated.workflow fields status and/or msg.
+
+        """
+
+        delta = DELTAS_MAP[ALL_DELTAS]()
+        delta.workflow.time = time.time()
+        flow = delta.workflow.updated
+        flow.id = w_id
+        flow.stamp = f'{w_id}@{delta.workflow.time}'
+
+        if status is not None:
+            flow.status = status
+        if status_msg is not None:
+            flow.status_msg = status_msg
+
+        # apply delta to data-store
+        if apply:
+            self._apply_all_delta(w_id, delta)
+        # Queue delta for subscription push
+        if send:
+            self._delta_store_to_queues(w_id, ALL_DELTAS, delta)
+
+        return delta
 
     def _get_status_msg(self, w_id: str, is_active: bool) -> str:
         """Derive a status message for the workflow.
@@ -552,7 +605,7 @@ class DataStoreMgr:
                 client=info['req_client'],
                 command='reqpub',
                 log=self.log,
-                args={'topic': topic, 'payload': 'pong'},
+                args={'topic': topic, 'payload': 'status'},
             )
             for w_id, info in self.workflows_mgr.workflows.items()
             if (
@@ -560,7 +613,7 @@ class DataStoreMgr:
                 info.get('req_client')
                 and w_id in self.w_subs
                 # BACK COMPAT
-                and info.get(CFF.VERSION) > '8.6.5'
+                and info.get(CFF.VERSION) >= '8.6.6'
             )
         }
         results = await asyncio.gather(

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -119,7 +119,7 @@ class DataStoreMgr:
         self.log = log
         self.data = {}
         self.w_subs: Dict[str, WorkflowSubscriber] = {}
-        self.topics = {ALL_DELTAS.encode('utf-8'), b'shutdown'}
+        self.topics = {ALL_DELTAS.encode('utf-8'), b'shutdown', b'ping'}
         self.loop = None
         self.executor = ThreadPoolExecutor(max_threads)
         self.delta_queues = {}
@@ -178,6 +178,10 @@ class DataStoreMgr:
             return
 
         self.delta_queues[w_id] = {}
+
+        # Setup connection checker points
+        self.workflows_mgr.workflows[w_id]['reqres_time'] = time.time()
+        self.workflows_mgr.workflows[w_id]['pubsub_time'] = time.time()
 
         # Might be options other than threads to achieve
         # non-blocking subscriptions, but this works.
@@ -305,6 +309,13 @@ class DataStoreMgr:
             self._delta_store_to_queues(w_id, topic, delta)
             # close connections
             self._disconnect_workflow(w_id)
+            return
+        elif (
+            topic == 'ping'
+            and delta == b'pong'
+            and w_id in self.workflows_mgr.workflows
+        ):
+            self.workflows_mgr.workflows[w_id]['pubsub_time'] = time.time()
             return
         self._apply_all_delta(w_id, delta)
         self._delta_store_to_queues(w_id, topic, delta)
@@ -532,3 +543,31 @@ class DataStoreMgr:
         else:
             # the workflow has not yet run
             return 'not yet run'
+
+    async def connections_checker(self):
+        """Check REQ/RES by requesting a PUB/SUB check."""
+        topic = 'ping'
+        requests = {
+            w_id: workflow_request(
+                client=info['req_client'],
+                command='reqpub',
+                log=self.log,
+                args={'topic': topic, 'payload': 'pong'},
+            )
+            for w_id, info in self.workflows_mgr.workflows.items()
+            if (
+                # skip stopped workflows
+                info.get('req_client')
+                and w_id in self.w_subs
+                # BACK COMPAT
+                and info.get(CFF.VERSION) > '8.6.5'
+            )
+        }
+        results = await asyncio.gather(
+            *requests.values(), return_exceptions=True
+        )
+        for w_id, result in zip(requests, results):
+            if isinstance(result, Exception):
+                continue
+            if result == topic:
+                self.workflows_mgr.workflows[w_id]['reqres_time'] = time.time()

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -194,10 +194,18 @@ class DataStoreMgr:
             # something went wrong, undo any changes to allow for subsequent
             # connection attempts
             self.log.info(f'failed to connect to {w_id}')
-            self.disconnect_workflow(w_id)
+            self._disconnect_workflow(w_id)
 
     @log_call
     def disconnect_workflow(self, w_id, update_contact=True):
+        """Terminate workflow subscriptions.
+
+        This is called externally i.e. by the workflow manager when the
+        workflow has stopped or changed state.
+        """
+        self._disconnect_workflow(w_id, update_contact)
+
+    def _disconnect_workflow(self, w_id, update_contact=True):
         """Terminate workflow subscriptions.
 
         Call this when a workflow has stopped.
@@ -245,7 +253,7 @@ class DataStoreMgr:
         """Purge the manager of a workflow's subscription and data."""
         # Ensure no old/new subscriptions exist on purge,
         # this shouldn't happen if disconnect is run before unregister.
-        self.disconnect_workflow(w_id, update_contact=False)
+        self._disconnect_workflow(w_id, update_contact=False)
         if w_id in self.data:
             del self.data[w_id]
         if w_id in self.delta_queues:
@@ -296,7 +304,7 @@ class DataStoreMgr:
         if topic == 'shutdown':
             self._delta_store_to_queues(w_id, topic, delta)
             # close connections
-            self.disconnect_workflow(w_id)
+            self._disconnect_workflow(w_id)
             return
         self._apply_all_delta(w_id, delta)
         self._delta_store_to_queues(w_id, topic, delta)

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -15,12 +15,14 @@
 """Test code and fixtures."""
 
 import asyncio
+from functools import partial
 import inspect
 import logging
 from pathlib import Path
 from shutil import rmtree
 from tempfile import TemporaryDirectory
 import threading
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -98,8 +100,38 @@ def async_client():
 
 
 @pytest.fixture
-def workflows_manager() -> WorkflowsManager:
-    return WorkflowsManager(None, logging.getLogger('cylc'))
+def dummy_uis():
+    calls = []
+
+    async def async_capture(func, *_):
+        nonlocal calls
+        calls.append(func)
+
+    def sync_capture(func, *_):
+        nonlocal calls
+        calls.append(func)
+
+    data_store_mgr = SimpleNamespace(
+        register_workflow=partial(async_capture, 'register'),
+        unregister_workflow=partial(async_capture, 'unregister'),
+        connect_workflow=partial(async_capture, 'connect'),
+        disconnect_workflow=partial(sync_capture, 'disconnect'),
+        calls=calls,
+    )
+
+    uis = SimpleNamespace(
+        data_store_mgr=data_store_mgr,
+        connections_check_interval=120.0,
+    )
+    wfm = WorkflowsManager(uis, logging.getLogger())
+    uis.workflows_mgr = wfm
+
+    return uis
+
+
+@pytest.fixture
+def workflows_manager(dummy_uis) -> WorkflowsManager:
+    return WorkflowsManager(dummy_uis, logging.getLogger('cylc'))
 
 
 @pytest.fixture

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -143,6 +143,33 @@ async def test_entire_workflow_update__stopped_workflow(
     ]
 
 
+async def test_connections_checker(
+    async_client: AsyncClientFixture,
+    data_store_mgr: DataStoreMgr,
+):
+    """Test that ``connections_checker`` is executed successfully."""
+    w_id = 'workflow_id'
+    async_client.will_return('ping')
+
+    # mark as active sub
+    data_store_mgr.w_subs[w_id] = {}
+
+    # Set the client used by our test workflow.
+    data_store_mgr.workflows_mgr.workflows[w_id] = {
+        'req_client': async_client,
+        CFF.VERSION: '8.6.6',
+    }
+
+    # Call the connections checker method.
+    # This should use the client defined above (``async_client``) when
+    # calling ``workflow_request``.
+    data_store_mgr.workflows_mgr.workflows[w_id]['reqres_time'] = 0.0
+    await data_store_mgr.connections_checker()
+
+    # Test the req/res connection check update
+    assert data_store_mgr.workflows_mgr.workflows[w_id]['reqres_time'] > 0.0
+
+
 async def test_register_workflow(
     data_store_mgr: DataStoreMgr
 ):
@@ -284,6 +311,28 @@ async def test_workflow_connect_fail(
         context.destroy()
 
 
+async def test_unregister_workflow(data_store_mgr: DataStoreMgr):
+    """Test that ``unregister_workflow`` is executed successfully.
+
+    Along with ``_purge_workflow``, as a consequence.
+    """
+
+    w_tokens = Tokens(user='user', workflow='workflow_id')
+    w_id = w_tokens.id
+
+    # Register data-store entry
+    await data_store_mgr.register_workflow(w_id=w_id, is_active=False)
+
+    assert w_id in data_store_mgr.data
+    assert w_id in data_store_mgr.delta_queues
+
+    # Unregister data-store entry
+    await data_store_mgr.unregister_workflow(w_id)
+
+    assert w_id not in data_store_mgr.data
+    assert w_id not in data_store_mgr.delta_queues
+
+
 async def test_update_workflow_data(
     async_client: AsyncClientFixture,
     data_store_mgr: DataStoreMgr,
@@ -332,3 +381,16 @@ async def test_update_workflow_data(
     # The data-store sould now contain info from the delta
     assert w_id_data['workflow'].status == 'running'
     assert w_id_data['task_proxies'][tp_id].state == 'running'
+
+    # Test the pub/sub connection check update
+    data_store_mgr.workflows_mgr.workflows[w_id]['pubsub_time'] = 0.0
+    data_store_mgr._update_workflow_data('ping', b'pong', w_id)
+    assert data_store_mgr.workflows_mgr.workflows[w_id]['pubsub_time'] > 0.0
+
+    # Test shutdown delta
+    class w_sub:
+        def stop(self):
+            pass
+    data_store_mgr.w_subs[w_id] = w_sub()
+    data_store_mgr._update_workflow_data('shutdown', b'stopped', w_id)
+    assert w_id not in data_store_mgr.w_subs

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -276,7 +276,6 @@ async def test_workflow_connect_fail(
         assert [record.message for record in caplog.records] == [
             "[data-store] connect_workflow('~user/workflow_id', <dict>)",
             'failed to connect to ~user/workflow_id',
-            "[data-store] disconnect_workflow('~user/workflow_id')",
         ]
     finally:
         # tidy up

--- a/cylc/uiserver/tests/test_data_store_mgr.py
+++ b/cylc/uiserver/tests/test_data_store_mgr.py
@@ -258,6 +258,7 @@ async def test_workflow_connect_fail(
 
         # register the workflow with the data store
         await data_store_mgr.register_workflow(w_id=w_id, is_active=False)
+        data_store_mgr.workflows_mgr.workflows.setdefault(w_id, {})
         contact_data = {
             'name': 'workflow_id',
             'owner': 'cylc',

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -16,8 +16,9 @@
 from itertools import product
 import logging
 from random import random
+from time import time
 from typing import Type
-from unittest.mock import AsyncMock
+from unittest.mock import Mock, AsyncMock
 
 import pytest
 
@@ -211,28 +212,42 @@ async def test_workflow_state_change_uuid(
 
 
 @pytest.mark.parametrize(
-    'pid, host, change_expected',
+    'pid, host, reqrespubsub_time, change_expected',
     [
-        pytest.param('42', '42', False, id='no-change'),
-        pytest.param('1', '42', True, id='pid-change'),
-        pytest.param('42', '1', True, id='host-change'),
+        pytest.param('42', '42', time(), False, id='no-change'),
+        pytest.param('1', '42', time(), True, id='pid-change'),
+        pytest.param('42', '1', time(), True, id='host-change'),
+        pytest.param('42', '42', 0, True, id='irresponsive'),
     ],
 )
 async def test_workflow_state_change__killed(
-    pid, host, change_expected, tmp_path
+    pid, host, reqrespubsub_time, change_expected, cylc_uis, tmp_path
 ):
-    """It identifies workflow restarts when the contact file is left behind.
+    """It identifies killed and/or irresponsive workflows/socket-connections.
 
-    This can happen when the workflow is killed or the host dies.
+    Killed workflows can happen when it is killed or the host dies leaving
+    behind a contact file, then is restarted before the next scan.
+
+    Killed/irresponsive workflows and/or socket-connection could occur from
+    a variety of reasons, i.e. network and/or hardware/software effecting
+    scheduler operation.
     """
-    wfm = WorkflowsManager(None, LOG, context=None, run_dir=tmp_path)
+    wfm = WorkflowsManager(cylc_uis, LOG, context=None, run_dir=tmp_path)
     wid = Tokens(user=wfm.owner, workflow='a').id
     wfm.workflows[wid] = {
         CFF.API: API,
         CFF.UUID: '42',
         CFF.PID: pid,
         CFF.HOST: host,
+        CFF.VERSION: '8.6.6',
+        'reqres_time': reqrespubsub_time,
+        'pubsub_time': reqrespubsub_time,
     }
+
+    if reqrespubsub_time == 0:
+        for method in ('_apply_all_delta', '_delta_store_to_queues'):
+            setattr(wfm.uiserver.data_store_mgr, method, Mock())
+
     wfm.get_workflows = lambda: ({wid}, set())  # workflow active before...
     mk_flow(tmp_path, 'a', active=True)  # ...and active after
 
@@ -245,6 +260,11 @@ async def test_workflow_state_change__killed(
             assert changes[0][3][field] == '42'
     else:
         assert not changes
+
+    # check irresponsive workflow was flagged.
+    if reqrespubsub_time == 0:
+        assert wid in wfm.irresponsive
+        wfm.irresponsive.discard(wid)
 
     # Check that the update calls the appropriate methods
     for method in ('_register', '_unregister', '_connect', '_disconnect'):

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -109,13 +109,13 @@ def mk_flow(path, reg, active=True, database=True):
     'active_before,active_after',
     product(['active', 'inactive', None], repeat=2)
 )
-async def test_workflow_state_changes(tmp_path, active_before, active_after):
+async def test_workflow_state_changes(tmp_path, cylc_uis, active_before, active_after):
     """It correctly identifies workflow state changes from the filesystem."""
     tmp_path /= str(random())
     tmp_path.mkdir()
 
     # mock the results of the previous scan
-    wfm = WorkflowsManager(None, LOG, context=None, run_dir=tmp_path)
+    wfm = WorkflowsManager(cylc_uis, LOG, context=None, run_dir=tmp_path)
     wid = Tokens(user=wfm.owner, workflow='a').id
 
     ret = (
@@ -149,6 +149,7 @@ async def test_workflow_state_changes(tmp_path, active_before, active_after):
 )
 async def test_workflow_state_change_uuid(
     tmp_path,
+    cylc_uis,
     active_before,
     active_after
 ):
@@ -165,7 +166,7 @@ async def test_workflow_state_change_uuid(
 
     """
     # mock the result of the previous scan
-    wfm = WorkflowsManager(None, LOG, context=None, run_dir=tmp_path)
+    wfm = WorkflowsManager(cylc_uis, LOG, context=None, run_dir=tmp_path)
     wid = Tokens(user=wfm.owner, workflow='a').id
 
     wfm.workflows[wid] = {

--- a/cylc/uiserver/tests/test_workflows_mgr_data_store.py
+++ b/cylc/uiserver/tests/test_workflows_mgr_data_store.py
@@ -13,45 +13,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from functools import partial
 from getpass import getuser
-import logging
-from types import SimpleNamespace
 
 import pytest
 
 from cylc.flow.id import Tokens
 from cylc.flow.workflow_files import ContactFileFields as CFF
 
-from cylc.uiserver.workflows_mgr import WorkflowsManager
-
 """Test interaction between the workflows manager and data store."""
-
-
-def dummy_uis():
-    calls = []
-
-    async def async_capture(func, *_):
-        nonlocal calls
-        calls.append(func)
-
-    def sync_capture(func, *_):
-        nonlocal calls
-        calls.append(func)
-
-    data_store_mgr = SimpleNamespace(
-        register_workflow=partial(async_capture, 'register'),
-        unregister_workflow=partial(async_capture, 'unregister'),
-        connect_workflow=partial(async_capture, 'connect'),
-        disconnect_workflow=partial(sync_capture, 'disconnect'),
-        calls=calls,
-    )
-
-    uis = SimpleNamespace(data_store_mgr=data_store_mgr)
-    wfm = WorkflowsManager(uis, logging.getLogger())
-    uis.workflows_mgr = wfm
-
-    return uis
 
 
 @pytest.mark.parametrize(
@@ -106,6 +75,7 @@ def dummy_uis():
 )
 async def test_data_store_changes(
     one_workflow_aiter,
+    dummy_uis,
     monkeypatch,
     before,
     after,
@@ -118,7 +88,7 @@ async def test_data_store_changes(
 
     workflow_name = 'register-me'
     wid = Tokens(user=getuser(), workflow=workflow_name).id
-    uiserver = dummy_uis()
+    uiserver = dummy_uis
 
     # mock the state of the data store
     ret = [

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -200,6 +200,19 @@ class WorkflowsManager:
         """
         active_before, inactive_before = self.get_workflows()
 
+        # workflows stopped between scans
+        w_stops = {
+            w_id
+            for w_id in inactive_before
+            if (
+                w_id in self.workflows
+                and self.workflows[w_id].get('req_client')
+            )
+        }
+        # ensure workflows get properly dealt with by the workflow manger
+        active_before |= w_stops
+        inactive_before -= w_stops
+
         active = set()
         inactive = set()
 
@@ -300,7 +313,7 @@ class WorkflowsManager:
         Marks the workflow as stopped.
         """
         self.uiserver.data_store_mgr.disconnect_workflow(wid)
-        with suppress(KeyError, IOError):
+        with suppress(KeyError, IOError, AttributeError):
             self.workflows[wid]['req_client'].stop(stop_loop=False)
         with suppress(KeyError):
             self.workflows[wid]['req_client'] = None

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -28,6 +28,7 @@ from getpass import getuser
 import logging
 from pathlib import Path
 import sys
+from time import time
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -179,6 +180,10 @@ class WorkflowsManager:
         # will be ignored
         self._stopping = False
 
+        # Connection checker threshold, twice the check interval and buffer
+        # to allow for two check attempts.
+        self.conn_threshold = uiserver.connections_check_interval * 2 + 60
+
     def get_workflows(self):
         return self.uiserver.data_store_mgr.get_workflows()
 
@@ -225,12 +230,15 @@ class WorkflowsManager:
             flow['owner'] = self.owner
             wid = Tokens(user=flow['owner'], workflow=flow['name']).id
             flow['id'] = wid
+            workflow = self.workflows.get(wid, {})
+
+            now = time()
 
             if not flow.get('contact'):
                 inactive.add(wid)
                 if (
                     # if the workflow has previously started...
-                    self.workflows.get(wid, {}).get(CFF.UUID)
+                    workflow.get(CFF.UUID)
                     # ...but the database has since been removed...
                     and not db_file_exists(flow)
                 ):
@@ -253,8 +261,8 @@ class WorkflowsManager:
 
             active.add(wid)
 
-            if wid in self.workflows:
-                if flow[CFF.UUID] != self.workflows[wid].get(CFF.UUID):
+            if workflow:
+                if flow[CFF.UUID] != workflow.get(CFF.UUID):
                     # UUID is unique to each workflow run, it is preserved
                     # across reload/restart.
                     # This workflow has been cleaned & started since last scan
@@ -264,12 +272,29 @@ class WorkflowsManager:
                         yield (wid, '/inactive', 'active', flow)
                     continue
                 if wid in active_before and (
-                    flow[CFF.PID] != self.workflows[wid].get(CFF.PID)
-                    or flow[CFF.HOST] != self.workflows[wid].get(CFF.HOST)
+                    flow[CFF.PID] != workflow.get(CFF.PID)
+                    or flow[CFF.HOST] != workflow.get(CFF.HOST)
                 ):
                     # Process ID or host changes means workflow must have
                     # restarted (contact file was left behind so we didn't
                     # detect it as inactive earlier)
+                    yield (wid, 'active', 'active', flow)
+                    continue
+                if (
+                    wid in active_before
+                    # BACK COMPAT
+                    and workflow.get(CFF.VERSION) > '8.6.5'
+                    and (
+                        (
+                            now - workflow['reqres_time']
+                        ) > self.conn_threshold
+                        or (
+                            now - workflow['pubsub_time']
+                        ) > self.conn_threshold
+                    )
+                ):
+                    # This tests if the REQ/RES or PUB/SUB connections
+                    # are irresponsive. If so, we must disconnect/reconnect.
                     yield (wid, 'active', 'active', flow)
                     continue
 

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -32,6 +32,7 @@ from time import time
 from typing import (
     TYPE_CHECKING,
     Any,
+    Set,
 )
 
 import zmq.asyncio
@@ -182,7 +183,9 @@ class WorkflowsManager:
 
         # Connection checker threshold, twice the check interval and buffer
         # to allow for two check attempts.
-        self.conn_threshold = uiserver.connections_check_interval * 2 + 60
+        self.conn_threshold = uiserver.connections_check_interval * 2 + 30
+        # Naughty bin of irresponsive workflows
+        self.irresponsive: Set[str] = set()
 
     def get_workflows(self):
         return self.uiserver.data_store_mgr.get_workflows()
@@ -283,7 +286,10 @@ class WorkflowsManager:
                 if (
                     wid in active_before
                     # BACK COMPAT
-                    and workflow.get(CFF.VERSION) > '8.6.5'
+                    and workflow.get(CFF.VERSION) >= '8.6.6'
+                    # Ping/Pong test for socket/network state and workflow
+                    # responsiveness.
+                    and wid not in self.irresponsive
                     and (
                         (
                             now - workflow['reqres_time']
@@ -295,6 +301,15 @@ class WorkflowsManager:
                 ):
                     # This tests if the REQ/RES or PUB/SUB connections
                     # are irresponsive. If so, we must disconnect/reconnect.
+                    self.irresponsive.add(wid)
+                    # Apply/Send new workflow status
+                    self.uiserver.data_store_mgr.create_status_delta(
+                        wid,
+                        status='irresponsive',
+                        status_msg=(
+                            'Workflow is not responding to the UI Server.'
+                        ),
+                    )
                     yield (wid, 'active', 'active', flow)
                     continue
 
@@ -389,6 +404,9 @@ class WorkflowsManager:
 
                 elif after == 'active':
                     # workflow has restarted without earlier being disconnected
+                    # or is irresponsive for some reason:
+                    # * Some internal scheduler issue/load/exception
+                    # * Some unrecoverable state of the network/socket
                     run(
                         self._disconnect(wid),
                         self._connect(wid, flow),


### PR DESCRIPTION
closes #857

There were two problems: 
- ~~DB restarts don't change the `CYLC_WORKFLOW_UUID`, and this was the criteria for reestablishing the UIS workflow.~~
- ~~old contact files of inactive workflows left an old subscription/workflow in the UIS.~~



~~These are addressed here by using PID as an alternate criteria,~~ and testing the PUB tcp listener of workflows (which will help clear old contact files and/or reestablish subscriptions)

**Update:**

I have an idea for another check, however, it would need some back compat added.. It would essentially check both the REQ/RES PUB/SUB are still connected/working.

I would create a new endpoint on the `cylc-flow` side that would take a REQ, and pass it back via the PUB. We would then pick that up via the existing UIS SUB, and record the timestamp. This would happen periodically (say every ~5min?), and any workflow with a last recorded time older than some threshold (say 11min) would be disconnected/unregistered/purged, and re-registered on the next scan (if available).

Why? Because it's good to check the existing connections (not just create new ones), and also another problem I've seen:
- Some workflows that are inactive for large periods of time (i.e. ones that run every month) stop receiving updates, as if the connections have timed out or failed in periods of inactivity..

Although I could investigate whether ZeroMQ has some kind of default inactivity timeout on connections, I think this will act as a check for any other connection disruptions.

I will crack on with it.

**Tasks:**

- [x] ~~Add criteria checks (`PID`, `HOST`) in addition to `UUID`.~~
- [x] Check both the REQ/RES PUB/SUB are still connected/working.

Sibling PR https://github.com/cylc/cylc-flow/pull/7355

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
