### PR TITLE
Fixed workflows showing stopped in GUI 

### DIFF
--- a/changes.d/862.fix.md
+++ b/changes.d/862.fix.md
@@ -1,0 +1,1 @@
+Fixed a bug causing some workflows to show as stopped in the GUI after a restart.

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -161,8 +161,6 @@ class DataStoreMgr:
         if w_id in self.w_subs:
             return
 
-        self.delta_queues[w_id] = {}
-
         # Might be options other than threads to achieve
         # non-blocking subscriptions, but this works.
         self.executor.submit(
@@ -173,6 +171,8 @@ class DataStoreMgr:
             contact_data[CFF.PUBLISH_PORT]
         )
         successful_updates = await self._entire_workflow_update(ids=[w_id])
+
+        self.delta_queues[w_id] = {}
 
         if w_id not in successful_updates:
             # something went wrong, undo any changes to allow for subsequent

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -161,8 +161,12 @@ class DataStoreMgr:
         if w_id in self.w_subs:
             return
 
-        # Might be options other than threads to achieve
-        # non-blocking subscriptions, but this works.
+        # Start the ZMQ subscription (in its own thread) first so that
+        # any scheduler deltas published while the entire workflow update
+        # (below) is in progress are not missed. These deltas wait,
+        # since _update_workflow_data() blocks until last_updated > 0.
+        # (Might be options other than threads to achieve
+        # non-blocking subscriptions, but this works.)
         self.executor.submit(
             self._start_subscription,
             w_id,
@@ -170,8 +174,12 @@ class DataStoreMgr:
             contact_data[CFF.HOST],
             contact_data[CFF.PUBLISH_PORT]
         )
+        # Populate the data store with the entire workflow state, setting
+        # last_updated > 0 so any queued deltas from step 1 can be applied.
         successful_updates = await self._entire_workflow_update(ids=[w_id])
 
+        # Only now clear the GraphQL subscribers' delta queues, so that they
+        # get a fresh "initial burst" snapshot of this up-to-date data store.
         self.delta_queues[w_id] = {}
 
         if w_id not in successful_updates:

--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -163,8 +163,8 @@ class DataStoreMgr:
 
         # Start the ZMQ subscription (in its own thread) first so that
         # any scheduler deltas published while the entire workflow update
-        # (below) is in progress are not missed. These deltas wait,
-        # since _update_workflow_data() blocks until last_updated > 0.
+        # (below) is in progress are not missed. These deltas wait until
+        # _update_workflow_data() is done by looking for last_updated > 0.
         # (Might be options other than threads to achieve
         # non-blocking subscriptions, but this works.)
         self.executor.submit(


### PR DESCRIPTION
Closes #695 
Moved GUI subscription removal to after _entire_workflow_update so when GUI subscription loop catches this workflow and re-subscribes, it gets the most up-to-date data including states.

Bug seemed to be a race condition where a workflow was de-subscribed before its status was updated; the subscription loop in cylc-flow could detect this and re-subscribe the workflow (triggering an 'initial_burst' snapshot of the data store) while/before status was updated, and therefore getting old data.  

The fix is to move the line de-subscribing the workflow to after the data store has been updated.  

I have not found any issues caused by this, but I think this needs some testing as it's a core behaviour being changed.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed). - Not really sure how to test this, but it would be nice
- [x] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
