### PR TITLE
cat-log tail-end mode

### DIFF
--- a/changes.d/878.feat.md
+++ b/changes.d/878.feat.md
@@ -1,0 +1,1 @@
+The GraphQL log subscription now supports a configurable `maxLines` parameter and provides structured truncation information via a `truncated` field. This allows the UI to intelligently truncate large log files and inform users which end of the file (start or end) has been omitted.

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -489,9 +489,7 @@ class Services:
 
                     # read in the log lines and add them to the buffer
                     line_count += 1
-                    # buffer.append(line)
-
-                    buffer.append(f"{line_count - 1}: {line}") # REMEMBER to revert this
+                    buffer.append(line)
 
                     if mode == TAIL_END and line_count - 1 == max_lines:
                         # we received exactly MAX_LINES lines -> the *start* of

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -52,6 +52,7 @@ from cylc.flow.data_store_mgr import WORKFLOW
 from cylc.flow.exceptions import CylcError
 from cylc.flow.id import Tokens
 from cylc.flow.network.resolvers import BaseResolvers
+from cylc.flow.scripts.cat_log import TAIL, TAIL_FROM_START
 from cylc.flow.scripts.clean import CleanOptions, run
 from cylc.flow.util import natural_sort_key
 
@@ -374,7 +375,9 @@ class Services:
                 await queue.put(exc)
 
     @classmethod
-    async def cat_log(cls, id_: Tokens, app: 'CylcUIServer', info, file=None):
+    async def cat_log(
+        cls, id_: Tokens, app: 'CylcUIServer', info, file=None, mode=TAIL
+    ):
         """Calls `cat log`.
 
         Used for log subscriptions.
@@ -382,7 +385,12 @@ class Services:
         cmd: List[str] = [
             'cylc',
             'cat-log',
-            '--mode=tail',
+            f'--mode={mode}',
+        ]
+        if mode == TAIL:
+            # only tail mode reads a fixed number of lines from the file
+            cmd.append(f'--tail-lines={MAX_LINES}')
+        cmd += [
             '--prepend-path',
             id_.id,
         ]
@@ -448,8 +456,9 @@ class Services:
 
                 else:
                     # there *are* lines to read from the cat-log process
-                    if line_count > MAX_LINES:
-                        # we have read beyond the line count
+                    if mode == TAIL_FROM_START and line_count > MAX_LINES:
+                        # we have read beyond the line count -> the *end* of
+                        # the file is truncated in tail-from-start mode
                         yield {'lines': buffer}
                         yield {
                             'error': (
@@ -479,7 +488,22 @@ class Services:
 
                     # read in the log lines and add them to the buffer
                     line_count += 1
-                    buffer.append(line)
+                    # buffer.append(line)
+
+                    buffer.append(f"{line_count - 1}: {line}") # REMEMBER to revert this
+
+                    if mode == TAIL and line_count - 1 == MAX_LINES:
+                        # we received exactly MAX_LINES lines -> the *start* of
+                        # the file is (probably) truncated in tail mode
+                        yield {'lines': list(buffer)}
+                        buffer.clear()
+                        yield {
+                            'error': (
+                                'The start of this file has been truncated'
+                                f' because it is over {MAX_LINES} lines long.'
+                            )
+                        }
+
                     if len(buffer) >= 75:
                         yield {'lines': list(buffer)}
                         buffer.clear()
@@ -639,13 +663,15 @@ class Resolvers(BaseResolvers):
         info: 'GraphQLResolveInfo',
         _command: str,
         ids: List[Tokens],
-        file=None
+        file=None,
+        mode=TAIL,
     ):
         async for ret in Services.cat_log(
             ids[0],
             self.app,
             info,
-            file
+            file,
+            mode,
         ):
             yield ret
 
@@ -701,6 +727,7 @@ async def stream_log(
     command='cat_log',
     id: str,  # noqa: required to match schema arg name
     file=None,
+    mode=TAIL,
     **kwargs: Any,
 ) -> AsyncGenerator[Any, None]:
     """Cat Log Resolver
