### PR TITLE
Fix logging rotation

### DIFF
--- a/changes.d/867.fix.md
+++ b/changes.d/867.fix.md
@@ -1,0 +1,3 @@
+Fixed logging issues:
+- Separated log files for UI servers run by `cylc gui` and JupyterHub - the latter now uses `hubapp-log` instead of `log`.
+- Log file rotation was not always working correctly. Log file names now rotate as `log.1`, `log.2` etc. (or `hubapp-log.1`, `hubapp-log.2` etc.).

--- a/cylc/uiserver/__init__.py
+++ b/cylc/uiserver/__init__.py
@@ -17,15 +17,8 @@ __version__ = "1.9.4.dev"
 
 import os
 from typing import Dict
+
 from cylc.uiserver.app import CylcUIServer
-
-from cylc.uiserver.logging_util import RotatingUISFileHandler
-
-
-def init_log():
-    LOG = RotatingUISFileHandler()
-    # set up uiserver log
-    LOG.on_start()
 
 
 def _jupyter_server_extension_points():

--- a/cylc/uiserver/jupyter_config.py
+++ b/cylc/uiserver/jupyter_config.py
@@ -66,16 +66,16 @@ c.ConfigurableHTTPProxy.pid_file = f'{USER_CONF_ROOT / "jupyterhub-proxy.pid"}'
 
 # write Cylc logging to the user config directory
 # NOTE: Parallel UIS instances will conflict over this file.
