### PR TITLE
actions: run main test CI on a schedule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ on:
       - 'setup.cfg'       # check deps and project config
       - '.gitignore'
       - '.github/workflows/build.yml'
+  schedule:
+    - cron: '37 06 * * 1' # 06:37, Monday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - master
       - '*.*.x'
+  schedule:
+    - cron: '37 06 * * 1' # 06:37, Monday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Run our main CI actions one a week in order to detect new failures caused by external factors.

This will help us to keep the project status page fresher: https://cylc.github.io/cylc-admin/status/status.html

Examples of external factors:

* New lint rules.
* New mypy improvements.
* Changes in an upstream Cylc repository.
* Changes in the [meta-release configuration](https://cylc.github.io/cylc-admin/status/status.html#branches).
* New releases of dependent software (incl. Python).
* Changes in GH actions (e.g, new runners, or removed support for old ones).
* Etc.