### PR TITLE
Use `jq` to improve Cylc Review tests

### DIFF
--- a/tests/functional/cylc-review/04-time-sort.t
+++ b/tests/functional/cylc-review/04-time-sort.t
@@ -1,7 +1,7 @@
 #!/bin/bash
 # THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
 # Copyright (C) NIWA & British Crown (Met Office) & Contributors.
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -20,6 +20,7 @@
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
 requires_cherrypy
+requires_jq
 
 set_test_number 14
 #-------------------------------------------------------------------------------
@@ -48,65 +49,71 @@ run_ok "${TEST_NAME}" curl \
     "${TEST_CYLC_WS_URL}/taskjobs/${USER}?suite=${ESC_WORKFLOW_NAME}&form=json&order=${ORDER}"
 # Note: only qux submit time order is reliable, the others are submitted at the
 # same time, in any order.
-cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
-    "[('order',), '${ORDER}']" \
-    "[('entries', 0, 'name'), 'qux']"
+cmp_ok <(jq -r '.order, .entries[0] .name' "${TEST_NAME}.stdout") << __EOF__
+$ORDER
+qux
+__EOF__
 
 ORDER='time_run_desc'
 TEST_NAME="${TEST_NAME_BASE}-200-curl-jobs-${ORDER}"
 run_ok "${TEST_NAME}" curl \
     "${TEST_CYLC_WS_URL}/taskjobs/${USER}?suite=${ESC_WORKFLOW_NAME}&form=json&order=${ORDER}"
-
-cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
-    "[('order',), '${ORDER}']" \
-    "[('entries', 0, 'name'), 'qux']" \
-    "[('entries', 1, 'name'), 'bar']" \
-    "[('entries', 2, 'name'), 'baz']" \
-    "[('entries', 3, 'name'), 'foo']"
+cmp_ok <(jq -r '.order, .entries[] .name' "${TEST_NAME}.stdout") << __EOF__
+$ORDER
+qux
+bar
+baz
+foo
+__EOF__
 
 ORDER='time_run_exit_desc'
 TEST_NAME="${TEST_NAME_BASE}-200-curl-jobs-${ORDER}"
 run_ok "${TEST_NAME}" curl \
     "${TEST_CYLC_WS_URL}/taskjobs/${USER}?suite=${ESC_WORKFLOW_NAME}&form=json&order=${ORDER}"
-cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
-    "[('order',), '${ORDER}']" \
-    "[('entries', 0, 'name'), 'qux']" \
-    "[('entries', 1, 'name'), 'baz']" \
-    "[('entries', 2, 'name'), 'bar']" \
-    "[('entries', 3, 'name'), 'foo']"
+cmp_ok <(jq -r '.order, .entries[] .name' "${TEST_NAME}.stdout") << __EOF__
+$ORDER
+qux
+baz
+bar
+foo
+__EOF__
 
 ORDER='duration_queue_desc'
 TEST_NAME="${TEST_NAME_BASE}-200-curl-jobs-${ORDER}"
 run_ok "${TEST_NAME}" curl \
     "${TEST_CYLC_WS_URL}/taskjobs/${USER}?suite=${ESC_WORKFLOW_NAME}&form=json&order=${ORDER}"
-cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
-    "[('order',), '${ORDER}']" \
-    "[('entries', 0, 'name'), 'bar']" \
-    "[('entries', 1, 'name'), 'baz']" \
-    "[('entries', 2, 'name'), 'foo']" \
-    "[('entries', 3, 'name'), 'qux']"
+cmp_ok <(jq -r '.order, .entries[] .name' "${TEST_NAME}.stdout") << __EOF__
+$ORDER
+bar
+baz
+foo
+qux
+__EOF__
 
 ORDER='duration_run_desc'
 TEST_NAME="${TEST_NAME_BASE}-200-curl-jobs-${ORDER}"
 run_ok "${TEST_NAME}" curl \
     "${TEST_CYLC_WS_URL}/taskjobs/${USER}?suite=${ESC_WORKFLOW_NAME}&form=json&order=${ORDER}"
-cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
-    "[('order',), '${ORDER}']" \
-    "[('entries', 0, 'name'), 'baz']" \
-    "[('entries', 1, 'name'), 'foo']" \
-    "[('entries', 2, 'name'), 'qux']" \
-    "[('entries', 3, 'name'), 'bar']"
+cmp_ok <(jq -r '.order, .entries[] .name' "${TEST_NAME}.stdout") << __EOF__
+$ORDER
+baz
+foo
+qux
+bar
+__EOF__
 
 ORDER='duration_queue_run_desc'
 TEST_NAME="${TEST_NAME_BASE}-200-curl-jobs-${ORDER}"
 run_ok "${TEST_NAME}" curl \
     "${TEST_CYLC_WS_URL}/taskjobs/${USER}?suite=${ESC_WORKFLOW_NAME}&form=json&order=${ORDER}"
-cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
-    "[('order',), '${ORDER}']" \
-    "[('entries', 0, 'name'), 'baz']" \
-    "[('entries', 1, 'name'), 'bar']" \
-    "[('entries', 2, 'name'), 'foo']" \
-    "[('entries', 3, 'name'), 'qux']"
+cmp_ok <(jq -r '.order, .entries[] .name' "${TEST_NAME}.stdout") << __EOF__
+$ORDER
+baz
+bar
+foo
+qux
+__EOF__
+
 #-------------------------------------------------------------------------------
 # Tidy up - note suite trivial so stops early on by itself
 purge "${WORKFLOW_NAME}"

--- a/tests/functional/cylc-review/test_header
+++ b/tests/functional/cylc-review/test_header
@@ -435,6 +435,12 @@ requires_cherrypy() {
     fi
 }
 
+requires_jq() {
+    if ! which jq 1>'/dev/null'; then
+        skip_all '"jq" not installed'
+    fi
+}
+
 
 get_hostname() {
     if [[ "${OSTYPE}" == "darwin"* ]]; then
@@ -503,7 +509,7 @@ cylc_ws_kill() {
                 sleep 1
             fi
         done
-        
+
         kill "${TEST_CYLC_WS_PID}" 2>'/dev/null'
         wait 2>'/dev/null'
     fi
@@ -535,16 +541,15 @@ for item in sys.argv[2:]:
                         datum = datum_item
                         break
                 else:
-                    raise KeyError
+                    raise KeyError(item)
             else:
                 datum = datum[key]
-        if datum != value:
-            raise ValueError((item, datum))
-    except IndexError:
+        assert datum == value, f"assert {datum!r} == {value!r}, in {item=}"
+    except IndexError as exc:
         print(data)
-        raise IndexError(item)
-    except KeyError:
-        raise KeyError(item)
+        raise IndexError(item) from exc
+    except KeyError as exc:
+        raise KeyError(item) from exc
 __PYTHON__
     if [[ -s "${TEST_NAME}.stderr" ]]; then
         # Only print the final exception line - change to cat for details


### PR DESCRIPTION
Make test failures less cryptic. Does not fix the flaky failure of `04-time-sort` (#807)

[jq](https://jqlang.org/manual/) is a useful command line tool for parsing JSON.

Edit: as it happened, the flaky test failed on this occasion: https://github.com/cylc/cylc-uiserver/actions/runs/28813257297/job/85446223206?pr=864#step:12:452

Before:
```
Traceback (most recent call last):
  File "<stdin>", line 21, in <module>
ValueError: ("[('entries', 2, 'name'), 'qux']", 'bar')
```

After:
```diff
--- -	2026-07-06 18:18:05
+++ /dev/fd/63	2026-07-06 18:18:05
@@ -1,5 +1,5 @@
 duration_run_desc
 baz
 foo
-qux
 bar
+qux
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] Changelog entry not needed 
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