-#       See https://github.com/cylc/cylc-uiserver/issues/240
+#       See https://github.com/cylc/cylc-uiserver/issues/743
 c.CylcUIServer.logging_config = {
     'version': 1,
     'handlers': {
         'file': {
-            'class': 'logging.handlers.RotatingFileHandler',
+            'class': 'cylc.uiserver.logging_util.RotatingUISFileHandler',
             'level': 'INFO',
             'filename': str(USER_CONF_ROOT / 'log' / 'log'),
             'mode': 'a',
-            'backupCount': 5,
+            'backupCount': 9,
             'maxBytes': 10485760,
             'formatter': 'file_fmt',
         },

--- a/cylc/uiserver/jupyter_config.py
+++ b/cylc/uiserver/jupyter_config.py
@@ -17,6 +17,7 @@
 
 from importlib.resources import files
 from pathlib import Path
+import sys
 
 from cylc.uiserver import (
     __file__ as uis_pkg,
@@ -24,6 +25,13 @@ from cylc.uiserver import (
 )
 from cylc.uiserver.app import USER_CONF_ROOT
 from cylc.uiserver.authorise import CylcAuthorizer
+
+
+LOG_PATH = USER_CONF_ROOT / 'log' / (
+    'log'
+    if (sys.argv[0].endswith('jupyter-cylc') or sys.argv[1] == 'gui')
+    else 'hubapp-log'
+)
 
 
 # the command the hub should spawn (i.e. the cylc uiserver itself)
@@ -73,7 +81,7 @@ c.CylcUIServer.logging_config = {
         'file': {
             'class': 'cylc.uiserver.logging_util.RotatingUISFileHandler',
             'level': 'INFO',
-            'filename': str(USER_CONF_ROOT / 'log' / 'log'),
+            'filename': str(LOG_PATH),
             'mode': 'a',
             'backupCount': 9,
             'maxBytes': 10485760,

--- a/cylc/uiserver/logging_util.py
+++ b/cylc/uiserver/logging_util.py
@@ -14,59 +14,36 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from contextlib import suppress
-from glob import glob
-import logging
-import os
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
-from typing import List
 
-from cylc.uiserver.app import USER_CONF_ROOT
+# Global var to track whether logging has been started before.
+# This is needed as Traitlets may reconfigure logging several times
+# within the lifetime of the application, which creates new instances
+# of the handler.
+log_started = False
 
 
-class RotatingUISFileHandler(logging.handlers.RotatingFileHandler):
-    """Rotate logs on ui-server restart"""
+class RotatingUISFileHandler(RotatingFileHandler):
+    """Rotate logs on ui-server restart or when reaching maxBytes."""
 
-    LOG_NAME_EXTENSION = "-uiserver.log"
+    def __init__(self, filename: str, *args, **kwargs):
+        global log_started
+        if log_started:
+            do_initial_rollover = False
+        else:
+            log_started = True
+            do_initial_rollover = Path(filename).is_file()
 
-    def __init__(self):
-        self.file_path = Path(USER_CONF_ROOT / "log").expanduser()
+        # Ensure the log directory exists:
+        Path(filename).parent.mkdir(parents=True, exist_ok=True)
 
-    def on_start(self):
-        """Set up logging"""
-        self.file_path.mkdir(parents=True, exist_ok=True)
-        self.delete_symlink()
-        self.update_log_archive()
-        self.setup_new_log()
+        super().__init__(filename, *args, **kwargs)
+        if do_initial_rollover:
+            self.doRollover()
 
-    def update_log_archive(self):
-        """Ensure log archive retains only 5 logs"""
-        log_files = sorted(glob(os.path.join(
-            self.file_path, f"[0-9]*{self.LOG_NAME_EXTENSION}")), reverse=True)
-        while len(log_files) > 4:
-            os.unlink(log_files.pop(0))
-        # rename logs, logs sent in descending order to prevent conflicts
-        self.rename_logs(log_files)
-
-    def rename_logs(self, log_files: List[str]):
-        """Increment the log number by one for each log"""
-        for file in log_files:
-            log_num = int(Path(file).name.partition('-')[0]) + 1
-            new_file_name = Path(
-                f"{self.file_path}/{log_num:02d}{self.LOG_NAME_EXTENSION}"
-            )
-            Path(file).rename(new_file_name)
-
-    def delete_symlink(self):
-        """Deletes an existing log symlink."""
-        symlink_path = Path(self.file_path / 'log')
-        if symlink_path.exists() and symlink_path.is_symlink():
-            symlink_path.unlink()
-
-    def setup_new_log(self):
-        """Create log"""
-        log = Path(self.file_path / f'01{self.LOG_NAME_EXTENSION}')
-        log.touch()
-        symlink_path = Path(self.file_path / 'log')
-        with suppress(OSError):
-            symlink_path.symlink_to(log)
+        # Remove any old naming scheme log files
+        for old_log in Path(filename).parent.glob('[0-9][0-9]-uiserver.log'):
+            with suppress(OSError):
+                old_log.unlink()

--- a/cylc/uiserver/scripts/gui.py
+++ b/cylc/uiserver/scripts/gui.py
@@ -20,41 +20,38 @@ Launch the Cylc GUI as a standalone web app for local use.
 For a multi-user system see `cylc hub`.
 """
 
-from ansimarkup import parse as cparse
 import argparse
 import asyncio
 from contextlib import suppress
+from getpass import getuser
 from glob import glob
 import os
 import re
-from requests.exceptions import RequestException
-import requests
 import sys
 from textwrap import dedent
 from typing import Optional
 import webbrowser
-from getpass import getuser
 
-
-from cylc.flow.id_cli import parse_id_async
-from cylc.flow.exceptions import (
-    InputError,
-    WorkflowFilesError
-)
+from ansimarkup import parse as cparse
+import requests
+from requests.exceptions import RequestException
 
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
-
-from cylc.uiserver import init_log
-from cylc.uiserver.app import (
-    CylcUIServer,
-    INFO_FILES_DIR
+from cylc.flow.exceptions import (
+    InputError,
+    WorkflowFilesError,
 )
+from cylc.flow.id_cli import parse_id_async
+from cylc.uiserver.app import (
+    INFO_FILES_DIR,
+    CylcUIServer,
+)
+
 
 CLI_OPT_NEW = "--new"
 
 
 def main(*argv):
-    init_log()
     hub_url = glbl_cfg().get(['hub', 'url'])
     jp_server_opts, new_gui, workflow_id = parse_args_opts()
     if '--help' in sys.argv and hub_url:

--- a/cylc/uiserver/scripts/hubapp.py
+++ b/cylc/uiserver/scripts/hubapp.py
@@ -18,12 +18,10 @@ This should be the command JupyterHub is configured to spawn e.g:
   c.Spawner.cmd = ['cylc', 'hubapp']
 """
 
-from cylc.uiserver import init_log
 from cylc.uiserver.hubapp import CylcHubApp
 
 INTERNAL = True
 
 
 def main(*argv):
-    init_log()
     return CylcHubApp.launch_instance(argv or None)

--- a/cylc/uiserver/tests/test_logging_util.py
+++ b/cylc/uiserver/tests/test_logging_util.py
@@ -13,82 +13,63 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from glob import glob
+from logging import getLogger
+from logging.config import dictConfig
 import os
+from pathlib import Path
+from secrets import token_hex
+
 import pytest
 
-from pathlib import Path
-
-from cylc.uiserver.logging_util import RotatingUISFileHandler
+from cylc.uiserver import logging_util
 
 
-def test_update_log_archive(tmp_path):
-    """Test update log archive retains log count at 5"""
-    LOG = RotatingUISFileHandler()
-    LOG.file_path = Path(tmp_path/'.cylc'/'uiserver'/'log')
-    LOG.file_path.mkdir(parents=True, exist_ok=True)
-    for file in [
-        '03-uiserver.log',
-        '01-uiserver.log',
-        '04-uiserver.log',
-        '02-uiserver.log',
-        '05-uiserver.log',
-        '07-uiserver.log',
-        '06-uiserver.log'
-    ]:
-        log_file = LOG.file_path.joinpath(file)
-        log_file.touch()
-
-    LOG.update_log_archive()
-    log_files = glob(os.path.join(LOG.file_path, f"[0-9]*.log"))
-    expected_files = [
-        f'{LOG.file_path}/05-uiserver.log',
-        f'{LOG.file_path}/04-uiserver.log',
-        f'{LOG.file_path}/03-uiserver.log',
-        f'{LOG.file_path}/02-uiserver.log',
-    ]
-    assert len(log_files) == 4
-    assert sorted(log_files) == sorted(expected_files)
+@pytest.fixture
+def rotating_log_setup():
+    """Fixture to reset RotatingUISFileHandler state after each test."""
+    try:
+        yield
+    finally:
+        logging_util.log_started = False
 
 
-def test_setup_new_log(tmp_path):
-    """Checks new log is set up correctly."""
-    LOG = RotatingUISFileHandler()
-    LOG.file_path = Path(tmp_path/'.cylc'/'uiserver'/'log')
-    LOG.file_path.mkdir(parents=True, exist_ok=True)
-    LOG.setup_new_log()
-    new_log = Path(LOG.file_path / '01-uiserver.log')
-    symlink_log = Path(LOG.file_path / 'log')
-    assert new_log.exists()
-    assert symlink_log.is_symlink()
-    assert symlink_log.resolve() == new_log
+def test_rollover(tmp_path: Path, rotating_log_setup):
+    """Check log file rotates on restart."""
+    log_dir = tmp_path / 'log_dir'
+    log_dir.mkdir(parents=True)
+    log_file = log_dir / 'log'
+    logger_name = f'test_{token_hex(3)}'
+    logging_config = {
+        'version': 1,
+        'handlers': {
+            'test_handler': {
+                'class': 'cylc.uiserver.logging_util.RotatingUISFileHandler',
+                'filename': str(log_file),
+                'backupCount': 1,
+            }
+        },
+        'loggers': {
+            logger_name: {
+                'handlers': ['test_handler'],
+                'level': 'INFO',
+            }
+        }
+    }
+    dictConfig(logging_config)
+    logger = getLogger(logger_name)
 
+    logger.info('A')
+    logger.info('B')
+    # Traitlets may reconfigure logging several times; it should not rollover
+    dictConfig(logging_config)
+    logger.info('C')
+    assert set(os.listdir(log_dir)) == {'log'}
 
-def test_first_init_log(tmp_path):
-    """Check initial setup, no previous logs present"""
-    LOG = RotatingUISFileHandler()
-    LOG.file_path = Path(tmp_path/'.cylc'/'uiserver'/'log')
-    LOG.on_start()
-    assert LOG.file_path.exists()
-    assert Path(LOG.file_path / 'log').is_symlink()
-    assert Path(LOG.file_path / 'log').resolve() == Path(
-        LOG.file_path / '01-uiserver.log')
+    # Simulate starting the application again, which should cause a rollover
+    logging_util.log_started = False
+    dictConfig(logging_config)
+    logger.info('Z')
+    assert set(os.listdir(log_dir)) == {'log', 'log.1'}
 
-
-def test_init_log_with_established_setup(tmp_path):
-    """Tests the entire logging init with a typically full logging dir"""
-    LOG = RotatingUISFileHandler()
-    LOG.file_path = Path(tmp_path/'.cylc'/'uiserver'/'log')
-    LOG.file_path.mkdir(parents=True, exist_ok=True)
-    for i in range(1, 5):
-        file = (LOG.file_path / f'{i:02d}-uiserver.log')
-        file.touch()
-        file.write_text(f"This file started as: {file}")
-    symlink_log = Path(LOG.file_path / 'log')
-    symlink_log.symlink_to(LOG.file_path / f'01-uiserver.log')
-    LOG.on_start()
-    log_files = glob(os.path.join(LOG.file_path, f"*.log"))
-    assert len(log_files) == 5
-    actual_output = Path(LOG.file_path/'05-uiserver.log').read_text()
-    expected_output = f"This file started as: {LOG.file_path}/04-uiserver.log"
-    assert actual_output == expected_output
+    assert log_file.read_text().splitlines() == ['Z']
+    assert (log_dir / 'log.1').read_text().splitlines() == ['A', 'B', 'C']


### PR DESCRIPTION
Supersedes and contains two of the bug fixes from #789

Closes #742, closes #743

Fixed logging issues:
- Separated log files for UI servers run by `cylc gui` and JupyterHub - the latter now uses `hubapp-log` instead of `log`.
- Log file rotation was not always working correctly. Log file names now rotate as `log.1`, `log.2` etc. (or `hubapp-log.1`, `hubapp-log.2` etc.).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included 
- [x] Changelog entry included 
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
