### PR TITLE
workflows mgr: fix detection of restarted crashed workflow

### DIFF
--- a/changes.d/856.fix.md
+++ b/changes.d/856.fix.md
@@ -1,0 +1,1 @@
+Fixed detection of workflows that were restarted after having crashed.

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -142,7 +142,7 @@ async def test_workflow_state_changes(tmp_path, active_before, active_after):
 
 
 @pytest.mark.parametrize(
-    'active_before,active_after',
+    'active_before, active_after',
     product([True, False], repeat=2)
 )
 async def test_workflow_state_change_uuid(
@@ -167,8 +167,11 @@ async def test_workflow_state_change_uuid(
     wid = Tokens(user=wfm.owner, workflow='a').id
 
     wfm.workflows[wid] = {
+        # NOTE: the mocked scan will return "42" for each of these fields
         CFF.API: API,
-        CFF.UUID: '41'
+        CFF.UUID: '41',
+        CFF.PID: '41',
+        CFF.HOST: '41',
     }
 
     if active_before:

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -216,10 +216,20 @@ class WorkflowsManager:  # noqa: SIM119
                     yield (wid, None, 'inactive', flow)
 
             elif (
+                # detect workflows which have restarted since the last scan
                 wid in self.workflows
-                and flow[CFF.UUID] != self.workflows[wid].get(CFF.UUID)
+                and (
+                    # UUID is unique to each workflow run, it is preserved
+                    # across reload/restart
+                    flow[CFF.UUID] != self.workflows[wid].get(CFF.UUID)
+                    # PID and HOST are (almost) unique to each scheduler
+                    # invocation
+                    or flow[CFF.PID] != self.workflows[wid].get(CFF.PID)
+                    or flow[CFF.HOST] != self.workflows[wid].get(CFF.HOST)
+                )
             ):
-                # this flow is running but it's a different run
+                # this workflow has been restarted or cleaned & cold-started
+                # since the last scan, we must disconnect/reconnect
                 active.add(wid)
                 if wid in active_before:
                     yield (wid, '/active', 'active', flow)


### PR DESCRIPTION
This is the fix @dwsutherland [came up with](https://github.com/cylc/cylc-uiserver/pull/851#discussion_r3468512847) for #845. I've chipped this part off of #851 as that PR is also attempting to solve #781.

Summary:

* Closes #845
* There was pre-existing logic to detect workflow runs which had been stopped, cleaned and restarted between scans (effectively resilience against failure of the "shutdown delta" mechanism or internal race conditions).
* However, crashed workflows weren't getting detected because they are the same workflow run (i.e, the UUID is unchanged).
* The rectification is the same in both cases, so this extends the UUID detection method to also inspect the PID and HOST which can be used to identify a scheduler instance.

To test:

```console
$ # open Cylc GUI

$ cylc vip --host=<host1>
$ # refresh workflow listing in Cylc GUI
$ # * workflow should be listed as running on host1

$ kill -9 <workflow-pid>
$ # refresh workflow listing in Cylc GUI
$ # * workflow should be listed as running on host1
$ # * not technically true but the UIS don't know better (#781 will handle this one day)

$ cylc play --host=<host2>
$ # refresh workflow listing in Cylc GUI
$ # * before this change the workflow will be listed as running on **host1** - wrong
$ # * after this change the workflow should be listed as running on **host2** - right (and should reconnect successfully)
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [~] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.