### PR TITLE
review: make command description fit on one line

### DIFF
--- a/cylc/review/scripts/review.py
+++ b/cylc/review/scripts/review.py
@@ -16,8 +16,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """cylc review [start|stop]
 
-Start/stop ad-hoc Cylc Review web service server for browsing users' suite
-logs via an HTTP interface.
+A web service for viewing workflows.
+
+Start/stop ad-hoc Cylc Review web servicefor browsing users' workflows
+including task states and job logs.
 
 With no arguments, the status of the ad-hoc web service server is printed.
 """


### PR DESCRIPTION
Provide this command a clear one-line description.

Minor docs change (one review will do).

Personal philosophy (stolen from PEP257), everything should have a simple, concise description that can fit in one line. This makes the vague purpose of things clear without requiring folks to dig deeper into the docs and makes it easier to skim documentation.

The Cylc CLI uses the first line of the description as the command's summary, presently Review's description doesn't fit on one line.

*Before:*

```console
$ cylc help all | grep review
review ................... Start/stop ad-hoc Cylc Review web service server for browsing users' suite
```

*After:*

```console
$ cylc help all | grep review
review ................... A web service for viewing workflows.
```


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.