### PR TITLE
Fix logic from #856

### DIFF
--- a/cylc/uiserver/data_store_mgr.py
+++ b/cylc/uiserver/data_store_mgr.py
@@ -36,15 +36,28 @@ from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from pathlib import Path
 import time
-from typing import TYPE_CHECKING, Dict, Optional, Set, cast
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    cast,
+)
 
+from cylc.flow.data_store_mgr import (
+    ALL_DELTAS,
+    DATA_TEMPLATE,
+    DELTAS_MAP,
+    EDGES,
+    WORKFLOW,
+    apply_delta,
+    create_delta_store,
+    generate_checksum,
+)
 from cylc.flow.exceptions import WorkflowStopped
 from cylc.flow.id import Tokens
 from cylc.flow.network.server import PB_METHOD_MAP
-from cylc.flow.network.subscriber import WorkflowSubscriber, process_delta_msg
-from cylc.flow.data_store_mgr import (
-    EDGES, DATA_TEMPLATE, ALL_DELTAS, DELTAS_MAP, WORKFLOW,
-    apply_delta, generate_checksum, create_delta_store
+from cylc.flow.network.subscriber import (
+    WorkflowSubscriber,
+    process_delta_msg,
 )
 from cylc.flow.workflow_files import (
     ContactFileFields as CFF,
@@ -56,7 +69,10 @@ from cylc.flow.workflow_status import WorkflowStatus
 from .utils import fmt_call
 from .workflows_mgr import workflow_request
 
+
 if TYPE_CHECKING:
+    from collections.abc import Container
+
     from cylc.flow.data_messages_pb2 import PbWorkflow
 
 
@@ -144,7 +160,7 @@ class DataStoreMgr:
         self._purge_workflow(w_id)
 
     @log_call
-    async def connect_workflow(self, w_id, contact_data):
+    async def connect_workflow(self, w_id: str, contact_data: dict) -> None:
         """Initiate workflow subscriptions.
 
         Call this when a workflow has started.
@@ -179,7 +195,6 @@ class DataStoreMgr:
             # connection attempts
             self.log.info(f'failed to connect to {w_id}')
             self.disconnect_workflow(w_id)
-            return False
 
     @log_call
     def disconnect_workflow(self, w_id, update_contact=True):
@@ -370,13 +385,15 @@ class DataStoreMgr:
                 self.log.exception(exc)
 
     async def _entire_workflow_update(
-        self, ids: Optional[list] = None
-    ) -> Set[str]:
+        self, ids: 'Container[str] | None' = None
+    ) -> set[str]:
         """Update entire local data-store of workflow(s).
 
         Args:
             ids: List of workflow external IDs.
 
+        Returns:
+            Set of IDs for workflows that were successfully updated.
         """
         if ids is None:
             ids = []
@@ -396,7 +413,7 @@ class DataStoreMgr:
         results = await asyncio.gather(
             *requests.values(), return_exceptions=True
         )
-        successes: Set[str] = set()
+        successes: set[str] = set()
         for w_id, result in zip(requests, results):
             if isinstance(result, Exception):
                 if not isinstance(result, WorkflowStopped):

--- a/cylc/uiserver/tests/conftest.py
+++ b/cylc/uiserver/tests/conftest.py
@@ -40,7 +40,6 @@ from cylc.flow.data_messages_pb2 import (  # type: ignore
 )
 from cylc.flow.data_store_mgr import generate_checksum
 from cylc.flow.network.client import WorkflowRuntimeClient
-from cylc.flow.workflow_files import ContactFileFields as CFF
 
 from cylc.uiserver.data_store_mgr import DataStoreMgr
 from cylc.uiserver.workflows_mgr import WorkflowsManager
@@ -349,15 +348,7 @@ def dummy_workflow(
 
     async def _register(name):
         await cylc_workflows_mgr._register(
-            Tokens(user='me', workflow=name).id,
-            {
-                'name': name,
-                'owner': 'me',
-                CFF.HOST: 'localhost',
-                CFF.PORT: 1234,
-                CFF.API: 1,
-            },
-            True,
+            Tokens(user='me', workflow=name).id, is_active=True
         )
 
     return _register

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -17,6 +17,7 @@ from itertools import product
 import logging
 from random import random
 from typing import Type
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -97,7 +98,8 @@ def mk_flow(path, reg, active=True, database=True):
                     f'{CFF.HOST}=42',
                     f'{CFF.PORT}=42',
                     f'{CFF.NAME}=42',
-                    f'{CFF.UUID}=42'
+                    f'{CFF.UUID}=42',
+                    f'{CFF.PID}=42',
                 ])
             )
 
@@ -170,8 +172,8 @@ async def test_workflow_state_change_uuid(
         # NOTE: the mocked scan will return "42" for each of these fields
         CFF.API: API,
         CFF.UUID: '41',
-        CFF.PID: '41',
-        CFF.HOST: '41',
+        CFF.PID: '42',
+        CFF.HOST: '42',
     }
 
     if active_before:
@@ -205,6 +207,56 @@ async def test_workflow_state_change_uuid(
     # it should have picked up the new uuid too
     if active_after:
         assert changes[0][3][CFF.UUID] == '42'
+
+
+@pytest.mark.parametrize(
+    'pid, host, change_expected',
+    [
+        pytest.param('42', '42', False, id='no-change'),
+        pytest.param('1', '42', True, id='pid-change'),
+        pytest.param('42', '1', True, id='host-change'),
+    ],
+)
+async def test_workflow_state_change__killed(
+    pid, host, change_expected, tmp_path
+):
+    """It identifies workflow restarts when the contact file is left behind.
+
+    This can happen when the workflow is killed or the host dies.
+    """
+    wfm = WorkflowsManager(None, LOG, context=None, run_dir=tmp_path)
+    wid = Tokens(user=wfm.owner, workflow='a').id
+    wfm.workflows[wid] = {
+        CFF.API: API,
+        CFF.UUID: '42',
+        CFF.PID: pid,
+        CFF.HOST: host,
+    }
+    wfm.get_workflows = lambda: ({wid}, set())  # workflow active before...
+    mk_flow(tmp_path, 'a', active=True)  # ...and active after
+
+    # Check that the state change is detected correctly
+    changes = [i async for i in wfm._workflow_state_changes()]
+    if change_expected:
+        assert len(changes) == 1
+        assert changes[0][1:3] == ('active', 'active')
+        for field in (CFF.PID, CFF.HOST):
+            assert changes[0][3][field] == '42'
+    else:
+        assert not changes
+
+    # Check that the update calls the appropriate methods
+    for method in ('_register', '_unregister', '_connect', '_disconnect'):
+        setattr(wfm, method, AsyncMock())
+    await wfm.update()
+    assert wfm._register.call_count == 0
+    assert wfm._unregister.call_count == 0
+    if change_expected:
+        assert wfm._disconnect.call_count == 1
+        assert wfm._connect.call_count == 1
+    else:
+        assert wfm._disconnect.call_count == 0
+        assert wfm._connect.call_count == 0
 
 
 async def test_multi_request(

--- a/cylc/uiserver/tests/test_workflows_mgr.py
+++ b/cylc/uiserver/tests/test_workflows_mgr.py
@@ -332,7 +332,6 @@ async def test_crashed_workflow(one_workflow_aiter, caplog, uis_caplog):
     # ... connection will fail, the UIS should catch the ClientError
     await uiserver.workflows_mgr.update()
 
-    # we should have two log messages
     assert len(caplog.records) == 2
     # one when it attempted to register the workflow
     assert 'register_workflow' in caplog.records[0].message

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -192,7 +192,6 @@ class WorkflowsManager:  # noqa: SIM119
             flow['id'] = wid
 
             if not flow.get('contact'):
-                # this flow isn't running
                 inactive.add(wid)
                 if (
                     # if the workflow has previously started...
@@ -215,36 +214,36 @@ class WorkflowsManager:  # noqa: SIM119
                 else:
                     yield (wid, None, 'inactive', flow)
 
-            elif (
-                # detect workflows which have restarted since the last scan
-                wid in self.workflows
-                and (
-                    # UUID is unique to each workflow run, it is preserved
-                    # across reload/restart
-                    flow[CFF.UUID] != self.workflows[wid].get(CFF.UUID)
-                    # PID and HOST are (almost) unique to each scheduler
-                    # invocation
-                    or flow[CFF.PID] != self.workflows[wid].get(CFF.PID)
-                    or flow[CFF.HOST] != self.workflows[wid].get(CFF.HOST)
-                )
-            ):
-                # this workflow has been restarted or cleaned & cold-started
-                # since the last scan, we must disconnect/reconnect
-                active.add(wid)
-                if wid in active_before:
-                    yield (wid, '/active', 'active', flow)
-                else:
-                    yield (wid, '/inactive', 'active', flow)
+                continue
 
+            active.add(wid)
+
+            if wid in self.workflows:
+                if flow[CFF.UUID] != self.workflows[wid].get(CFF.UUID):
+                    # UUID is unique to each workflow run, it is preserved
+                    # across reload/restart.
+                    # This workflow has been cleaned & started since last scan
+                    if wid in active_before:
+                        yield (wid, '/active', 'active', flow)
+                    else:
+                        yield (wid, '/inactive', 'active', flow)
+                    continue
+                if wid in active_before and (
+                    flow[CFF.PID] != self.workflows[wid].get(CFF.PID)
+                    or flow[CFF.HOST] != self.workflows[wid].get(CFF.HOST)
+                ):
+                    # Process ID or host changes means workflow must have
+                    # restarted (contact file was left behind so we didn't
+                    # detect it as inactive earlier)
+                    yield (wid, 'active', 'active', flow)
+                    continue
+
+            if wid in active_before:
+                pass
+            elif wid in inactive_before:
+                yield (wid, 'inactive', 'active', flow)
             else:
-                # this flow is running
-                active.add(wid)
-                if wid in active_before:
-                    pass
-                elif wid in inactive_before:
-                    yield (wid, 'inactive', 'active', flow)
-                else:
-                    yield (wid, None, 'active', flow)
+                yield (wid, None, 'active', flow)
 
         for wid in active_before - (active | inactive):
             yield (wid, 'active', None, None)
@@ -323,6 +322,13 @@ class WorkflowsManager:  # noqa: SIM119
                     run(
                         self._disconnect(wid),
                         self._unregister(wid),
+                    )
+
+                elif after == 'active':
+                    # workflow has restarted without earlier being disconnected
+                    run(
+                        self._disconnect(wid),
+                        self._connect(wid, flow),
                     )
 
             elif before is None:

--- a/cylc/uiserver/workflows_mgr.py
+++ b/cylc/uiserver/workflows_mgr.py
@@ -25,16 +25,22 @@ Includes:
 import asyncio
 from contextlib import suppress
 from getpass import getuser
+import logging
 from pathlib import Path
 import sys
 from typing import (
-    TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
+    TYPE_CHECKING,
+    Any,
 )
 
 import zmq.asyncio
 
+from cylc.flow.exceptions import (
+    ClientError,
+    ClientTimeout,
+    WorkflowStopped,
+)
 from cylc.flow.id import Tokens
-from cylc.flow.exceptions import ClientError, ClientTimeout
 from cylc.flow.network import API
 from cylc.flow.network.client import WorkflowRuntimeClient
 from cylc.flow.network.scan import (
@@ -42,15 +48,19 @@ from cylc.flow.network.scan import (
     contact_info,
     is_active,
     scan,
-    validate_contact_info
+    validate_contact_info,
 )
 from cylc.flow.workflow_files import (
     ContactFileFields as CFF,
     WorkflowFiles,
 )
 
+
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from logging import Logger
+
+    from cylc.uiserver.app import CylcUIServer
 
 
 CLIENT_TIMEOUT = 2.0
@@ -59,12 +69,12 @@ CLIENT_TIMEOUT = 2.0
 async def workflow_request(
     client: WorkflowRuntimeClient,
     command: str,
-    args: Optional[Dict[str, Any]] = None,
-    timeout: Optional[float] = None,
+    args: dict[str, Any] | None = None,
+    timeout: float | None = None,
     *,
-    log: Optional['Logger'] = None,
-    req_meta: Optional[Dict[str, Any]] = None
-) -> Union[bytes, object]:
+    log: 'Logger | None' = None,
+    req_meta: dict[str, Any] | None = None
+) -> bytes | object:
     """Workflow request command.
 
     Args:
@@ -113,7 +123,7 @@ def db_file_exists(flow) -> bool:
     ).exists()
 
 
-class WorkflowsManager:  # noqa: SIM119
+class WorkflowsManager:
     """Object for tracking workflows by performing filesystem scans.
 
     * Detects stopped & running workflows in the run dir.
@@ -121,7 +131,13 @@ class WorkflowsManager:  # noqa: SIM119
 
     """
 
-    def __init__(self, uiserver, log, context=None, run_dir=None) -> None:
+    def __init__(
+        self,
+        uiserver: 'CylcUIServer',
+        log: 'Logger',
+        context: 'zmq.asyncio.Context | None' = None,
+        run_dir: 'Path | None' = None,
+    ) -> None:
         self.uiserver = uiserver
         self.log = log
         if context is None:
@@ -130,8 +146,14 @@ class WorkflowsManager:  # noqa: SIM119
             self.context = context
         self.owner = getuser()
 
-        # all workflows currently tracked
-        self.workflows: 'Dict[str, Dict]' = {}
+        self.workflows: dict[str, dict] = {}
+        """Mapping of workflow ID to workflow scan data
+        (including the contact data and the WorkflowRuntimeClient if active).
+
+        We add a workflow to this dict when we connect to it for the first
+        time (i.e. it first becomes active), and remove it when we unregister
+        it (i.e. workflow was cleaned).
+        """
 
         # the "workflow pipe" used to detect workflows on the filesystem
         self._scan_pipe = (
@@ -151,7 +173,7 @@ class WorkflowsManager:  # noqa: SIM119
         # * True  - (stop=True)  The stop signal (stops the scanner)
         # * False - (stop=False) Request a new scan
         # * None  - The "stopped" signal, sent after the scan task has stopped
-        self._queue: 'asyncio.Queue[Union[bool, None]]' = asyncio.Queue()
+        self._queue: asyncio.Queue[bool | None] = asyncio.Queue()
 
         # signal that the scanner is stopping, subsequent scan requests
         # will be ignored
@@ -251,25 +273,28 @@ class WorkflowsManager:  # noqa: SIM119
         for wid in inactive_before - (active | inactive):
             yield (wid, 'inactive', None, None)
 
-    async def _register(self, wid, flow, is_active):
+    async def _register(self, wid: str, is_active: bool) -> None:
         """Register a new workflow with the data store."""
         await self.uiserver.data_store_mgr.register_workflow(wid, is_active)
 
-    async def _connect(self, wid, flow):
+    async def _connect(self, wid: str, flow: dict) -> None:
         """Open a connection to a running workflow."""
         try:
             flow['req_client'] = WorkflowRuntimeClient(flow['name'])
         except ClientError as exc:
-            self.log.debug(f'Could not connect to {wid}: {exc}')
-            return False
+            self.log.log(
+                (
+                    logging.DEBUG
+                    if isinstance(exc, WorkflowStopped)
+                    else logging.WARNING  # Something has gone very wrong
+                ),
+                f'Could not connect to {wid}: {exc}',
+            )
+            return
         self.workflows[wid] = flow
-        await self.uiserver.data_store_mgr.connect_workflow(
-            wid,
-            flow
-        )
-        return True
+        await self.uiserver.data_store_mgr.connect_workflow(wid, flow)
 
-    async def _disconnect(self, wid):
+    async def _disconnect(self, wid: str) -> None:
         """Disconnect from a running workflow.
 
         Marks the workflow as stopped.
@@ -280,7 +305,7 @@ class WorkflowsManager:  # noqa: SIM119
         with suppress(KeyError):
             self.workflows[wid]['req_client'] = None
 
-    async def _unregister(self, wid):
+    async def _unregister(self, wid: str) -> None:
         """Unregister a workflow from the data store."""
         await self.uiserver.data_store_mgr.unregister_workflow(wid)
         if wid in self.workflows:
@@ -302,7 +327,7 @@ class WorkflowsManager:  # noqa: SIM119
         Between scans workflows can jump from any state to any other state.
 
         """
-        tasks: List[asyncio.Task] = []
+        tasks: list[asyncio.Task] = []
 
         def run(*coros):
             # start tasks running as soon as possible
@@ -335,13 +360,13 @@ class WorkflowsManager:  # noqa: SIM119
                 if after == 'active':
                     # workflow has been created and started
                     run(
-                        self._register(wid, flow, is_active=True),
+                        self._register(wid, is_active=True),
                         self._connect(wid, flow),
                     )
 
                 elif after == 'inactive':
                     # workflow has been created
-                    run(self._register(wid, flow, is_active=False))
+                    run(self._register(wid, is_active=False))
 
             elif before == 'inactive':
                 if after == 'active':
@@ -363,7 +388,7 @@ class WorkflowsManager:  # noqa: SIM119
                 # re-register the workflow
                 cmds.extend([
                     self._unregister(wid),
-                    self._register(wid, flow, is_active=(after == 'active')),
+                    self._register(wid, is_active=(after == 'active')),
                 ])
                 if after == 'active':
                     # connect to the new workflow
@@ -376,12 +401,12 @@ class WorkflowsManager:  # noqa: SIM119
     async def multi_request(
         self,
         command: str,
-        workflows: Iterable[str],
-        args: Optional[Dict[str, Any]] = None,
-        multi_args: Optional[Dict[str, Any]] = None,
-        timeout=None,
-        req_meta: Optional[Dict[str, Any]] = None
-    ) -> List[Union[bytes, object, Exception]]:
+        workflows: 'Iterable[str]',
+        args: dict[str, Any] | None = None,
+        multi_args: dict[str, Any] | None = None,
+        timeout: float | None = None,
+        req_meta: dict[str, Any] | None = None
+    ) -> list[bytes | object | Exception]:
         """Send requests to multiple workflows."""
         if args is None:
             args = {}


### PR DESCRIPTION
See https://github.com/cylc/cylc-uiserver/pull/856#issuecomment-4858697422

The change made in that PR treated changes to the PID or host as equivalent to changes to the UUID but that is not the case.
- UUID changed - workflow was cleaned and started
  - disconnect, unregister, reregister, reconnect
- PID/host changed - workflow was *re*started
  - disconnect, reconnect

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] No changelog entry needed as minimal impact to users
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