@@ -717,6 +744,7 @@ async def stream_log(
         info,
         command,
         [tokens],
-        file
+        file,
+        mode,
     ):
         yield item

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -52,7 +52,12 @@ from cylc.flow.data_store_mgr import WORKFLOW
 from cylc.flow.exceptions import CylcError
 from cylc.flow.id import Tokens
 from cylc.flow.network.resolvers import BaseResolvers
-from cylc.flow.scripts.cat_log import TAIL, TAIL_FROM_START
+from cylc.flow.scripts.cat_log import (
+    MIXED,
+    MIXED_TRUNCATION_PREFIX,
+    TAIL,
+    TAIL_FROM_START,
+)
 from cylc.flow.scripts.clean import CleanOptions, run
 from cylc.flow.util import natural_sort_key
 
@@ -376,20 +381,23 @@ class Services:
 
     @classmethod
     async def cat_log(
-        cls, id_: Tokens, app: 'CylcUIServer', info, file=None, mode=TAIL
+        cls, id_: Tokens, app: 'CylcUIServer', info, file=None, mode=TAIL,
+        max_lines: Optional[int] = None,
     ):
         """Calls `cat log`.
 
         Used for log subscriptions.
         """
+        # the maximum number of log lines to display before truncating
+        max_lines = max_lines or MAX_LINES
         cmd: List[str] = [
             'cylc',
             'cat-log',
             f'--mode={mode}',
         ]
-        if mode == TAIL:
-            # only tail mode reads a fixed number of lines from the file
-            cmd.append(f'--tail-lines={MAX_LINES}')
+        if mode in (TAIL, MIXED):
+            # these modes read a fixed number of lines from the file
+            cmd.append(f'--tail-lines={max_lines}')
         cmd += [
             '--prepend-path',
             id_.id,
@@ -456,16 +464,11 @@ class Services:
 
                 else:
                     # there *are* lines to read from the cat-log process
-                    if mode == TAIL_FROM_START and line_count > MAX_LINES:
+                    if mode == TAIL_FROM_START and line_count > max_lines:
                         # we have read beyond the line count -> the *end* of
                         # the file is truncated in tail-from-start mode
                         yield {'lines': buffer}
-                        yield {
-                            'error': (
-                                'This file has been truncated because'
-                                f' it is over {MAX_LINES} lines long.'
-                            )
-                        }
+                        yield {'truncated': 'end'}
                         break
 
                     line = await queue.get()
@@ -487,22 +490,30 @@ class Services:
                         continue
 
                     # read in the log lines and add them to the buffer
+                    if mode == MIXED and line.startswith(
+                        MIXED_TRUNCATION_PREFIX
+                    ):
+                        # in "mixed" mode cat-log emits a marker between the
+                        # head and tail blocks -> flush the head block and tell
+                        # the client the *middle* of the file was omitted
+                        # (the marker line itself is not shown)
+                        if buffer:
+                            yield {'lines': list(buffer)}
+                            buffer.clear()
+                        yield {'truncated': 'middle'}
+                        continue
+
                     line_count += 1
                     # buffer.append(line)
 
                     buffer.append(f"{line_count - 1}: {line}") # REMEMBER to revert this
 
-                    if mode == TAIL and line_count - 1 == MAX_LINES:
+                    if mode == TAIL and line_count - 1 == max_lines:
                         # we received exactly MAX_LINES lines -> the *start* of
                         # the file is (probably) truncated in tail mode
                         yield {'lines': list(buffer)}
                         buffer.clear()
-                        yield {
-                            'error': (
-                                'The start of this file has been truncated'
-                                f' because it is over {MAX_LINES} lines long.'
-                            )
-                        }
+                        yield {'truncated': 'start'}
 
                     if len(buffer) >= 75:
                         yield {'lines': list(buffer)}
@@ -665,6 +676,7 @@ class Resolvers(BaseResolvers):
         ids: List[Tokens],
         file=None,
         mode=TAIL,
+        max_lines: Optional[int] = None,
     ):
         async for ret in Services.cat_log(
             ids[0],
@@ -672,6 +684,7 @@ class Resolvers(BaseResolvers):
             info,
             file,
             mode,
+            max_lines,
         ):
             yield ret
 
@@ -728,6 +741,7 @@ async def stream_log(
     id: str,  # noqa: required to match schema arg name
     file=None,
     mode=TAIL,
+    max_lines=None,
     **kwargs: Any,
 ) -> AsyncGenerator[Any, None]:
     """Cat Log Resolver
@@ -746,5 +760,6 @@ async def stream_log(
         [tokens],
         file,
         mode,
+        max_lines,
     ):
         yield item

--- a/cylc/uiserver/resolvers.py
+++ b/cylc/uiserver/resolvers.py
@@ -53,10 +53,8 @@ from cylc.flow.exceptions import CylcError
 from cylc.flow.id import Tokens
 from cylc.flow.network.resolvers import BaseResolvers
 from cylc.flow.scripts.cat_log import (
-    MIXED,
-    MIXED_TRUNCATION_PREFIX,
     TAIL,
-    TAIL_FROM_START,
+    TAIL_END,
 )
 from cylc.flow.scripts.clean import CleanOptions, run
 from cylc.flow.util import natural_sort_key
@@ -395,8 +393,8 @@ class Services:
             'cat-log',
             f'--mode={mode}',
         ]
-        if mode in (TAIL, MIXED):
-            # these modes read a fixed number of lines from the file
+        if mode == TAIL_END:
+            # this mode reads a fixed number of lines from the file
             cmd.append(f'--tail-lines={max_lines}')
         cmd += [
             '--prepend-path',
@@ -464,9 +462,9 @@ class Services:
 
                 else:
                     # there *are* lines to read from the cat-log process
-                    if mode == TAIL_FROM_START and line_count > max_lines:
+                    if mode == TAIL and line_count > max_lines:
                         # we have read beyond the line count -> the *end* of
-                        # the file is truncated in tail-from-start mode
+                        # the file is truncated in tail (from-start) mode
                         yield {'lines': buffer}
                         yield {'truncated': 'end'}
                         break
@@ -490,27 +488,14 @@ class Services:
                         continue
 
                     # read in the log lines and add them to the buffer
-                    if mode == MIXED and line.startswith(
-                        MIXED_TRUNCATION_PREFIX
-                    ):
-                        # in "mixed" mode cat-log emits a marker between the
-                        # head and tail blocks -> flush the head block and tell
-                        # the client the *middle* of the file was omitted
-                        # (the marker line itself is not shown)
-                        if buffer:
-                            yield {'lines': list(buffer)}
-                            buffer.clear()
-                        yield {'truncated': 'middle'}
-                        continue
-
                     line_count += 1
                     # buffer.append(line)
 
                     buffer.append(f"{line_count - 1}: {line}") # REMEMBER to revert this
 
-                    if mode == TAIL and line_count - 1 == max_lines:
+                    if mode == TAIL_END and line_count - 1 == max_lines:
                         # we received exactly MAX_LINES lines -> the *start* of
-                        # the file is (probably) truncated in tail mode
+                        # the file is (probably) truncated in tail-end mode
                         yield {'lines': list(buffer)}
                         buffer.clear()
                         yield {'truncated': 'start'}

--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -60,7 +60,7 @@ from cylc.flow.network.schema import (
 )
 from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.rundb import CylcWorkflowDAO
-from cylc.flow.scripts.cat_log import TAIL, TAIL_FROM_START
+from cylc.flow.scripts.cat_log import TAIL, TAIL_END
 from cylc.flow.task_state import (
     TASK_STATUS_FAILED,
     TASK_STATUS_RUNNING,
@@ -879,9 +879,8 @@ class UISSubscriptions(Subscriptions):
         truncated = graphene.String(
             description=(
                 'Set at the point in the stream where the file has been'
-                ' truncated: "start" (earlier lines omitted), "middle"'
-                ' (lines omitted between the head and tail blocks in "mixed"'
-                ' mode) or "end" (later lines omitted).'
+                ' truncated: "start" (earlier lines omitted) or "end"'
+                ' (later lines omitted).'
             ),
         )
 
@@ -904,9 +903,9 @@ class UISSubscriptions(Subscriptions):
             default_value=TAIL,
             description=(
                 'Log view mode: '
-                f'"{TAIL}" (follow the last lines from the end of the file), '
-                f'"{TAIL_FROM_START}" (follow from the start of the file) '
-                'or "mixed" (show the start and follow the end of the file).'
+                f'"{TAIL}" (follow from the start of the file) or '
+                f'"{TAIL_END}" (follow the last lines from the end of the '
+                'file).'
             ),
         ),
         max_lines=graphene.Argument(

--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -876,6 +876,14 @@ class UISSubscriptions(Subscriptions):
         connected = graphene.Boolean()
         path = graphene.String()
         error = graphene.String()
+        truncated = graphene.String(
+            description=(
+                'Set at the point in the stream where the file has been'
+                ' truncated: "start" (earlier lines omitted), "middle"'
+                ' (lines omitted between the head and tail blocks in "mixed"'
+                ' mode) or "end" (later lines omitted).'
+            ),
+        )
 
     logs = graphene.Field(
         Logs,
@@ -896,8 +904,17 @@ class UISSubscriptions(Subscriptions):
             default_value=TAIL,
             description=(
                 'Log view mode: '
-                f'"{TAIL}" (follow the last lines from the end of the file) '
-                f'or "{TAIL_FROM_START}" (follow from the start of the file).'
+                f'"{TAIL}" (follow the last lines from the end of the file), '
+                f'"{TAIL_FROM_START}" (follow from the start of the file) '
+                'or "mixed" (show the start and follow the end of the file).'
+            ),
+        ),
+        maxLines=graphene.Argument(
+            graphene.Int,
+            required=False,
+            description=(
+                'The maximum number of log lines to display before'
+                ' truncating the file.'
             ),
         ),
         resolver=identity_resolve

--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -60,6 +60,7 @@ from cylc.flow.network.schema import (
 )
 from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.rundb import CylcWorkflowDAO
+from cylc.flow.scripts.cat_log import TAIL, TAIL_FROM_START
 from cylc.flow.task_state import (
     TASK_STATUS_FAILED,
     TASK_STATUS_RUNNING,
@@ -888,6 +889,16 @@ class UISSubscriptions(Subscriptions):
             graphene.String,
             required=False,
             description='File name of job log to fetch, e.g. job.out'
+        ),
+        mode=graphene.Argument(
+            graphene.String,
+            required=False,
+            default_value=TAIL,
+            description=(
+                'Log view mode: '
+                f'"{TAIL}" (follow the last lines from the end of the file) '
+                f'or "{TAIL_FROM_START}" (follow from the start of the file).'
+            ),
         ),
         resolver=identity_resolve
     )

--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -909,7 +909,7 @@ class UISSubscriptions(Subscriptions):
                 'or "mixed" (show the start and follow the end of the file).'
             ),
         ),
-        maxLines=graphene.Argument(
+        max_lines=graphene.Argument(
             graphene.Int,
             required=False,
             description=(

--- a/cylc/uiserver/tests/test_resolvers.py
+++ b/cylc/uiserver/tests/test_resolvers.py
@@ -379,7 +379,11 @@ async def test_cat_log_timeout(workflow_run_dir, app, fast_sleep):
     assert 'error' not in responses[0]
 
 
-async def test_cat_log_truncates_end_in_tail_mode(workflow_run_dir, app, fast_sleep):
+async def test_cat_log_truncates_end_in_tail_mode(
+        workflow_run_dir,
+        app,
+        fast_sleep
+    ):
     """TAIL (from-start) mode should truncate the end when max_lines is hit."""
     (id_, log_dir) = workflow_run_dir
     log_file = log_dir / '01-start-01.log'

--- a/cylc/uiserver/tests/test_resolvers.py
+++ b/cylc/uiserver/tests/test_resolvers.py
@@ -380,10 +380,10 @@ async def test_cat_log_timeout(workflow_run_dir, app, fast_sleep):
 
 
 async def test_cat_log_truncates_end_in_tail_mode(
-        workflow_run_dir,
-        app,
-        fast_sleep
-    ):
+    workflow_run_dir,
+    app,
+    fast_sleep
+):
     """TAIL (from-start) mode should truncate the end when max_lines is hit."""
     (id_, log_dir) = workflow_run_dir
     log_file = log_dir / '01-start-01.log'

--- a/cylc/uiserver/tests/test_resolvers.py
+++ b/cylc/uiserver/tests/test_resolvers.py
@@ -33,6 +33,7 @@ else:
 from cylc.flow import CYLC_LOG
 from cylc.flow.exceptions import CylcError
 from cylc.flow.id import Tokens
+from cylc.flow.scripts.cat_log import TAIL, TAIL_END
 from cylc.flow.scripts.clean import CleanOptions
 from cylc.uiserver.resolvers import (
     ENOENT_MSG,
@@ -376,6 +377,96 @@ async def test_cat_log_timeout(workflow_run_dir, app, fast_sleep):
     assert len(responses) == 1
     assert responses[0]['connected'] is False
     assert 'error' not in responses[0]
+
+
+async def test_cat_log_truncates_end_in_tail_mode(workflow_run_dir, app, fast_sleep):
+    """TAIL (from-start) mode should truncate the end when max_lines is hit."""
+    (id_, log_dir) = workflow_run_dir
+    log_file = log_dir / '01-start-01.log'
+    log_file.write_text('alpha\nbeta\ngamma\ndelta\n')
+
+    info = MagicMock()
+    info.root_value = 3
+    info.context = {'sub_statuses': {3: 'start'}}
+    workflow = Tokens(id_)
+
+    responses = []
+    async with timeout(10):
+        ret = services.cat_log(
+            workflow,
+            app,
+            info,
+            mode=TAIL,
+            max_lines=3,
+        )
+        async for response in ret:
+            responses.append(response)
+            if response.get('truncated') == 'end':
+                info.context['sub_statuses'][3] = 'stop'
+            await asyncio.sleep(0)
+
+    lines = [
+        line
+        for response in responses
+        for line in response.get('lines', [])
+    ]
+    truncated = [
+        response.get('truncated')
+        for response in responses
+        if response.get('truncated') is not None
+    ]
+
+    assert truncated == ['end']
+    assert len(lines) == 3
+    assert any('alpha' in line for line in lines)
+    assert any('beta' in line for line in lines)
+    assert any('gamma' in line for line in lines)
+
+
+async def test_cat_log_truncates_start_in_tail_end_mode(
+    workflow_run_dir, app, fast_sleep
+):
+    """TAIL_END mode should truncate the start when max_lines is hit."""
+    (id_, log_dir) = workflow_run_dir
+    log_file = log_dir / '01-start-01.log'
+    log_file.write_text('one\ntwo\nthree\nfour\nDONE\n')
+
+    info = MagicMock()
+    info.root_value = 4
+    info.context = {'sub_statuses': {4: 'start'}}
+    workflow = Tokens(id_)
+
+    responses = []
+    async with timeout(10):
+        ret = services.cat_log(
+            workflow,
+            app,
+            info,
+            mode=TAIL_END,
+            max_lines=3,
+        )
+        async for response in ret:
+            responses.append(response)
+            if response.get('truncated') == 'start':
+                info.context['sub_statuses'][4] = 'stop'
+            await asyncio.sleep(0)
+
+    lines = [
+        line
+        for response in responses
+        for line in response.get('lines', [])
+    ]
+    truncated = [
+        response.get('truncated')
+        for response in responses
+        if response.get('truncated') is not None
+    ]
+
+    assert truncated == ['start']
+    assert len(lines) == 3
+    assert any('three' in line for line in lines)
+    assert any('four' in line for line in lines)
+    assert any('DONE' in line for line in lines)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Trio of PRs to add a new tail mode to cat-log and make use of it in the GUI
 - cylc-flow: https://github.com/cylc/cylc-flow/pull/7414
 - cylc-uiserver: https://github.com/cylc/cylc-uiserver/pull/878
 - cylc-ui: https://github.com/cylc/cylc-ui/pull/2620

The three PR's will close 
 - https://github.com/cylc/cylc-uiserver/issues/802

Changes will be documented in cylc-doc: 
 - https://github.com/cylc/cylc-doc/pull/965

-----------------------------------------------------------------------------------

Added new mode for tailing the log file and altered the truncation warning to warn either the start or end is cut off.

The new mode relies on ```cat-log -t --tail-lines=MAX_LINES``` for the start position (MAX_LINES lines from end) where MAX_LINES is set in the UI.  It can pick up new lines followed from the end of the file.  

Out of scope for this PR, but I went through and removed any instances of typing.Optional from the 2 files this PR touches and removed the imports.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
